### PR TITLE
Add concrete derivations roadmap to THEORY_OF_EVERYTHING.md

### DIFF
--- a/THEORY_OF_EVERYTHING.md
+++ b/THEORY_OF_EVERYTHING.md
@@ -357,6 +357,37 @@ Z₄ = 2 → Weak isospin central element
 
 ---
 
+## PART XIII: Concrete Derivations to Close the Loop
+
+### 1) Explicit Q45 Label Assignment
+- Construct the Q45 quotient map from W33 automorphisms.
+- Assign each Q45 vertex its inherited $(\mathbb{Z}_4, \mathbb{Z}_3)$ label.
+- Verify universal $Z_4 = 2$ across all fibers.
+- Export the labeling table for downstream mass/coupling extraction.
+
+### 2) Holonomy → Mass Eigenvalues
+- Compute holonomy frequency spectrum for each Q45 fiber.
+- Map holonomy entropy to relative mass weights.
+- Normalize using a single experimental anchor (e.g., electron mass).
+- Predict full charged lepton and quark mass hierarchy.
+
+### 3) Coupling Constants from Symmetry Counts
+- Derive $g_1, g_2, g_3$ from orbit sizes in Aut(W33).
+- Check unification via geometric 12× enhancement.
+- Convert to low-energy values using discrete RG flow steps.
+
+### 4) Neutrino Sector and Mixing
+- Identify tricentric triangle sector contribution to neutral states.
+- Compute mixing matrix from V23 adjacency transitions.
+- Predict $\theta_{12}, \theta_{23}, \theta_{13}$ and mass splittings.
+
+### 5) Consistency Checks (No Adjustable Parameters)
+- Charge quantization: all U(1) charges from Z₃ ports.
+- Anomaly cancellation: verify by incidence parity alone.
+- Proton decay channels: fiber transitions restricted by holonomy class.
+
+---
+
 ## Conclusion
 
 **W33 is not just elegant mathematics—it is PHYSICAL REALITY.**


### PR DESCRIPTION
### Motivation
- Provide an explicit, computable roadmap that turns the theory's qualitative claims into concrete derivations for downstream implementation and verification (labeling, mass extraction, coupling derivation, neutrino mixing, and consistency checks). 

### Description
- Add `PART XIII: Concrete Derivations to Close the Loop` to `THEORY_OF_EVERYTHING.md` detailing steps for Q45 label assignment, holonomy→mass mapping, coupling constants from symmetry counts, neutrino mixing from V23 adjacency, and parameter-free consistency checks. 
- The change is a documentation update of ~31 inserted lines describing the computational procedures and data exports that downstream scripts should implement. 

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a18f119883309ed25be59b938354)