### PR TITLE
Add generated SUMMARY_RESULTS.json and NUMERIC_COMPARISONS.json and track them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ tmpclaude-*
 
 # Generated output files from CI/CD and Sage verification
 PART_*.json
-SUMMARY_RESULTS.json
-NUMERIC_COMPARISONS.json
 artifacts/
 
 # Extracted bundles (redundant with bundles/ directory)

--- a/NUMERIC_COMPARISONS.json
+++ b/NUMERIC_COMPARISONS.json
@@ -1,0 +1,10 @@
+[
+  {
+    "file": "PART_CIII_precision_frontier.json",
+    "name": "DESI w0",
+    "measured": -0.827,
+    "predicted": -0.826,
+    "diff": 0.0010000000000000009,
+    "pct": 0.12091898428053217
+  }
+]

--- a/SUMMARY_RESULTS.json
+++ b/SUMMARY_RESULTS.json
@@ -1,0 +1,5121 @@
+{
+  "file_list": [
+    "PART_CIII_precision_frontier.json",
+    "PART_CII_quantum_gravity.json",
+    "PART_CIV_definitive_tests.json",
+    "PART_CIX_d4_triality.json",
+    "PART_CI_new_frontiers.json",
+    "PART_CVIII_group_isomorphism.json",
+    "PART_CVII_e8_test_results.json",
+    "PART_CVI_e8_embedding.json",
+    "PART_CV_e8_connection.json",
+    "PART_CXIII_sagemath_verification.json",
+    "PART_CXIII_verified_results.json",
+    "PART_CXII_grand_synthesis.json",
+    "PART_CXIV_tomotope_connection.json",
+    "PART_CXIX_27_analysis.json",
+    "PART_CXI_particle_map.json",
+    "PART_CXVIII_explicit_construction.json",
+    "PART_CXVIII_explicit_results.json",
+    "PART_CXVII_jordan_algebras.json",
+    "PART_CXVI_quantum_contextuality.json",
+    "PART_CXV_reye_tomotope.json",
+    "PART_CXXIII_72_decomposition.json",
+    "PART_CXXII_number_40.json",
+    "PART_CXXI_grand_unified.json",
+    "PART_CXXV_D5_verification.json",
+    "PART_CXX_1296_analysis.json",
+    "PART_CX_symmetry_breaking.json",
+    "PART_C_manifesto.json",
+    "PART_LIII_exploration_results.json",
+    "PART_LIX_master_formula_results.json",
+    "PART_LVIII_cosmology_results.json",
+    "PART_LVII_fermion_masses_results.json",
+    "PART_LVI_quantum_codes_results.json",
+    "PART_LV_exceptional_results.json",
+    "PART_LXIII_gut_breaking_results.json",
+    "PART_LXII_sage_pysymmetry_results.json",
+    "PART_LXIV_eigenvector_results.json",
+    "PART_LXIX_CP_violation.json",
+    "PART_LXI_predictions_results.json",
+    "PART_LXVIII_why_F3.json",
+    "PART_LXVII_1111_mystery.json",
+    "PART_LXVI_unified_alpha.json",
+    "PART_LXXIII_proton_decay.json",
+    "PART_LXXII_fermion_masses.json",
+    "PART_LXXIV_dark_matter.json",
+    "PART_LXXIX_anomalies.json",
+    "PART_LXXI_higgs_mass.json",
+    "PART_LXXVIII_running.json",
+    "PART_LXXVII_neutrinos.json",
+    "PART_LXXVI_verification.json",
+    "PART_LXXV_string_theory.json",
+    "PART_LXXXIII_cosmology.json",
+    "PART_LXXXII_corrections.json",
+    "PART_LXXXIV_construction.json",
+    "PART_LXXXIX_quantum_code.json",
+    "PART_LXXXI_gravity.json",
+    "PART_LXXXVIII_ultimate.json",
+    "PART_LXXXVII_spacetime.json",
+    "PART_LXXXVI_bootstrap.json",
+    "PART_LXXXV_why_w33.json",
+    "PART_LXXX_consolidation.json",
+    "PART_LXX_gravity.json",
+    "PART_LX_1111_mystery_results.json",
+    "PART_XCIII_predictions.json",
+    "PART_XCII_consciousness.json",
+    "PART_XCIV_lagrangian.json",
+    "PART_XCIX_cp_violation.json",
+    "PART_XCI_multiverse.json",
+    "PART_XCVIII_mass_hierarchy.json",
+    "PART_XCVI_complete_derivation.json",
+    "PART_XCV_proton_decay.json",
+    "PART_XC_arrow_of_time.json"
+  ],
+  "summaries": {
+    "PART_CIII_precision_frontier.json": {
+      "date": "2026-01-16T19:34:55.231560",
+      "key_results": {
+        "desi_dark_energy_2025": {
+          "agreement_percent": 0.1,
+          "w0_measured": -0.827,
+          "w0_w33_predicted": -0.826
+        },
+        "lhc_2025": {
+          "exceeded_target_by_fb": 5.4,
+          "status": "Record-breaking luminosity"
+        },
+        "muon_g2_final_2025": {
+          "experimental": 0.001165920705,
+          "precision_ppm": 0.127,
+          "status": "Most precise magnetic moment ever measured"
+        },
+        "quark_entanglement_2024": {
+          "discovered": "September 18, 2024",
+          "significance": "First observation at highest energy"
+        },
+        "w_boson_mass_2024": {
+          "cms_value_gev": 80.3602,
+          "error_gev": 0.0099,
+          "status": "CDF anomaly resolved - SM confirmed"
+        }
+      },
+      "part": "CIII",
+      "predictions_total": 15,
+      "summary": "W33 theory passes all 2025-2026 precision tests",
+      "title": "THE PRECISION FRONTIER",
+      "w33_parameters": {
+        "dimension": 11,
+        "eigenvalues": [
+          12,
+          2,
+          -4
+        ],
+        "k": 12,
+        "lambda": 2,
+        "mu": 4,
+        "multiplicities": [
+          1,
+          24,
+          15
+        ],
+        "total_spectrum": 121,
+        "v": 40
+      }
+    },
+    "PART_CII_quantum_gravity.json": {
+      "W33_predictions": {
+        "graviton_mass": 0,
+        "mass_hierarchy": "normal",
+        "neutrino_mass_sum": "0.06-0.08 eV",
+        "spacetime_dimensions": 11,
+        "w_0_predicted": -0.8264462809917356
+      },
+      "date": "2026-01-16T19:26:05.796695",
+      "discoveries": {
+        "DESI_2025": {
+          "significance": "2.8-4.2\u03c3",
+          "w_0": -0.827,
+          "w_a": -0.75
+        },
+        "KATRIN_2025": "m_\u03bd < 0.45 eV",
+        "graviton_mass_bound": "< 1.76e-23 eV"
+      },
+      "experimental_matches": {
+        "DESI_w0": {
+          "agreement": "0.1%",
+          "observed": -0.827,
+          "predicted": -0.826
+        },
+        "mass_ratio": {
+          "agreement": "exact",
+          "observed": 33.5,
+          "predicted": 33.5
+        }
+      },
+      "key_formulas": {
+        "cosmological_constant": "\u039b = 10^(-(40+81)) \u00d7 M_Planck\u2074",
+        "dark_energy_w0": "w\u2080 = -1 + (40-27+8)/121 = -0.826",
+        "mass_splitting_ratio": "\u0394m\u00b2\u2083\u2081/\u0394m\u00b2\u2082\u2081 ~ 81/(\u03bb+\u03bc) ~ 33",
+        "seesaw_scale": "M_R = M_GUT \u00d7 (40/121)"
+      },
+      "part": "CII",
+      "title": "Quantum Gravity, Neutrino Masses, and Evolving Dark Energy"
+    },
+    "PART_CIV_definitive_tests.json": {
+      "cosmology": {
+        "desi_prediction": -0.826,
+        "tensor_to_scalar": 0.001,
+        "w0": -0.8264462809917356,
+        "wa": -0.005532408988457072
+      },
+      "dark_matter": {
+        "cross_section_cm2": 1e-47,
+        "detection_window": "2028-2030",
+        "falsifiable": true,
+        "mass_GeV": 77
+      },
+      "gravitational_waves": {
+        "mass_ratio": 1.6,
+        "mass_scale_solar": 77,
+        "o5_start": "late 2025",
+        "sgwb_amplitude": 1e-09
+      },
+      "hl_lhc": {
+        "higgs_self_coupling": 1.0,
+        "integrated_lumi_fb": 3000,
+        "new_particles_predicted": false,
+        "start_year": 2029
+      },
+      "milestones": [
+        [
+          "2026",
+          "JUNO data",
+          "Neutrino mass hierarchy"
+        ],
+        [
+          "2027",
+          "LIGO O5 ends",
+          "BH mass clustering test"
+        ],
+        [
+          "2028",
+          "DESI final",
+          "Definitive w\u2080, w_a measurement"
+        ],
+        [
+          "2028",
+          "DARWIN reaches design",
+          "77 GeV DM sensitivity"
+        ],
+        [
+          "2029",
+          "HL-LHC starts",
+          "Search for new particles"
+        ],
+        [
+          "2030",
+          "LEGEND-1000",
+          "Majorana neutrino test"
+        ],
+        [
+          "2030",
+          "100 logical qubits",
+          "W33 quantum simulation"
+        ],
+        [
+          "2032",
+          "Einstein Telescope?",
+          "GW stochastic background"
+        ],
+        [
+          "2035",
+          "HL-LHC 3000 fb\u207b\u00b9",
+          "Final new particle search"
+        ]
+      ],
+      "neutrinos": {
+        "hierarchy": "normal",
+        "juno_prediction": "normal hierarchy",
+        "nature": "Majorana",
+        "sum_masses_eV": 0.07
+      },
+      "part": "CIV",
+      "part_number": 104,
+      "predictions": [
+        [
+          "Number of generations",
+          "3",
+          "3",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "W boson mass",
+          "80.36 GeV",
+          "80.360 GeV",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "Higgs mass",
+          "125 GeV",
+          "125.20 GeV",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "sin \u03b8\u2081\u2082 (CKM)",
+          "0.225",
+          "0.2248",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "sin \u03b8\u2082\u2083 (CKM)",
+          "0.0417",
+          "0.0418",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "sin \u03b8\u2081\u2083 (CKM)",
+          "0.00369",
+          "0.00365",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "Weinberg angle",
+          "0.2312",
+          "0.2312",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "\u03b1_s(M_Z)",
+          "0.1178",
+          "0.1180",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "\u03b1\u207b\u00b9 (QED)",
+          "137.0",
+          "137.036",
+          "2024",
+          "\u2713 VERIFIED"
+        ],
+        [
+          "Dark energy w\u2080",
+          "-0.826",
+          "-0.827",
+          "2025",
+          "\u2713 DESI"
+        ],
+        [
+          "Muon g-2",
+          "SM consistent",
+          "SM consistent",
+          "2025",
+          "\u2713 FINAL"
+        ],
+        [
+          "DM mass",
+          "77 GeV",
+          "TBD",
+          "2028-2030",
+          "\u23f3 DARWIN/LZ"
+        ],
+        [
+          "DM cross-section",
+          "10\u207b\u2074\u2077 cm\u00b2",
+          "TBD",
+          "2028-2030",
+          "\u23f3 DARWIN"
+        ],
+        [
+          "\u03bd mass hierarchy",
+          "Normal",
+          "TBD",
+          "2025-2028",
+          "\u23f3 JUNO"
+        ],
+        [
+          "\u03a3m_\u03bd",
+          "0.07 eV",
+          "< 0.45 eV",
+          "2028",
+          "\u23f3 Cosmology"
+        ],
+        [
+          "\u03bd nature",
+          "Majorana",
+          "TBD",
+          "2030+",
+          "\u23f3 LEGEND"
+        ],
+        [
+          "Higgs self-coupling",
+          "~1",
+          "TBD",
+          "2030+",
+          "\u23f3 HL-LHC"
+        ],
+        [
+          "New particles",
+          "None < 1 TeV",
+          "None found",
+          "2035",
+          "\u23f3 HL-LHC"
+        ],
+        [
+          "Dark energy w_a",
+          "-0.0055",
+          "~-0.6",
+          "2028",
+          "\u23f3 DESI final"
+        ],
+        [
+          "GW stochastic BG",
+          "10\u207b\u2079",
+          "TBD",
+          "2030",
+          "\u23f3 LIGO O6"
+        ],
+        [
+          "Tensor-to-scalar r",
+          "~0.001",
+          "< 0.03",
+          "2028",
+          "\u23f3 CMB-S4"
+        ]
+      ],
+      "quantum": {
+        "feasibility_year": 2030,
+        "logical_qubits_needed": 40,
+        "qubits_needed": 40
+      },
+      "timestamp": "2026-01-16T19:40:22.001203",
+      "title": "The Definitive Tests (2026-2035)"
+    },
+    "PART_CIX_d4_triality.json": {
+      "d4_dim": 28,
+      "d4_reps": [
+        "8_v (vector)",
+        "8_s (spinor)",
+        "8_c (conjugate spinor)"
+      ],
+      "d4_roots": 24,
+      "d4_roots_explicit": 24,
+      "e8_d4d4": "248 = 28 + 28 + 64 + 64 + 64",
+      "eigenspace_dim": 0,
+      "key_finding": "24 = 3 x 8 explains three generations via D4 triality",
+      "mass_ratios": {
+        "eigenvalue_ratios": {
+          "12/(-4)": -3,
+          "12/2": 6,
+          "2/(-4)": -0.5
+        },
+        "tau_mu_e": "3500:200:1 approximately"
+      },
+      "part": "CIX",
+      "part_number": 109,
+      "timestamp": "2026-01-16T20:04:24.301736",
+      "triality_connection": true
+    },
+    "PART_CI_new_frontiers.json": {
+      "CKM_matrix": {
+        "delta_CP": 68,
+        "sin_theta_12": 0.225,
+        "sin_theta_13": 0.0036900369003690036,
+        "sin_theta_23": 0.041666666666666664
+      },
+      "date": "2026-01-16T19:17:59.755210",
+      "key_findings": {
+        "CKM_solidified": true,
+        "W_mass_resolved": true,
+        "dark_matter_abundance": 5.0,
+        "dark_matter_mass": 77,
+        "muon_g2_resolved": true
+      },
+      "part": "CI",
+      "predictions": [
+        {
+          "experiment": "LZ, XENONnT, DARWIN",
+          "falsifiable": "If no signal by 10\u207b\u2074\u2078 cm\u00b2, W33 WIMP excluded",
+          "name": "Dark Matter Detection",
+          "prediction": "\u03c7 particle at 77 GeV with \u03c3_SI ~ 10\u207b\u2074\u2077 cm\u00b2",
+          "timeline": "2026-2030"
+        },
+        {
+          "experiment": "DUNE, Hyper-Kamiokande",
+          "falsifiable": "If \u03b4_PMNS < 90\u00b0 or > 150\u00b0, W33 CP phase wrong",
+          "name": "Neutrino CP Phase",
+          "prediction": "\u03b4_PMNS = 120\u00b0 \u00b1 15\u00b0 (from 2\u03c0/3)",
+          "timeline": "2026-2032"
+        },
+        {
+          "experiment": "Hyper-Kamiokande",
+          "falsifiable": "\u03c4_p > 10\u00b3\u2076 years excludes W33 GUT",
+          "name": "Proton Decay",
+          "prediction": "\u03c4_p \u2192 e\u207a\u03c0\u2070 ~ 10\u00b3\u2074\u207b\u00b3\u2075 years",
+          "timeline": "2027-2040"
+        },
+        {
+          "experiment": "LHC Run 3, HL-LHC",
+          "falsifiable": "Discovery of light SUSY/extra Higgs falsifies W33",
+          "name": "LHC Null Results",
+          "prediction": "No SUSY, no extra Higgs below 500 GeV",
+          "timeline": "2025-2035"
+        },
+        {
+          "experiment": "nEXO, LEGEND",
+          "falsifiable": "m_\u03b2\u03b2 > 50 meV indicates Majorana mass",
+          "name": "0\u03bd\u03b2\u03b2 Decay",
+          "prediction": "m_\u03b2\u03b2 < 10 meV (Dirac-like neutrinos)",
+          "timeline": "2028-2035"
+        }
+      ],
+      "title": "New Frontiers and Resolved Anomalies"
+    },
+    "PART_CVIII_group_isomorphism.json": {
+      "27_lines": {
+        "cubic_surface_lines": 27,
+        "each_meets": 10,
+        "pairs": 45,
+        "w33_decomposition": "40 = 27 + 12 + 1"
+      },
+      "factorization": [
+        [
+          2,
+          7
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          5,
+          1
+        ]
+      ],
+      "group_orders": {
+        "|GL(4, F_3)|": 24261120,
+        "|Sp(4, F_3)|": 51840,
+        "|W(E6)|": 51840,
+        "|W(E7)|": 2903040,
+        "|W(E8)|": 696729600
+      },
+      "isomorphism_proven": "Sp(4, F_3) \u2245 W(E6)",
+      "next_steps": [
+        "Find explicit 8D embedding subspace",
+        "Map E6 roots to W33 structure",
+        "Understand triality and D4 connection",
+        "Derive symmetry breaking pattern",
+        "Identify dark matter as W33 singlet"
+      ],
+      "orders_match": true,
+      "part": "CVIII",
+      "part_number": 108,
+      "physical_implications": [
+        "Discrete-continuous bridge via W(E6)",
+        "F_3 structure \u2192 3 generations",
+        "E6 GUT connection via 27-dimensional rep",
+        "81 = 3^4 fundamental discretization"
+      ],
+      "sp4_f3_order": 51840,
+      "timestamp": "2026-01-16T19:59:02.486070",
+      "w_e6_order": 51840
+    },
+    "PART_CVII_e8_test_results.json": {
+      "automorphism_order": 51840,
+      "e6_e8": {
+        "27_times_3": 81,
+        "e6_roots": 72,
+        "e8_roots": 240,
+        "ratio": 13440,
+        "w_e6": 51840,
+        "w_e8": 696729600
+      },
+      "e8_edge_match": true,
+      "e8_roots": 240,
+      "edges": 240,
+      "eigenvalues": {
+        "-4": 15,
+        "12": 1,
+        "2": 24
+      },
+      "part": "CVII",
+      "part_number": 107,
+      "timestamp": "2026-01-16T19:59:16.282786",
+      "triangles": 160,
+      "vertices": 40,
+      "w33_confirmed": true,
+      "w_e6_match": true
+    },
+    "PART_CVI_e8_embedding.json": {
+      "automorphism": {
+        "aut_w33": 51840,
+        "factorization": "2^7 \u00d7 3^4 \u00d7 5",
+        "sp4_f3": 51840,
+        "w_e6": 51840
+      },
+      "e6_27": {
+        "decomposition": "27 + 12 + 1",
+        "e6_fund": 27,
+        "e8_e6_81": 81,
+        "w33_vertices": 40
+      },
+      "e6_roots": 60,
+      "e8_roots": 240,
+      "heterotic": {
+        "e8_e8_roots": 480,
+        "w33_squared_edges_cart": 19200,
+        "w33_squared_edges_tens": 115200,
+        "w33_squared_vertices": 1600
+      },
+      "requirements": {
+        "neighbors": 12,
+        "root_norm": 1.4142135623730951,
+        "vertices": 40
+      },
+      "spherical": {
+        "eigenvalues": [
+          12,
+          2,
+          -4
+        ],
+        "multiplicities": [
+          1,
+          24,
+          15
+        ]
+      }
+    },
+    "PART_CV_e8_connection.json": {
+      "breaking": {
+        "e6_to_sm": true,
+        "e8_to_e6": true,
+        "symmetry_ratio": 13440
+      },
+      "construction": {
+        "copies_of_8": 3,
+        "embedding_dim": 8,
+        "main_eigenspace": 24
+      },
+      "correspondence": {
+        "e8_roots": 240,
+        "sm_bosons": 12,
+        "w33_edges": 240,
+        "w33_k": 12
+      },
+      "e8_basics": [
+        [
+          [
+            -1,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            -1,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            -1,
+            -1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            -1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            -1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            0,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            -1,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            -1,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            1,
+            -1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            -1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            -1,
+            1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            -1
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1
+          ]
+        ],
+        [
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5
+          ],
+          [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5
+          ]
+        ]
+      ],
+      "e8_e6": {
+        "e6_adjoint": 78,
+        "e6_fundamental": 27,
+        "e8_dim": 248,
+        "w33_vertices": 40
+      },
+      "lattices": {
+        "d4_roots": 24,
+        "kissing_number": 240,
+        "w33_mult_2": 24
+      },
+      "lisi": {
+        "generations": "W33 better",
+        "lisi_uses": "E8",
+        "w33_uses": "W(E6) via edges=240"
+      },
+      "part": "CV",
+      "part_number": 105,
+      "roadmap": {
+        "conjectured": [
+          "40\u2194?",
+          "24\u2194triality",
+          "15\u2194SU4"
+        ],
+        "directions": [
+          "embedding",
+          "27 of E6",
+          "triality",
+          "breaking",
+          "heterotic"
+        ],
+        "established": [
+          "240=240",
+          "51840=W(E6)",
+          "E6\u2282E8"
+        ]
+      },
+      "timestamp": "2026-01-16T19:49:45.220795",
+      "triality": {
+        "d4_dim": 8,
+        "generations": 3,
+        "triality_reps": 3
+      },
+      "w33_edges": 240,
+      "weyl": {
+        "E6": 51840,
+        "E7": 2903040,
+        "E8": 696729600
+      }
+    },
+    "PART_CXIII_sagemath_verification.json": {
+      "aut_order": 51840,
+      "d4_roots": 24,
+      "e6_roots": 72,
+      "e8_match": true,
+      "e8_roots": 240,
+      "edges": 240,
+      "eigenvalues": [
+        [
+          12,
+          1
+        ],
+        [
+          2,
+          24
+        ],
+        [
+          -4,
+          15
+        ]
+      ],
+      "orders_match": true,
+      "part": "CXIII",
+      "sp4_f3_order": 51840,
+      "srg_params": [
+        40,
+        12,
+        2,
+        4
+      ],
+      "timestamp": "2026-01-16T20:23:20.913315",
+      "triple_match": true,
+      "verified_with": "SageMath 10.7",
+      "vertices": 40,
+      "w_e6_order": 51840,
+      "w_e8_order": 696729600
+    },
+    "PART_CXIII_verified_results.json": {
+      "aut_order": 51840,
+      "d4_roots": 24,
+      "e6_roots": 72,
+      "e8_match": true,
+      "e8_roots": 240,
+      "edges": 240,
+      "eigenvalues": [
+        [
+          12,
+          1
+        ],
+        [
+          2,
+          24
+        ],
+        [
+          -4,
+          15
+        ]
+      ],
+      "orders_match": true,
+      "part": "CXIII",
+      "sp4_f3_order": 51840,
+      "srg_params": [
+        40,
+        12,
+        2,
+        4
+      ],
+      "timestamp": "2026-01-16T20:23:20.913315",
+      "triple_match": true,
+      "verified_with": "SageMath 10.7",
+      "vertices": 40,
+      "w_e6_order": 51840,
+      "w_e8_order": 696729600
+    },
+    "PART_CXII_grand_synthesis.json": {
+      "eigenvalues": {
+        "-4": {
+          "meaning": "Pati-Salam SU(4)",
+          "mult": 15
+        },
+        "12": {
+          "meaning": "gauge boson count",
+          "mult": 1
+        },
+        "2": {
+          "meaning": "D4 triality, 3 generations",
+          "mult": 24
+        }
+      },
+      "key_finding": "W33 is the discrete skeleton of E8 physics",
+      "key_numbers": {
+        "12": [
+          "k = degree",
+          "12 gauge bosons of SM"
+        ],
+        "15": [
+          "Eigenvalue mult",
+          "dim(SU(4)) Pati-Salam"
+        ],
+        "24": [
+          "Eigenvalue mult",
+          "D4 roots, 3x8 triality"
+        ],
+        "240": [
+          "Edges",
+          "E8 roots, gauge structure"
+        ],
+        "248": [
+          "dim(E8)",
+          "E8 Lie algebra dimension"
+        ],
+        "27": [
+          "27 of E6",
+          "One generation in E6 GUT"
+        ],
+        "3": [
+          "F_3 = {0,1,2}",
+          "3 generations of fermions"
+        ],
+        "4": [
+          "F_3^4 dimension",
+          "Spacetime dimensions?"
+        ],
+        "40": [
+          "Vertices",
+          "Fundamental particles + gauge + DM"
+        ],
+        "51840": [
+          "|Aut(W33)|",
+          "|W(E6)| = |Sp(4,F_3)|"
+        ],
+        "72": [
+          "E6 roots",
+          "From W(E6) structure"
+        ],
+        "78": [
+          "dim(E6)",
+          "E6 Lie algebra dimension"
+        ],
+        "8": [
+          "8 = (3^2-1)",
+          "D4 representation dimension, 8 gluons"
+        ],
+        "81": [
+          "3^4 = |F_3^4|",
+          "27x3 = total matter states"
+        ]
+      },
+      "part": "CXII",
+      "part_number": 112,
+      "parts_covered": "CV-CXI (105-111)",
+      "parts_summary": [
+        [
+          "CV",
+          105,
+          "E8 Connection"
+        ],
+        [
+          "CVI",
+          106,
+          "E8 Embedding"
+        ],
+        [
+          "CVII",
+          107,
+          "Explicit E8 Test"
+        ],
+        [
+          "CVIII",
+          108,
+          "Group Isomorphism"
+        ],
+        [
+          "CIX",
+          109,
+          "D4 Triality"
+        ],
+        [
+          "CX",
+          110,
+          "Symmetry Breaking"
+        ],
+        [
+          "CXI",
+          111,
+          "Particle Map"
+        ]
+      ],
+      "predictions": [
+        [
+          "Dark matter mass",
+          "77.03 \u00b1 0.5 GeV",
+          "Direct detection, LHC"
+        ],
+        [
+          "Number of generations",
+          "Exactly 3",
+          "Confirmed (LEP Z-width)"
+        ],
+        [
+          "Gauge boson count",
+          "12",
+          "Confirmed (SM)"
+        ],
+        [
+          "Right-handed neutrino",
+          "Must exist",
+          "Neutrino oscillations"
+        ],
+        [
+          "w_0 (dark energy)",
+          "-0.827",
+          "DESI match: -0.826"
+        ],
+        [
+          "Proton lifetime",
+          "> 10^34 years",
+          "Future experiments"
+        ],
+        [
+          "No 4th generation",
+          "Forbidden",
+          "Confirmed (LEP)"
+        ],
+        [
+          "E6 exotic particles",
+          "Exist at high scale",
+          "Future colliders"
+        ]
+      ],
+      "timestamp": "2026-01-16T20:11:55.464169",
+      "title": "The Grand Synthesis"
+    },
+    "PART_CXIV_tomotope_connection.json": {
+      "24cell_symmetry": 1152,
+      "connection": "tomotope_flags = |W(D4)| = 192",
+      "d4_roots": 24,
+      "hierarchy": {
+        "E6_over_D4": 270,
+        "W_D4": 192,
+        "W_E6": 51840,
+        "W_E8": 696729600
+      },
+      "key_insight": "Tomotope 192 flags = |W(D4)| = triality origin of 3 generations",
+      "part": "CXIV",
+      "part_number": 114,
+      "quotient": 270,
+      "timestamp": "2026-01-16T20:29:12.660525",
+      "tomotope_flags": 192,
+      "w_d4_order": 192
+    },
+    "PART_CXIX_27_analysis.json": {
+      "findings": {
+        "albert_decompositions": {
+          "SO10_U1": "16 + 10 + 1",
+          "SO9": "1 + 9 + 9 + 8",
+          "natural": "3 + 24 = 3 + 3\u00d78"
+        },
+        "cross_edges": 108,
+        "decomposition": "40 = 1 + 12 + 27",
+        "h27_edges": 108,
+        "h27_regular_degree": 8,
+        "number_108": {
+          "cross_edges": 108,
+          "h27_edges": 108,
+          "total_216": 216
+        },
+        "srg_params": [
+          40,
+          12,
+          2,
+          4
+        ],
+        "stab_order": 1296
+      },
+      "part": "CXIX"
+    },
+    "PART_CXI_particle_map.json": {
+      "dark_matter": {
+        "charges": "all zero (singlet)",
+        "mass_GeV": 77.03,
+        "stability": "from W33 adjacency structure"
+      },
+      "e6_27": {
+        "singlet": 1,
+        "so10_10": 10,
+        "so10_16": 16,
+        "total": 27
+      },
+      "gauge_bosons": 12,
+      "key_finding": "40 = 27 + 12 + 1 particle decomposition",
+      "part": "CXI",
+      "part_number": 111,
+      "predictions": [
+        "Dark matter at 77 GeV",
+        "40 total fundamental particles",
+        "Heavy D-quarks at GUT scale",
+        "Right-handed neutrinos exist",
+        "Constrained Yukawa couplings",
+        "Exactly 3 generations"
+      ],
+      "sm_fermions_per_gen": 16,
+      "three_generations": {
+        "per_generation": 27,
+        "source": "F_3 = {0, 1, 2}",
+        "total_states": 81
+      },
+      "timestamp": "2026-01-16T20:10:07.396632",
+      "vertex_map": {
+        "dark_matter": "V40",
+        "e6_singlet": "V27",
+        "exotics": "V17-V26",
+        "fermions": "V1-V16",
+        "gauge": "V28-V39"
+      },
+      "w33_decomposition": {
+        "dark_1": 1,
+        "gauge_12": 12,
+        "matter_27": 27,
+        "total": 40
+      }
+    },
+    "PART_CXVIII_explicit_construction.json": {
+      "findings": {},
+      "part": "CXVIII",
+      "sage_output": null,
+      "success": true,
+      "timestamp": "2026-01-16T20:47:54.615312",
+      "title": "Explicit Construction - Finding Reye/24-cell/Tomotope in W33"
+    },
+    "PART_CXVIII_explicit_results.json": {
+      "conclusion": "W33 explicitly encodes Albert + Reye + singlet structure",
+      "interpretation": {
+        "1": "singlet / origin / identity",
+        "12": "Reye configuration / D4 triality / neighbors",
+        "27": "Albert algebra J\u00b3(\ud835\udd46) / E6 fundamental / non-neighbors"
+      },
+      "part": "CXVIII",
+      "timestamp": "2026-01-16T20:51:33.984171",
+      "title": "Explicit Construction - The 40 = 1 + 12 + 27 Decomposition",
+      "verified_claims": {
+        "automorphism": {
+          "d4_factor": 192,
+          "e6_quotient": 270,
+          "factorization": "192 \u00d7 270",
+          "order": 51840
+        },
+        "decomposition": {
+          "formula": "40 = 1 + 12 + 27",
+          "neighbors": 12,
+          "non_neighbors": 27,
+          "verified": true,
+          "vertex": 1
+        },
+        "eigenvalues": {
+          "d4_multiplicity": 24,
+          "matches_d4_roots": true,
+          "spectrum": [
+            [
+              12,
+              1
+            ],
+            [
+              2,
+              24
+            ],
+            [
+              -4,
+              15
+            ]
+          ]
+        },
+        "neighbor_subgraph": {
+          "edges": 12,
+          "regular_degree": 2,
+          "structure": "6 disjoint edges (cocktail party complement)",
+          "type": "SRG(12, 2, 1, 0)",
+          "vertices": 12
+        }
+      }
+    },
+    "PART_CXVII_jordan_algebras.json": {
+      "findings": {
+        "albert_structure": {
+          "base_field": "octonions",
+          "diagonal_entries": 3,
+          "matrix_size": "3\u00d73",
+          "off_diagonal_entries": "3 octonions = 24 real",
+          "total_dimension": 27
+        },
+        "classification": {
+          "dimension": 27,
+          "exceptional": "H_3(O)",
+          "maximum_n": 3,
+          "types": [
+            "real",
+            "spin",
+            "symmetric",
+            "hermitian",
+            "quaternionic",
+            "octonionic"
+          ]
+        },
+        "cubic_form": {
+          "applications": [
+            "supergravity",
+            "black_hole_entropy",
+            "Yukawa_couplings"
+          ],
+          "degree": 3,
+          "preserved_by": "E6",
+          "variables": 27
+        },
+        "e6_27": {
+          "1": "singlet",
+          "10": "vector = Higgs",
+          "16": "spinor = one generation",
+          "decomposition_SO10": "16 + 10 + 1",
+          "rep_dimension": 27
+        },
+        "e_series": {
+          "E6": {
+            "action": "preserves cubic form",
+            "dim": 78,
+            "fund_rep": 27
+          },
+          "E7": {
+            "dim": 133,
+            "fund_rep": 56
+          },
+          "E8": {
+            "dim": 248,
+            "roots": 240
+          },
+          "F4": {
+            "action": "automorphisms of J\u00b3(\ud835\udd46)",
+            "dim": 52
+          }
+        },
+        "factorization": {
+          "all_equal_51840": true,
+          "detailed": "192 \u00d7 27 \u00d7 10",
+          "e_series": "8 \u00d7 27 \u00d7 240",
+          "main": "192 \u00d7 270",
+          "symmetric": "720 \u00d7 72"
+        },
+        "jordan_definition": {
+          "axioms": [
+            "commutativity",
+            "jordan_identity"
+          ],
+          "product": "a \u2218 b = \u00bd(ab + ba)",
+          "quantum_significance": "algebra of observables"
+        },
+        "vertex_40": {
+          "decomposition_1": "27 + 12 + 1",
+          "decomposition_2": "27 + 13",
+          "decomposition_3": "16 + 16 + 8",
+          "interpretation": {
+            "1": "identity / singlet",
+            "12": "Reye configuration / triality",
+            "27": "Albert algebra / E6 fundamental"
+          }
+        }
+      },
+      "part": "CXVII",
+      "summary": {
+        "10_meaning": "SO(10) vector, GUT structure",
+        "192_meaning": "W(D4), quantum contextuality, triality",
+        "27_meaning": "Albert algebra J\u00b3(\ud835\udd46), E6 fundamental",
+        "main_factorization": "51,840 = 192 \u00d7 27 \u00d7 10",
+        "octonion_central": true,
+        "unification_complete": true
+      },
+      "timestamp": "2026-01-16T20:38:34.588977",
+      "title": "Exceptional Jordan Algebras and the Number 27"
+    },
+    "PART_CXVI_quantum_contextuality.json": {
+      "findings": {
+        "dimension_4": {
+          "classical_symmetry": "maximal (24-cell is unique)",
+          "division_algebra": "quaternions (non-commutative)",
+          "quantum_contextuality": "first provable here",
+          "structures": [
+            "24-cell",
+            "D4 triality",
+            "quaternions",
+            "Reye"
+          ],
+          "triality": "three generations"
+        },
+        "kochen_specker": {
+          "authors": "Simon Kochen, Ernst Specker",
+          "implication": "Quantum contextuality is fundamental",
+          "result": "No non-contextual hidden variable theory for dim >= 3",
+          "year": 1967
+        },
+        "n192_quantum": {
+          "interpretation": "quantum measurement configurations",
+          "product": 192,
+          "reye_incidences": 48,
+          "tomotope_vertices": 4
+        },
+        "peres_mermin": {
+          "contexts": 6,
+          "contradiction": "parity",
+          "observables": 9,
+          "relation_to_reye": "subset of Reye configuration",
+          "type": "2-qubit system"
+        },
+        "physics_implications": {
+          "contextuality_structural": true,
+          "e_series_necessary": true,
+          "qm_geometric": true,
+          "three_generations_required": true
+        },
+        "reye_proof": {
+          "configuration": "(12\u2084, 16\u2083)",
+          "contexts": 16,
+          "coordinates": "permutations of (\u00b11, \u00b11, 0, 0)",
+          "dimension": 4,
+          "projectors": 12,
+          "same_as": [
+            "24-cell vertices",
+            "D4 roots",
+            "Tomotope edges"
+          ]
+        },
+        "three_generations": {
+          "center": 1,
+          "cube_contribution": 8,
+          "infinity_points": 3,
+          "total": 12,
+          "triality_decomposition": "12 = 4 + 4 + 4",
+          "unification": "contextuality and generations from same geometry"
+        },
+        "w33_quantum": {
+          "aut_w33": 51840,
+          "d4_factor": 192,
+          "e6_factor": 270,
+          "factorization": "192 \u00d7 270",
+          "interpretation": "quantum \u00d7 GUT structure"
+        }
+      },
+      "part": "CXVI",
+      "summary": {
+        "dimension_4_special": true,
+        "n192_quantum": true,
+        "reye_proves_ks": true,
+        "triality_contextuality_unified": true,
+        "w33_unifies": true
+      },
+      "timestamp": "2026-01-16T20:36:34.575116",
+      "title": "Quantum Contextuality and the Kochen-Specker Theorem"
+    },
+    "PART_CXV_reye_tomotope.json": {
+      "connection": {
+        "incidence_match": true,
+        "reye_lines": 16,
+        "reye_points": 12,
+        "tomotope_edges": 12,
+        "tomotope_faces": 16
+      },
+      "flag_analysis": {
+        "24cell_symmetry": 1152,
+        "reye_symmetry": 576,
+        "tomotope_flags": 192,
+        "triality_factor": 6,
+        "w_d4_order": 192
+      },
+      "key_insight": "Tomotope edges-faces = Reye config, both from 24-cell/D4",
+      "part": "CXV",
+      "part_number": 115,
+      "references": [
+        "Monson, Pellicer & Williams (2012), \"The Tomotope\", Ars Mathematica Contemporanea",
+        "Aravind (2000), \"How Reye's configuration helps in proving Bell-Kochen-Specker\"",
+        "Manivel (2006), \"Configurations of lines and models of Lie algebras\"",
+        "Reye (1882), \"Das Problem der Configurationen\""
+      ],
+      "reye": {
+        "flags": 48,
+        "lines": 16,
+        "lines_per_point": 4,
+        "points": 12,
+        "points_per_line": 3,
+        "symmetry_order": 576
+      },
+      "timestamp": "2026-01-16T20:32:35.248440",
+      "tomotope": {
+        "cells": 8,
+        "edges": 12,
+        "faces": 16,
+        "flag_orbits": 2,
+        "flags": 192,
+        "rank": 4,
+        "symmetry_order": 96,
+        "vertices": 4
+      }
+    },
+    "PART_CXXIII_72_decomposition.json": {
+      "analysis": {
+        "E6_roots": {
+          "D5_part": 40,
+          "decomposition": "72 = 40 + 32",
+          "spinor_part": 32,
+          "total": 72
+        },
+        "summary": {
+          "27_meaning": "Weyl quotient = Albert = E6 fund = non-neighbors",
+          "32_meaning": "spinors = matter generations",
+          "40_meaning": "D5 roots = W33 vertices = gauge",
+          "E6_decomposition": "72 = 40 + 32",
+          "chain": "E8 > E6 > D5 > D4 encoded in W33"
+        },
+        "weyl_groups": {
+          "W_D5": 1920,
+          "W_E6": 51840,
+          "interpretation": "27 = Albert algebra dimension",
+          "quotient": 27
+        }
+      },
+      "part": "CXXIII"
+    },
+    "PART_CXXII_number_40.json": {
+      "analysis": {
+        "D5_connection": {
+          "D5_root_count": 40,
+          "formula": "2n(n-1) where n=5",
+          "match": true
+        },
+        "E6_decomposition": {
+          "D5_roots": 40,
+          "E6_roots": 72,
+          "decomposition": "72 = 40 + 32",
+          "spinor_weights": 32
+        },
+        "factorizations": [
+          [
+            1,
+            40
+          ],
+          [
+            2,
+            20
+          ],
+          [
+            4,
+            10
+          ],
+          [
+            5,
+            8
+          ]
+        ],
+        "interpretation": {
+          "40_as_D5_roots": true,
+          "5_meaning": "rank of D5 = SO(10)",
+          "8_meaning": "octonion dimension via exceptional structure",
+          "E6_contains_D5": true,
+          "symplectic_formula": "(q\u00b2+1)(q+1) for q=3"
+        }
+      },
+      "part": "CXXII"
+    },
+    "PART_CXXI_grand_unified.json": {
+      "part": "CXXI",
+      "synthesis": {
+        "number_table": {
+          "automorphisms": {
+            "aut": 51840,
+            "stab_v": 1296,
+            "stab_v_n": 108,
+            "stab_v_nn": 48
+          },
+          "edges": {
+            "cross": 108,
+            "h12": 12,
+            "h27": 108,
+            "total": 240
+          },
+          "eigenvalues": [
+            [
+              12,
+              1
+            ],
+            [
+              2,
+              24
+            ],
+            [
+              -4,
+              15
+            ]
+          ],
+          "vertices": {
+            "decomposition": "1+12+27",
+            "n": 40
+          }
+        }
+      }
+    },
+    "PART_CXXV_D5_verification.json": {
+      "findings": {
+        "D5_root_count": 40,
+        "W33_built": true,
+        "correspondence_found": false,
+        "inner_product_distribution": {
+          "-1": 12,
+          "-2": 1,
+          "0": 14,
+          "1": 12
+        }
+      },
+      "part": "CXXV"
+    },
+    "PART_CXX_1296_analysis.json": {
+      "findings": {
+        "e6_quotients": {
+          "/27": 1920,
+          "/40": 1296,
+          "/45": 1152,
+          "/72": 720
+        },
+        "factorizations": {
+          "fourth_power": "6\u2074",
+          "key_products": [
+            "12 \u00d7 108",
+            "27 \u00d7 48",
+            "16 \u00d7 81"
+          ],
+          "prime": "2^4 \u00d7 3^4",
+          "square": "36\u00b2"
+        },
+        "number_48": {
+          "factorizations": [
+            "2\u00d724",
+            "3\u00d716",
+            "4\u00d712",
+            "6\u00d78"
+          ],
+          "gl2_f3": true
+        },
+        "powers_of_6": {
+          "6^1": 6,
+          "6^2": 36,
+          "6^3": 216,
+          "6^4": 1296
+        }
+      },
+      "part": "CXX"
+    },
+    "PART_CX_symmetry_breaking.json": {
+      "breaking_chain": [
+        "E8 --> E6 x SU(3)",
+        "E6 --> SO(10) x U(1)",
+        "SO(10) --> SU(5) x U(1)",
+        "SU(5) --> SU(3) x SU(2) x U(1)"
+      ],
+      "e8": {
+        "dim": 248,
+        "rank": 8,
+        "roots": 240
+      },
+      "eigenvalues": {
+        "multiplicities": [
+          1,
+          24,
+          15
+        ],
+        "sum": 40,
+        "values": [
+          12,
+          2,
+          -4
+        ]
+      },
+      "generations": {
+        "number": 3,
+        "one_gen_in_so10": 16,
+        "source": "81 = 27 x 3 from F_3^4"
+      },
+      "key_finding": "Complete E8 --> SM breaking encoded in W33",
+      "part": "CX",
+      "part_number": 110,
+      "pati_salam": {
+        "dimension": 21,
+        "gauge_group": "SU(4) x SU(2) x SU(2)",
+        "w33_connection": "multiplicity 15"
+      },
+      "predictions": [
+        "3 generations (confirmed)",
+        "12 gauge bosons (confirmed)",
+        "Pati-Salam intermediate stage",
+        "E6 GUT structure",
+        "77 GeV dark matter scalar",
+        "Extra Z' bosons from E6"
+      ],
+      "scales": {
+        "electroweak": "246 GeV",
+        "gut": "10^16 GeV",
+        "planck": "10^19 GeV"
+      },
+      "sm_gauge": {
+        "bosons": {
+          "gluons": 8,
+          "hypercharge": 1,
+          "weak": 3
+        },
+        "group": "SU(3) x SU(2) x U(1)",
+        "total": 12
+      },
+      "timestamp": "2026-01-16T20:07:42.528643",
+      "vertex_decomposition": {
+        "e6_fund": 27,
+        "gauge": 12,
+        "singlet": 1,
+        "total": 40
+      }
+    },
+    "PART_C_manifesto.json": {
+      "axiom": "F\u2083 = {0, 1, 2}",
+      "completion_date": "2026-01-16T18:30:46.378291",
+      "construction": "W33 = Sp(4, F\u2083)",
+      "key_predictions": {
+        "H0_CMB": 67,
+        "H0_local": 73,
+        "Lambda_exponent": -122,
+        "M_Higgs_GeV": 125,
+        "N_generations": 3,
+        "alpha_inverse": 137.036004,
+        "proton_lifetime": "10^34-10^35 years",
+        "sin2_theta_W": 0.216
+      },
+      "parameters": {
+        "e1": 12,
+        "e2": 2,
+        "e3": -4,
+        "k": 12,
+        "m1": 1,
+        "m2": 24,
+        "m3": 15,
+        "v": 40,
+        "\u03bb": 2,
+        "\u03bc": 4
+      },
+      "part": "C",
+      "philosophy": {
+        "consciousness": "part of the loop",
+        "multiverse": false,
+        "observers_inevitable": true,
+        "time_arrow": "from eigenvalue positivity",
+        "universe_is_math": true
+      },
+      "polynomial": "P(x) = (x-12)(x-2)^24(x+4)^15",
+      "status": "THEORY OF EVERYTHING - COMPLETE",
+      "subtitle": "The Theory of Everything",
+      "title": "The Manifesto",
+      "total_parts": 100
+    },
+    "PART_LIII_exploration_results.json": {
+      "doily_lines": 15,
+      "doily_points": 15,
+      "key_numbers": {
+        "W33_lines": 40,
+        "W33_points": 40,
+        "alpha_denominator": 1728,
+        "alpha_numerator": 173,
+        "automorphisms": 25920,
+        "h1_rank": 81
+      },
+      "pg32_lines": 35,
+      "pg32_points": 15,
+      "sp4f3_edges": 240,
+      "sp4f3_vertices": 40
+    },
+    "PART_LIX_master_formula_results.json": {
+      "author": "Wil Dahn",
+      "date": "January 2026",
+      "exceptional_connection": "W33 \u2192 E\u2086 \u2192 E\u2087 \u2192 E\u2088",
+      "fundamental_object": "W33 = Isotropic lines in F\u2083\u2074",
+      "graph_parameters": "SRG(40, 12, 2, 4)",
+      "mean_error": 0.3184008585587276,
+      "predictions": {
+        "Atmospheric Angle": {
+          "error_percent": 0.27424582398404135,
+          "formula": "sin\u00b2\u03b8\u2082\u2083 = 4/7",
+          "observed": 0.573,
+          "predicted": 0.5714285714285714
+        },
+        "Cabibbo Angle": {
+          "error_percent": 1.0146003464489066,
+          "formula": "sin \u03b8_c = 2/9",
+          "observed": 0.2245,
+          "predicted": 0.2222222222222222
+        },
+        "Dark Energy Fraction": {
+          "error_percent": 0.35680428093453764,
+          "formula": "\u03a9_\u039b = 56/81",
+          "observed": 0.6889,
+          "predicted": 0.691358024691358
+        },
+        "Fine Structure Constant": {
+          "error_percent": 2.627309635016781e-06,
+          "formula": "\u03b1\u207b\u00b9 = 81 + 56 + 40/1111",
+          "observed": 137.036,
+          "predicted": 137.03600360036003
+        },
+        "Hubble Constant": {
+          "error_percent": 0.14836795252224674,
+          "formula": "H\u2080 = 27 \u00d7 5/2",
+          "observed": 67.4,
+          "predicted": 67.5
+        },
+        "Koide Parameter": {
+          "error_percent": 0.0100010001000089,
+          "formula": "Q = 2/3",
+          "observed": 0.6666,
+          "predicted": 0.6666666666666666
+        },
+        "Matter Fraction": {
+          "error_percent": 0.7901075832073383,
+          "formula": "\u03a9_m = 25/81",
+          "observed": 0.3111,
+          "predicted": 0.30864197530864196
+        },
+        "Reactor Angle": {
+          "error_percent": 0.9999009999009965,
+          "formula": "sin\u00b2\u03b8\u2081\u2083 = 2/91",
+          "observed": 0.0222,
+          "predicted": 0.02197802197802198
+        },
+        "Solar Angle": {
+          "error_percent": 0.44194455604661054,
+          "formula": "sin\u00b2\u03b8\u2081\u2082 = 40/131",
+          "observed": 0.304,
+          "predicted": 0.3053435114503817
+        },
+        "Spectral Index": {
+          "error_percent": 0.0012727434712828257,
+          "formula": "n_s = 55/57",
+          "observed": 0.9649,
+          "predicted": 0.9649122807017544
+        },
+        "Strong Coupling": {
+          "error_percent": 0.003333444448141942,
+          "formula": "\u03b1_s = 27/229",
+          "observed": 0.1179,
+          "predicted": 0.11790393013100436
+        },
+        "Weak Mixing Angle": {
+          "error_percent": 0.0016750280567185028,
+          "formula": "sin\u00b2\u03b8_W = 40/173",
+          "observed": 0.23121,
+          "predicted": 0.23121387283236994
+        },
+        "Wolfenstein A": {
+          "error_percent": 0.5212211466865124,
+          "formula": "A = 27/34",
+          "observed": 0.79,
+          "predicted": 0.7941176470588235
+        },
+        "Wolfenstein \u03b7\u0304": {
+          "error_percent": 0.04001600640256773,
+          "formula": "\u03b7\u0304 = 5/14",
+          "observed": 0.357,
+          "predicted": 0.35714285714285715
+        },
+        "Wolfenstein \u03bb": {
+          "error_percent": 0.1725193388613688,
+          "formula": "\u03bb = 27/119",
+          "observed": 0.2265,
+          "predicted": 0.226890756302521
+        }
+      },
+      "symmetry_group": "Sp(4,3), order 51840",
+      "theory": "W33 Theory of Everything",
+      "total_predictions": 15
+    },
+    "PART_LVIII_cosmology_results.json": {
+      "dark_energy_fraction": {
+        "formula": "56/81 = E7_fund / 3^4",
+        "observed": 0.6889,
+        "predicted": 0.691358024691358
+      },
+      "hubble_constant": {
+        "formula": "27 \u00d7 5/2",
+        "observed": 67.4,
+        "predicted": 67.5
+      },
+      "key_insight": "Omega_Lambda + Omega_m = 56/81 + 25/81 = 1",
+      "matter_fraction": {
+        "formula": "25/81 = (81-56)/81",
+        "observed": 0.3111,
+        "predicted": 0.30864197530864196
+      },
+      "spectral_index": {
+        "formula": "55/57",
+        "observed": 0.9649,
+        "predicted": 0.9649122807017544
+      },
+      "vacuum_suppression": "137^(-57) \u2248 10^(-122)"
+    },
+    "PART_LVII_fermion_masses_results.json": {
+      "cabibbo_prediction": 0.2222222222222222,
+      "key_numbers": [
+        2,
+        4,
+        7,
+        9,
+        13,
+        14,
+        17,
+        27,
+        34,
+        40,
+        91,
+        119,
+        131
+      ],
+      "koide_parameter": 0.66663234501809,
+      "pmns": {
+        "sin2_theta12_pred": 0.3053435114503817,
+        "sin2_theta13_pred": 0.02197802197802198,
+        "sin2_theta23_pred": 0.5714285714285714
+      },
+      "wolfenstein": {
+        "A_pred": 0.7941176470588235,
+        "eta_bar_pred": 0.35714285714285715,
+        "lambda_pred": 0.226890756302521
+      }
+    },
+    "PART_LVI_quantum_codes_results.json": {
+      "137_base3": "12002",
+      "137_binary": "0b10001001",
+      "137_decomposition": "81 + 56 = 137 exactly",
+      "contextuality": "W33 may encode KS-type proof for qutrits",
+      "e7_fundamental": 56,
+      "pauli_space_dim": 81,
+      "qec_interpretation": "W33 encodes 2-qutrit Pauli structure",
+      "w33_points": 40
+    },
+    "PART_LV_exceptional_results.json": {
+      "E8_parallel": {
+        "formula": "81 + 56 + 111 = 248",
+        "verified": true
+      },
+      "alpha_formula": "81 + 56 + 40/1111",
+      "alpha_inv_exact": 137.03600360036003,
+      "connections": {
+        "1728": "12^3 = (W33 degree)^3",
+        "173": "dim(E7) + |W33| = 133 + 40",
+        "229": "173 + 56",
+        "40": "|W33 points|",
+        "56": "dim(E7 fundamental)",
+        "81": "H1(W33) = 3^4"
+      }
+    },
+    "PART_LXIII_gut_breaking_results.json": {
+      "eigenvalue_structure": {
+        "-4": {
+          "interpretation": "SU(4) adjoint",
+          "multiplicity": 15
+        },
+        "12": {
+          "interpretation": "singlet/total charge",
+          "multiplicity": 1
+        },
+        "2": {
+          "interpretation": "SU(5) adjoint",
+          "multiplicity": 24
+        }
+      },
+      "five_cliques": 0,
+      "four_cliques": 40,
+      "gauge_dimensions": {
+        "E6": 78,
+        "E7": 133,
+        "E8": 248,
+        "SM": 12,
+        "SU4": 15,
+        "SU5": 24
+      },
+      "predictions": {
+        "gut_coupling_inverse": "24 or 25",
+        "proton_lifetime": "10^34-36 years"
+      },
+      "w33_encodings": {
+        "complement_degree": "27 = E6 fund",
+        "degree": "12 = SM gauge dim",
+        "edges": "240 = E8 roots",
+        "eigenvalue_15": "SU(4) adjoint",
+        "eigenvalue_24": "SU(5) adjoint",
+        "vertices": 40
+      }
+    },
+    "PART_LXII_sage_pysymmetry_results.json": {
+      "eigenvalues": {
+        "-4": {
+          "multiplicity": 15
+        },
+        "12": {
+          "multiplicity": 1
+        },
+        "2": {
+          "multiplicity": 24
+        }
+      },
+      "four_cliques": 40,
+      "generated_files": [
+        "w33_sage_sp4_3_verification.sage",
+        "w33_pysymmetry_analysis.sage",
+        "w33_comprehensive_verification.sage"
+      ],
+      "key_verifications": {
+        "1111 = 11 \u00d7 101": true,
+        "1111 = 37 \u00d7 30 + 1": true,
+        "137 \u2248 81 + 56": true,
+        "173 = 133 + 40": true,
+        "229 = 173 + 56": true,
+        "240 edges = E8 roots": true,
+        "248 = 81 + 56 + 111": true,
+        "37 = 7 + 13 + 17": true,
+        "40 vertices": true,
+        "81 = 3^4": true
+      },
+      "physical_interpretation": {
+        "eigenvalue_ratios": {
+          "12/-4": -3,
+          "12/2": 6,
+          "2/-4": -0.5
+        },
+        "multiplicity_15": "SU(4) adjoint dimension",
+        "multiplicity_24": "SU(5) adjoint dimension",
+        "spectral_gap": 10
+      },
+      "srg_parameters": [
+        40,
+        12,
+        2,
+        4
+      ],
+      "triangles": 160,
+      "w33_edges": 240,
+      "w33_vertices": 40
+    },
+    "PART_LXIV_eigenvector_results.json": {
+      "alpha_formula": {
+        "error_ppm": 0.03357044909722473,
+        "experimental": 137.035999,
+        "formula": "degree^2 - e2*|e3| + 1 + 40/1111",
+        "value": 137.03600360036003
+      },
+      "eigenspace_dimensions": {
+        "SU4_adjoint": 15,
+        "SU5_adjoint": 24,
+        "trivial": 1
+      },
+      "eigenvalues": {
+        "-4": 15,
+        "12": 1,
+        "2": 24
+      },
+      "key_insight": "12^2 - 2*4 + 1 = 137",
+      "trace_A2": 480,
+      "trace_A3": 960,
+      "triangles": 160
+    },
+    "PART_LXIX_CP_violation.json": {
+      "CKM_parameters": {
+        "delta_deg": {
+          "exp": 68.75,
+          "formula": "arctan(40/15)",
+          "value": 69.44395478041653
+        },
+        "sin_theta_12": {
+          "exp": 0.22501,
+          "formula": "9/40",
+          "value": 0.225
+        },
+        "sin_theta_13": {
+          "exp": 0.00369,
+          "formula": "1/271",
+          "value": 0.0036900369003690036
+        },
+        "sin_theta_23": {
+          "exp": 0.04182,
+          "formula": "4/96",
+          "value": 0.041666666666666664
+        }
+      },
+      "Jarlskog_invariant": {
+        "W33": 3.153306638727913e-05,
+        "experimental": 3.150385083287883e-05,
+        "ratio": 1.0009273645483938
+      },
+      "formulas": {
+        "271": "240 + 31 = edges + 31",
+        "40/15": "v / m3",
+        "96": "81 + 15 = 3^4 + m3"
+      }
+    },
+    "PART_LXI_predictions_results.json": {
+      "key_statement": "W33 makes falsifiable predictions testable in the next 10 years",
+      "predictions": {
+        "alpha_s": {
+          "experiment": "LHC",
+          "value": "27/229 = 0.1179"
+        },
+        "dark_matter_mass": {
+          "experiment": "XENONnT",
+          "value": "28-40 GeV"
+        },
+        "fourth_generation": {
+          "exists": false,
+          "status": "confirmed"
+        },
+        "heavy_higgs": {
+          "H2": "250-280 GeV",
+          "H3": "375-420 GeV",
+          "experiment": "HL-LHC"
+        },
+        "omega_lambda": {
+          "experiment": "Euclid",
+          "value": "56/81 = 0.6914"
+        },
+        "pmns_cp_phase": {
+          "experiment": "DUNE/HK",
+          "value": "206 degrees"
+        },
+        "proton_lifetime": {
+          "experiment": "Hyper-K",
+          "value": "10^34-36 years"
+        },
+        "spectral_index": {
+          "experiment": "CMB-S4",
+          "value": "55/57 = 0.9649"
+        }
+      }
+    },
+    "PART_LXVIII_why_F3.json": {
+      "Cabibbo_angle": {
+        "error_percent": 0.0,
+        "experimental": 0.22501,
+        "formula": "sin(theta_C) = 9/40",
+        "prediction": 0.225
+      },
+      "PMNS_theta_12": {
+        "error_percent": 2.3,
+        "experimental": 0.307,
+        "formula": "sin^2(theta_12) = 12/40",
+        "prediction": 0.3
+      },
+      "PMNS_theta_23": {
+        "error_percent": 2.0,
+        "experimental": 0.545,
+        "formula": "sin^2(theta_23) = 15/27",
+        "prediction": 0.556
+      },
+      "generation_count": {
+        "error_percent": 0.0,
+        "experimental": 3,
+        "formula": "dim(F_3) = 3",
+        "prediction": 3
+      }
+    },
+    "PART_LXVII_1111_mystery.json": {
+      "1111_formula": {
+        "correction": "lambda + mu + m2 + 1 = 2 + 4 + 24 + 1 = 31",
+        "main_term": "(e1 \u00d7 m2 \u00d7 m3) / |e3| = 12 \u00d7 24 \u00d7 15 / 4 = 1080",
+        "total": 1111
+      },
+      "alpha_complete_formula": {
+        "denominator_D": "(e1 \u00d7 m2 \u00d7 m3)/|e3| + lambda + mu + m2 + 1 = 1111",
+        "integer_part": "e1^2 - e2*|e3| + 1 = 144 - 8 + 1 = 137",
+        "numerator": "v = 40",
+        "result": "137 + 40/1111 = 137.036004"
+      },
+      "factorization": "1111 = 11 \u00d7 101",
+      "geometric_meaning": "1111 encodes eigenvalue products and SRG parameters"
+    },
+    "PART_LXVI_unified_alpha.json": {
+      "error_ppb": 5,
+      "exact_value": {
+        "decimal": 137.036004,
+        "denominator": 1111,
+        "numerator": 152247
+      },
+      "experimental": 137.035999,
+      "formulas": {
+        "E7": "81 + 56 + 40/1111",
+        "SU8": "81 + dim(SU8 3-form) + 40/1111",
+        "eigenvalue": "12^2 - 2*4 + 1 + 40/1111"
+      },
+      "key_numbers": {
+        "1": "U(1) dimension",
+        "144": "12^2 = degree^2",
+        "56": "E_7 fundamental = SU(8) 3-form",
+        "63": "SU(8) adjoint = 8^2 - 1",
+        "8": "2*4 = SU(3) dimension",
+        "81": "3^4 = |F_3^4|"
+      }
+    },
+    "PART_LXXIII_proton_decay.json": {
+      "B_minus_L": "Exactly conserved in W33",
+      "GUT_scale": {
+        "derivation": "M_Planck \u00d7 (M_W/M_Planck)^(7/40)",
+        "formula": "M_GUT = 3^33",
+        "value_GeV": 5559060566555523
+      },
+      "baryogenesis": "Compatible with thermal leptogenesis",
+      "proton_lifetime": {
+        "consistent": true,
+        "experimental_bound": 2.4e+34,
+        "prediction_years": 4.397023005937319e+36
+      },
+      "significance_of_33": [
+        "v - 7 = 40 - 7 = 33",
+        "Interpolation between Planck and weak scales",
+        "Natural GUT scale emergence"
+      ]
+    },
+    "PART_LXXII_fermion_masses.json": {
+      "generation_charges": [
+        4,
+        2,
+        0
+      ],
+      "koide_parameter": {
+        "error_percent": 0.005148512344643178,
+        "experimental": 0.66663234501809,
+        "formula": "K = e2/|F3| = 2/3",
+        "predicted": 0.6666666666666666
+      },
+      "mechanism": "Froggatt-Nielsen with epsilon = 1/3",
+      "neutrino_ratio": {
+        "dm31_dm21": 33,
+        "error_percent": 1.0101010101010173,
+        "experimental": 33.333333333333336,
+        "formula": "v - 7 = 40 - 7"
+      },
+      "seesaw_scale": {
+        "M_R": "3^20",
+        "value_GeV": 3486784401
+      }
+    },
+    "PART_LXXIV_dark_matter.json": {
+      "DM_to_baryon": {
+        "error_percent": 7.894736842105267,
+        "experimental": 5.428571428571429,
+        "formula": "v / (mu + lambda + 2) = 40/8",
+        "prediction": 5
+      },
+      "WIMP_candidate": {
+        "formula": "M_\u03c7 = 3^4 - mu = 81 - 4",
+        "mass_GeV": 77,
+        "stability": "Z_2 parity from Sp(4, F_3)"
+      },
+      "dark_sector": {
+        "composition": [
+          "\u03c7 (77 GeV)",
+          "\u03c7' (85 GeV)",
+          "3 right-handed \u03bd",
+          "\u03b3'",
+          "2 dark scalars"
+        ],
+        "total_vertices": 10
+      },
+      "predictions": {
+        "direct_detection": "Below current limits, within reach",
+        "gamma_line_energy": "77 GeV"
+      }
+    },
+    "PART_LXXIX_anomalies.json": {
+      "SM_anomalies": "All cancel per generation",
+      "W33_consistency": "All anomalies cancel - theory is quantum consistent!",
+      "W33_decomposition": {
+        "m1": {
+          "interpretation": "Higgs singlet",
+          "value": 1
+        },
+        "m2": {
+          "interpretation": "SU(5) adjoint gauge bosons",
+          "value": 24
+        },
+        "m3": {
+          "interpretation": "Fermion structure",
+          "value": 15
+        }
+      },
+      "anomaly_types": {
+        "[Grav]\u00b2U(1)": "Cancels per generation",
+        "[SU(2)]\u00b3": "Vanishes by group theory",
+        "[SU(3)]\u00b3": "Vanishes for complete generations",
+        "[U(1)]\u00b3": "Cancels: 1-32+4-9+36 = 0"
+      }
+    },
+    "PART_LXXI_higgs_mass.json": {
+      "Higgs_mass": {
+        "error_percent": 0.2,
+        "experimental": 125.25,
+        "formula": "3^4 + v + mu = 81 + 40 + 4",
+        "prediction": 125
+      },
+      "Higgs_quartic": {
+        "approx": "1/8 = 1/(e2 \u00d7 |e3|)",
+        "formula": "M_H^2 / (2*v^2)",
+        "value": 0.12909808976138543
+      },
+      "mass_ratios": {
+        "M_H/M_W": 1.5432098765432098,
+        "M_t/M_H": 1.384,
+        "M_t/M_W": 2.1358024691358026
+      },
+      "top_mass": {
+        "error_percent": 0.2,
+        "experimental": 172.69,
+        "formula": "M_H + 2*m2 = 125 + 48",
+        "prediction": 173
+      }
+    },
+    "PART_LXXVIII_running.json": {
+      "boundary_conditions": {
+        "alpha1_inv_MZ": 63.21082543352601,
+        "alpha2_inv_MZ": 31.684624277456646,
+        "alpha3_inv_MZ": 8.481481481481481,
+        "alpha_inv": 137.036,
+        "alpha_s": 0.11790393013100436,
+        "sin2_theta_W": 0.23121387283236994
+      },
+      "gut_scale": {
+        "M_GUT": "3^33",
+        "alpha_GUT_inv": 40.84988742057914,
+        "value_GeV": 5559060566555523
+      },
+      "proton_lifetime": {
+        "consistent": true,
+        "prediction_years": 4.5858567377577304e+36
+      },
+      "unification": {
+        "MSSM_required": true,
+        "threshold_corrections": "From W33 eigenvalues"
+      }
+    },
+    "PART_LXXVII_neutrinos.json": {
+      "majorana_phases": {
+        "alpha1": 30.0,
+        "alpha2": 60.0
+      },
+      "mass_ratio": {
+        "R_exp": 32.57636122177955,
+        "R_w33": 33,
+        "error_percent": 1.3004484304932695
+      },
+      "pmns_angles": {
+        "theta12": {
+          "error": 0.7177033492822814,
+          "exp": 33.44,
+          "w33": 33.2
+        },
+        "theta13": {
+          "error": 0.8168028004667477,
+          "exp": 8.57,
+          "w33": 8.5
+        },
+        "theta23": {
+          "error": 2.2448979591836764,
+          "exp": 49.0,
+          "w33": 47.9
+        }
+      },
+      "seesaw_scale": "3^14 to 3^20 GeV",
+      "tribimaximal": "sin\u00b2\u03b8_12 = 1/3 from F_3"
+    },
+    "PART_LXXVI_verification.json": {
+      "W33_verified": true,
+      "alpha_inv": 137.03600360036003,
+      "alpha_s": 0.1210762331838565,
+      "eigenvalues": {
+        "e1": 12,
+        "e2": 2,
+        "e3": -4
+      },
+      "multiplicities": {
+        "m1": 1,
+        "m2": 24,
+        "m3": 15
+      },
+      "parameters": {
+        "k": 12,
+        "lambda": 2,
+        "mu": 4,
+        "v": 40
+      },
+      "sage_available": false,
+      "sin2_theta_W": 0.21621621621621623
+    },
+    "PART_LXXV_string_theory.json": {
+      "E8_connection": {
+        "E8_roots": 240,
+        "W33_edges": 240,
+        "match": true
+      },
+      "exceptional_structures": {
+        "24": "Leech lattice dimension = m_2",
+        "240": "E8 roots = W33 edges",
+        "Sp(4,F3)": "Order 51840 related to Weyl groups"
+      },
+      "mass_scales": {
+        "M_GUT": "3^33",
+        "M_Planck": "3^40",
+        "M_string": "3^38",
+        "ratio_pattern": "Powers of 3"
+      },
+      "string_interpretation": {
+        "F3": "Emerges from M-theory Z3 structures",
+        "compactification": "(1, 24, 15) = moduli counting",
+        "hypothesis": "W33 is moduli space of string vacuum"
+      }
+    },
+    "PART_LXXXIII_cosmology.json": {
+      "key_number": {
+        "appears_in": [
+          "cosmological constant",
+          "age of universe",
+          "holographic entropy"
+        ],
+        "formula": "k\u00b2 - m\u2082 + \u03bb",
+        "value": 122
+      },
+      "part": "LXXXIII",
+      "predictions": {
+        "H0_CMB": 67,
+        "H0_local": 73,
+        "age_exponent": 61,
+        "cosmological_constant_exponent": -122,
+        "e_folds_inflation": 60
+      },
+      "speculative": true,
+      "theory": "W33",
+      "title": "Cosmology"
+    },
+    "PART_LXXXII_corrections.json": {
+      "1111_derivation": {
+        "components": {
+          "factor1": 11,
+          "factor2": 101
+        },
+        "formula": "(k-1) \u00d7 ((k-\u03bb)\u00b2 + 1)",
+        "k": 12,
+        "lambda": 2,
+        "result": 1111
+      },
+      "alpha_formula": {
+        "base": 137,
+        "complete": "k\u00b2 - 2\u03bc + 1 + v/[(k-1)\u00d7((k-\u03bb)\u00b2+1)]",
+        "denominator": 1111,
+        "result": 137.03600360036003
+      },
+      "alternative_derivations": [
+        "1111 = v \u00d7 3\u00b3 + 31 = 40 \u00d7 27 + 31",
+        "1111 = 11 \u00d7 101 (prime factorization)",
+        "1111 = (10\u2074 - 1)/9 (repunit)"
+      ],
+      "part": "LXXXII",
+      "second_order": -4.516360036003601e-06,
+      "theory": "W33",
+      "title": "Higher-Order Corrections"
+    },
+    "PART_LXXXIV_construction.json": {
+      "alpha_experimental": 137.035999084,
+      "alpha_inverse": 137.03600360036003,
+      "construction": "Symplectic graph on 1-dim subspaces of F_3^4",
+      "eigenvalues": {
+        "e1": 12,
+        "e2": 2,
+        "e3": -4,
+        "multiplicities": [
+          1,
+          24,
+          15
+        ]
+      },
+      "files_generated": [
+        "W33_adjacency_matrix.txt",
+        "W33_lines.txt",
+        "w33_sage_construction.sage"
+      ],
+      "part": "LXXXIV",
+      "theory": "W33",
+      "title": "SageMath Graph Construction",
+      "verified_parameters": {
+        "k": 12,
+        "lambda": 2,
+        "mu": 4,
+        "v": 40
+      }
+    },
+    "PART_LXXXIX_quantum_code.json": {
+      "automorphism_weyl": {
+        "aut_w33": 51840,
+        "match": true,
+        "weyl_E6": 51840
+      },
+      "code_parameters": {
+        "code_rate": 0.6,
+        "logical_qubits": 24,
+        "physical_qubits": 40
+      },
+      "implications": [
+        "Spacetime stability from error correction",
+        "Decoherence from exceeding code distance",
+        "Quantum gravity as error correction",
+        "Black hole information preserved"
+      ],
+      "part": "LXXXIX",
+      "title": "Quantum Error Correcting Code"
+    },
+    "PART_LXXXI_gravity.json": {
+      "dimensions": {
+        "internal": 36,
+        "spacetime": 4,
+        "total": 40
+      },
+      "hierarchy": {
+        "experimental": 5e+16,
+        "formula": "3^(v-4) = 3^36",
+        "value": 1.5009463529699914e+17
+      },
+      "part": "LXXXI",
+      "planck_mass": {
+        "experimental": 1.22e+19,
+        "formula": "M_W \u00d7 3^(v-4)",
+        "predicted": 1.206760867787873e+19,
+        "ratio": 0.9891482522851419
+      },
+      "speculations": [
+        "Graviton in 5 \u2282 15 eigenspace",
+        "Extra dimensions: 36 internal",
+        "1111 may encode Planck physics"
+      ],
+      "theory": "W33",
+      "title": "Gravitational Sector"
+    },
+    "PART_LXXXVIII_ultimate.json": {
+      "characteristic_polynomial": "(x - 12)(x - 2)^24(x + 4)^15",
+      "derived_constants": {
+        "N_generations": 3,
+        "alpha_inverse": "137.03600360036003600360036003600360036003600360036",
+        "cosmological_exponent": -122,
+        "sin2_theta_W": "0.21621621621621621621621621621621621621621621621622"
+      },
+      "fundamental_structure": "Sp(4, F\u2083) symplectic graph",
+      "information_bits": 11,
+      "key_numbers": {
+        "1111": "alpha denominator",
+        "122": "cosmological exponent",
+        "33": "mass ratio, GUT",
+        "36": "extra dimensions"
+      },
+      "parameters": {
+        "eigenvalues": [
+          12,
+          2,
+          -4
+        ],
+        "k": 12,
+        "lambda": 2,
+        "mu": 4,
+        "multiplicities": [
+          1,
+          24,
+          15
+        ],
+        "v": 40
+      },
+      "part": "LXXXVIII",
+      "theory": "W33",
+      "title": "The Ultimate Equation"
+    },
+    "PART_LXXXVII_spacetime.json": {
+      "decomposition": {
+        "formula": "40 = 4 + 36 = 1 + 3 + 36",
+        "internal": 36,
+        "spacetime": 4,
+        "total": 40
+      },
+      "emergence_mechanism": [
+        "Graph structure at Planck scale",
+        "Eigenvalue decomposition",
+        "Compactification of 36 dimensions",
+        "Continuum limit",
+        "Lorentz symmetry emerges"
+      ],
+      "part": "LXXXVII",
+      "prediction": "Tiny Lorentz violations at Planck energies",
+      "theory": "W33",
+      "title": "Emergence of Spacetime",
+      "why_3_plus_1": {
+        "space": "d = p = 3 (dimension of base field F\u2083)",
+        "time": "m\u2081 = 1 (unique trivial eigenspace)"
+      }
+    },
+    "PART_LXXXVI_bootstrap.json": {
+      "constraints": {
+        "E8_connection": "240 edges",
+        "alpha_inverse": 137.036,
+        "anomaly_cancellation": "40 = 1 + 24 + 15",
+        "sin2_theta_W": 0.231,
+        "symplectic": "Over F_3"
+      },
+      "information_bits": 11.90689059560852,
+      "key_insight": "W33 is self-consistently determined by physical requirements",
+      "part": "LXXXVI",
+      "self_reference": "W33 describes a universe that can discover W33",
+      "theory": "W33",
+      "title": "The Bootstrap",
+      "unique_solution": "SRG(40, 12, 2, 4)"
+    },
+    "PART_LXXXV_why_w33.json": {
+      "alternative_srgs_found": 2,
+      "anthropic_argument": "\u03b1 must be ~137 for life; W33 gives exactly this",
+      "mathematical_uniqueness": {
+        "automorphism_order": 51840,
+        "symplectic_origin": "Sp(4, F_3)",
+        "vertex_transitive": true
+      },
+      "part": "LXXXV",
+      "theory": "W33",
+      "title": "Why W33?",
+      "uniqueness_criteria": [
+        "\u03b1\u207b\u00b9 \u2248 137.036 within 100 ppb",
+        "Multiplicities = 1 + 24 + 15 (SU(5))",
+        "Symplectic origin over F_p",
+        "240 edges (E\u2088 roots)"
+      ],
+      "w33_satisfies_all": true
+    },
+    "PART_LXXX_consolidation.json": {
+      "alpha_formula": {
+        "base": "k\u00b2 - 2\u03bc + 1",
+        "correction": "v/1111",
+        "error_ppb": 32.95747151381058,
+        "experimental": 137.035999084,
+        "value": 137.03600360036003
+      },
+      "date": "2026-01-16T17:13:20.887834",
+      "key_connections": [
+        "40 = 1 + 24 + 15 = SU(5) decomposition",
+        "240 edges = E\u2088 non-zero roots",
+        "Sp(4, F\u2083) \u2192 symplectic quantum mechanics",
+        "3 generations = 15/5 from eigenvalue multiplicities"
+      ],
+      "parameters": {
+        "e1": 12,
+        "e2": 2.0,
+        "e3": -4.0,
+        "k": 12,
+        "lambda": 2,
+        "m1": 1,
+        "m2": 24,
+        "m3": 15,
+        "mu": 4,
+        "v": 40
+      },
+      "part": "LXXX",
+      "testable_predictions": 4,
+      "testable_predictions_list": [
+        {
+          "experiment": "Direct detection",
+          "quantity": "M_\u03c7 (dark matter)",
+          "value": "77 GeV"
+        },
+        {
+          "experiment": "Hyper-Kamiokande",
+          "quantity": "\u03c4_proton",
+          "value": "4.6\u00d710\u00b3\u2076 years"
+        },
+        {
+          "experiment": "0\u03bd\u03b2\u03b2 decay",
+          "quantity": "Majorana phases",
+          "value": "\u03b1\u2081=30\u00b0, \u03b1\u2082=60\u00b0"
+        }
+      ],
+      "theory": "W33",
+      "title": "Grand Consolidation",
+      "verified_predictions": 13
+    },
+    "PART_LXX_gravity.json": {
+      "Higgs_VEV": {
+        "error_percent": 0.08935098692226418,
+        "experimental": 246.22,
+        "formula": "3(3^4 + 1) GeV",
+        "prediction": 246
+      },
+      "Newton_G": {
+        "formula": "3^(-80) in natural units"
+      },
+      "Planck_mass": {
+        "experimental": 1.221e+19,
+        "formula": "3^40 GeV",
+        "prediction": 12157665459056928801,
+        "ratio": 0.9957137968105593
+      },
+      "W_mass": {
+        "error_percent": 0.7725898555592817,
+        "experimental": 80.379,
+        "formula": "3^4 GeV",
+        "prediction": 81
+      },
+      "hierarchy": {
+        "W33_value": 150094635296999121,
+        "experimental": 1.5190534841189862e+17,
+        "formula": "3^36"
+      }
+    },
+    "PART_LX_1111_mystery_results.json": {
+      "1111_factorization": "11 \u00d7 101",
+      "1111_from_37": "37 \u00d7 30 + 1 = 999 + 111 + 1",
+      "1111_from_W33": "40 \u00d7 27 + 31",
+      "1111_repunit": "(10^4 - 1)/9",
+      "40/1111": 0.036003600360036005,
+      "alpha_inverse_formula": "81 + 56 + 40/1111",
+      "interpretation": "Vacuum constraint count from generation hierarchy"
+    },
+    "PART_XCIII_predictions.json": {
+      "confirmed_count": 12,
+      "free_parameters": 0,
+      "part": "XCIII",
+      "predictions": [
+        [
+          "\u03b1\u207b\u00b9",
+          137.036004,
+          137.035999,
+          2.1e-05,
+          "5e-5"
+        ],
+        [
+          "sin\u00b2\u03b8\u2081\u2082",
+          0.3,
+          0.307,
+          0.013,
+          "0.5\u03c3"
+        ],
+        [
+          "sin\u00b2\u03b8\u2082\u2083",
+          0.55,
+          0.545,
+          0.021,
+          "0.2\u03c3"
+        ],
+        [
+          "R_\u03bd",
+          33,
+          33.0,
+          1.0,
+          "0\u03c3"
+        ],
+        [
+          "M_H (GeV)",
+          125,
+          125.25,
+          0.17,
+          "1.5\u03c3"
+        ],
+        [
+          "H\u2080(CMB)",
+          67,
+          67.4,
+          0.5,
+          "0.8\u03c3"
+        ],
+        [
+          "H\u2080(local)",
+          73,
+          73.0,
+          1.0,
+          "0\u03c3"
+        ],
+        [
+          "\u039b exponent",
+          -122,
+          -122,
+          1,
+          "0\u03c3"
+        ],
+        [
+          "N_gen",
+          3,
+          3,
+          0,
+          "EXACT"
+        ],
+        [
+          "\u03a9_DM/\u03a9_b",
+          5,
+          5.3,
+          0.2,
+          "1.5\u03c3"
+        ]
+      ],
+      "status": "All predictions consistent with experiment",
+      "testable_future": [
+        "Proton decay",
+        "Dark matter mass",
+        "Lorentz violation",
+        "Neutrino CP phase"
+      ],
+      "title": "Experimental Predictions"
+    },
+    "PART_XCII_consciousness.json": {
+      "hard_problem": "remains open",
+      "key_ideas": {
+        "consciousness_from_integration": "IIT-compatible",
+        "free_will": "compatibilist (quantum + processing)",
+        "mind_matter_relation": "neutral monism",
+        "observers_inevitable": true,
+        "strange_loop": "W33 \u2192 Physics \u2192 Brains \u2192 Math \u2192 W33"
+      },
+      "meaning": "Universe understands itself through observers",
+      "part": "XCII",
+      "speculation_level": "high but grounded in W33 structure",
+      "title": "Consciousness and Observers"
+    },
+    "PART_XCIV_lagrangian.json": {
+      "key_results": {
+        "alpha_gut": 0.025,
+        "fermions": "E\u2083 eigenspace, dim 15",
+        "gauge_bosons": "E\u2082 eigenspace, dim 24",
+        "gauge_group": "SU(3)\u00d7SU(2)\u00d7U(1) from Aut(W33)",
+        "higgs": "E\u2081 eigenspace, dim 1",
+        "lagrangian": "L_SM emerges from graph action"
+      },
+      "part": "XCIV",
+      "title": "The Emergent Lagrangian"
+    },
+    "PART_XCIX_cp_violation.json": {
+      "cabibbo_angle": 0.2,
+      "conclusion": "Matter-antimatter asymmetry explained",
+      "cp_phase": 2.0943951023931953,
+      "cp_phase_degrees": 120,
+      "jarlskog_pmns": 0.02864033383796355,
+      "leptogenesis": "Works with M_R ~ M_GUT",
+      "part": "XCIX",
+      "strong_cp": "\u03b8 = 0 naturally",
+      "title": "CP Violation"
+    },
+    "PART_XCI_multiverse.json": {
+      "conclusion": "No multiverse - W33 is unique",
+      "implications": [
+        "Universe is unique",
+        "Constants are determined",
+        "No fine-tuning needed",
+        "Mathematical necessity"
+      ],
+      "landscape_size": 1,
+      "other_universes": {
+        "(4,2)": "Fails: p=2 too small, no chemistry",
+        "(4,5)": "Fails: d=5 spatial dimensions",
+        "(4,7)": "Fails: d=7 spatial dimensions",
+        "(6,3)": "Fails: No SU(5) structure"
+      },
+      "part": "XCI",
+      "selection_principle": "Self-consistency, not anthropics",
+      "title": "The Multiverse Question"
+    },
+    "PART_XCVIII_mass_hierarchy.json": {
+      "clebsch_gordan": {
+        "c_d": 0.5773502691896257,
+        "c_e": 0.408248290463863,
+        "c_u": 1
+      },
+      "conclusion": "Hierarchy is geometric from graph structure",
+      "generation_scaling": "\u03b5^(2(3-g))",
+      "hierarchy_parameter": 0.16666666666666666,
+      "neutrino_mechanism": "See-saw with M_R ~ M_GUT",
+      "part": "XCVIII",
+      "title": "Fermion Mass Hierarchy"
+    },
+    "PART_XCVI_complete_derivation.json": {
+      "axiom": "Finite field F\u2083 exists",
+      "construction": "W33 = Sp(4, F\u2083) symplectic graph",
+      "parameters": {
+        "e1": 12,
+        "e2": 2,
+        "e3": -4,
+        "k": 12,
+        "lambda": 2,
+        "m1": 1,
+        "m2": 24,
+        "m3": 15,
+        "mu": 4,
+        "v": 40
+      },
+      "part": "XCVI",
+      "polynomial": "P(x) = (x-12)(x-2)^24(x+4)^15",
+      "predictions": {
+        "H0_CMB": 67,
+        "H0_local": 75,
+        "Lambda_exponent": -122,
+        "M_Higgs_GeV": 125,
+        "N_generations": 3,
+        "alpha_inverse": 137.03600360036003,
+        "proton_lifetime_years": "1e34-1e35",
+        "sin2_theta_W": 0.21621621621621623
+      },
+      "status": "COMPLETE THEORY OF EVERYTHING",
+      "title": "The Complete Derivation"
+    },
+    "PART_XCV_proton_decay.json": {
+      "experimental": {
+        "current_limit": "2.4e34 years",
+        "future_test": "Hyper-Kamiokande 2027+",
+        "status": "consistent"
+      },
+      "part": "XCV",
+      "predictions": {
+        "M_GUT_GeV": 5.069173913188384e+17,
+        "alpha_GUT": 0.025,
+        "dominant_channel": "p \u2192 e\u207a + \u03c0\u2070",
+        "tau_p_range": "10^34 - 10^35 years",
+        "tau_p_years": 1.3466766552519488e+46
+      },
+      "title": "Proton Decay - The Smoking Gun",
+      "verdict": "Testable smoking gun prediction"
+    },
+    "PART_XC_arrow_of_time.json": {
+      "dominant_eigenvalue": {
+        "multiplicity": 1,
+        "sign": "positive",
+        "value": 12
+      },
+      "eigenvalue_asymmetry": {
+        "negative_content": -60,
+        "positive_content": 60,
+        "ratio": 1.0
+      },
+      "part": "XC",
+      "predictions": [
+        "Time is discrete at Planck scale",
+        "CPT symmetry is exact",
+        "Initial entropy was minimal",
+        "Arrow is universal"
+      ],
+      "time_cycle": {
+        "automorphisms": 51840,
+        "cycle_duration_seconds": 2.7941759999999998e-39,
+        "planck_times_per_cycle": 51840
+      },
+      "title": "Arrow of Time"
+    }
+  },
+  "total_part_json_files": 71
+}


### PR DESCRIPTION
### Motivation
- The test suite expects `SUMMARY_RESULTS.json` and `NUMERIC_COMPARISONS.json` to be present in the repository root for automated checks.  
- These files were previously ignored, preventing the tests from accessing the generated summary artifacts needed for `tests/test_summary.py`.

### Description
- Removed `SUMMARY_RESULTS.json` and `NUMERIC_COMPARISONS.json` from `.gitignore` so they can be tracked.  
- Added generated `SUMMARY_RESULTS.json` and `NUMERIC_COMPARISONS.json` to the repository root (produced from available `PART_*.json` artifacts).  
- The summary files were produced by running `python scripts/collect_results_from_artifact.py .`, which automatically invoked `scripts/make_numeric_comparisons_from_summary.py` to create the numeric comparisons.

### Testing
- Ran `python scripts/collect_results_from_artifact.py .`, which succeeded and wrote `SUMMARY_RESULTS.json` and `NUMERIC_COMPARISONS.json`.  
- The numeric comparisons extractor `scripts/make_numeric_comparisons_from_summary.py` was invoked by the collector and produced `NUMERIC_COMPARISONS.json`.  
- Ran `pytest -q`, which aborted during collection due to missing runtime dependencies and failed with `ModuleNotFoundError: No module named 'pandas'` and `ModuleNotFoundError: No module named 'sage'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a797fa6c8330b62b5b69cbc5cdb5)