### PR TITLE
Add quick numerical verification notes to January 24 summary

### DIFF
--- a/W33_DEEP_EXPLORATION_SUMMARY_JAN24_2026.md
+++ b/W33_DEEP_EXPLORATION_SUMMARY_JAN24_2026.md
@@ -1,0 +1,420 @@
+# W33 Theory: Complete Deep Exploration Summary
+
+## January 24, 2026 - Extended Session
+
+-----
+
+# PART I: THE ALPHA DERIVATION
+
+## The Master Formula
+
+$$\alpha^{-1} = 81 + 56 + \frac{40}{|Z_{CS}| + 31 + \frac{1}{7}} = 137.0359989715$$
+
+**Agreement with experiment: 0.8 parts per billion**
+
+## The Chern-Simons Origin
+
+The number 1080 emerges from the partition function:
+
+$$Z_{CS} = \sum_{\text{triangles}} e^{i \cdot \text{holonomy} \cdot 2\pi/3}$$
+
+- 360 flat triangles → contribute +360
+- 2880 non-flat triangles → contribute -1440 (via ω + ω² = -1)
+- **Z_CS = 360 - 1440 = -1080**
+
+This is a **derivation**, not a fit!
+
+## Complete Decomposition
+
+|Component|Value       |Origin                    |
+|---------|------------|--------------------------|
+|81       |3⁴          |Flux sectors (topological)|
+|56       |dim(E₇ fund)|Charge space (algebraic)  |
+|40       |points      |Spacetime (geometric)     |
+|1080     |            |Z_CS                      |
+|31       |2⁵-1        |Mersenne M₅ = 121-90      |
+|1/7      |1/          |Fano                      |
+
+-----
+
+# PART II: THE STANDARD MODEL
+
+## E₈ Decomposition
+
+$$248 = 78 + 8 + 81 + 81$$
+$$= \text{E}_6\text{ adj} + \text{SU}(3) + (27,3) + (\bar{27},\bar{3})$$
+
+W33 identifications:
+
+- 240 codewords = E₈ roots = particle states
+- 81 cycles = matter in (27,3)
+- 8 = dim(H) = gluons
+- |Aut| = |W(E₆)| = gauge symmetry
+
+## The Three Generations
+
+$$N_{\text{gen}} = \frac{|cycles|}{dim(J_3(\mathbb{O}))} = \frac{81}{27} = 3$$
+
+Origin: Z₃ holonomy = D₄ triality
+
+-----
+
+# PART III: THE MASS SPECTRUM
+
+## Heavy Particles
+
+|Particle|Formula      |Prediction|Experiment|Agreement|
+|--------|-------------|----------|----------|---------|
+|Top     |v√(40/81)    |173.0 GeV |172.7 GeV |0.2%     |
+|Higgs   |(v/2)√(81/78)|125.5 GeV |125.3 GeV |0.2%     |
+|W boson |m_Z√(133/173)|80.0 GeV  |80.4 GeV  |0.5%     |
+
+## The Top Yukawa
+
+$$y_t = \sqrt{2} \cdot \frac{m_t}{v} = \sqrt{\frac{80}{81}} \approx 0.994$$
+
+The top quark is **maximally coupled** to the Higgs!
+
+## Lepton Mass Ratios (NEW)
+
+$$\frac{m_\tau}{m_\mu} = 16 + 1 = 17$$ (exp: 16.8, error 1%)
+
+$$\frac{m_\mu}{m_e} = 16 \times 13 = 208$$ (exp: 207, error 0.5%)
+
+Where 13 = 40 - 27 = points - Jordan dimension
+
+-----
+
+# PART IV: THE CKM MATRIX (NEW)
+
+## Cabibbo Angle
+
+$$\lambda^2 = \frac{2}{40} = \frac{2}{\text{points}}$$
+
+$$\lambda = \sqrt{\frac{1}{20}} = 0.2236$$
+
+Experimental: 0.2265, error **1.3%**
+
+## Wolfenstein A Parameter
+
+$$A = \frac{31}{40} = \frac{\text{Mersenne}}{\text{points}} = 0.775$$
+
+Experimental: 0.790, error **1.9%**
+
+## Interpretation
+
+The CKM matrix measures how quarks “rotate” between generations when moving through discrete W33 spacetime. The factor 2 in λ² = 2/40 represents two “charged directions” out of 40 spacetime points.
+
+-----
+
+# PART V: GRAVITY AND HIERARCHY (NEW)
+
+## The Hierarchy Ratio
+
+$$\frac{M_{Pl}}{v} \approx 3^{36} = 1.5 \times 10^{17}$$
+
+Where 36 = 4 × 9 = 4 × 3² = dim(phase space) × q²
+
+**The Planck scale is exponentially larger by a W33-determined factor!**
+
+## The Cosmological Constant (Hint)
+
+$$\frac{\rho_\Lambda^{obs}}{\rho_\Lambda^{naive}} \approx 10^{-123} \approx 3^{-256}$$
+
+And 256 = 2⁸ = 2^(dim H)!
+
+## Black Hole Entropy
+
+For a solar-mass black hole:
+$$\ln(S) \approx 177 \approx 40 + 137 = \text{points} + \alpha^{-1}$$
+
+-----
+
+# PART VI: THE BOOTSTRAP (NEW)
+
+## The Self-Reference
+
+$$Q = W_{33}$$
+
+The quotient equals the original structure.
+
+## The Bootstrap Equation
+
+$$|\text{cycles}| = 2 \times |\text{points}| + 1$$
+$$81 = 2 \times 40 + 1$$
+
+W33 **doubles itself** (plus 1) when forming the flux structure.
+
+## Physical Meaning
+
+The universe is a **self-consistent fixed point** of its own dynamics:
+
+- Spacetime creates itself
+- Constants are uniquely determined
+- Quantum mechanics is built in
+- There is only ONE self-consistent universe
+
+-----
+
+# PART VII: COMPLETE NUMBER DICTIONARY
+
+|W33 Number|Derivation        |Physical Meaning             |
+|----------|------------------|-----------------------------|
+|40        |(q²+1)(q+1), q=3  |Spacetime points             |
+|81        |3⁴                |Flux sectors / Matter (27,3) |
+|240       |weight-6 codewords|E₈ roots / Particles         |
+|1080      |                  |Z_CS                         |
+|1111      |1080 + 31         |Holonomy + Mersenne          |
+|56        |dim(E₇ fund)      |Charge representation        |
+|133       |dim(E₇)           |Full gauge structure         |
+|173       |133 + 40          |sin²θ_W denominator          |
+|3240      |40 × 81           |Triangles                    |
+|360       |flat triangles    |Trivial holonomy             |
+|2880      |non-flat          |Z₃ holonomy                  |
+|51840     |                  |Aut(W33)                     |
+|31        |2⁵-1 = 121-90     |Mersenne / quantum correction|
+|7         |Fano points       |Octonionic imaginary units   |
+|27        |J₃(O)             |Jordan algebra               |
+|3         |81/27             |Generations                  |
+|11        |√121              |M-theory dimensions          |
+
+-----
+
+# PART VIII: PREDICTIONS AND TESTS
+
+## Already Confirmed
+
+|Prediction|Value  |Status        |
+|----------|-------|--------------|
+|α⁻¹       |137.036|10⁻⁷ precision|
+|sin²θ_W   |40/173 |0.1σ          |
+|Ω_DM/Ω_b  |27/5   |exact         |
+|N_gen     |3      |exact         |
+
+## Testable Soon
+
+|Prediction |Value    |Status      |
+|-----------|---------|------------|
+|m_t        |173.0 GeV|1.1σ tension|
+|m_H        |125.5 GeV|1.2σ tension|
+|λ (Cabibbo)|0.2236   |1.3% off    |
+
+## Would Kill Theory
+
+- Discovery of 4th generation
+- sin²θ_W away from 40/173
+- Dark matter ratio ≠ 5.4
+- m_t far from 173 GeV
+
+-----
+
+# ASSESSMENT
+
+## What We Have
+
+1. **A derivation of α** from partition functions (not fitting)
+1. **Self-consistent structure** (Q = W33 bootstrap)
+1. **Multiple independent verifications** (masses, CKM, hierarchy)
+1. **Deep mathematical connections** (E₆-E₇-E₈, Klein quadric, Vogel)
+
+## What We Lack
+
+1. First-principles QFT derivation
+1. Explicit continuum limit
+1. Complete mass spectrum
+1. Gravity equations
+
+## Verdict
+
+This is either:
+
+- A profound discovery about the structure of physics
+- An extraordinarily elaborate coincidence
+
+The **depth of the mathematics** and **precision of the numbers** suggest the former. But definitive proof requires either a rigorous derivation or a verified new prediction.
+
+-----
+
+*Exploration completed: January 24, 2026*
+*Total: 10 deep dives, ~1500 lines of code*
+
+# W33 Theory: Deep Exploration Summary
+
+## Breakthroughs from January 24, 2026
+
+-----
+
+## The Major Discovery: α from Partition Functions
+
+We have found that the fine structure constant can be **derived** (not just fitted) from W33:
+
+$$\alpha^{-1} = 81 + 56 + \frac{40}{|Z_{CS}| + 31 + \frac{1}{7}}$$
+
+where:
+
+- **81** = 3⁴ = flux sectors in F₃⁴ symplectic space
+- **56** = dim(E₇ fundamental) = Freudenthal triple system
+- **40** = |W33 points| = discrete spacetime
+- **|Z_CS|** = 1080 = |Chern-Simons partition function|
+- **31** = 2⁵ - 1 = Mersenne prime M₅ = 121 - 90
+- **1/7** = 1/|Fano| = octonionic correction
+
+**Result: α⁻¹ = 137.0359989715, matching experiment to 0.8 parts per billion!**
+
+-----
+
+## The Chern-Simons Partition Function
+
+The key breakthrough: **1080 emerges from holonomy counting!**
+
+```
+Z_CS = Σ_triangles exp(i × holonomy × 2π/3)
+
+For W33's 3240 triangles:
+  - 360 flat (identity holonomy) → contribute 360 × 1 = 360
+  - 2880 non-flat (Z₃ holonomy) → contribute 1440×ω + 1440×ω² = -1440
+
+Z_CS = 360 - 1440 = -1080
+|Z_CS| = 1080
+```
+
+This is **not numerology** — it’s the actual partition function!
+
+-----
+
+## The Standard Model Embedding
+
+E₈ decomposes under E₆ × SU(3)_color as:
+
+```
+240 = 72 + 6 + 81 + 81
+    = E₆ roots + SU(3) roots + (27,3) + (27̄,3̄)
+    = gauge bosons + gluons + matter + antimatter
+```
+
+**W33 identifications:**
+
+- 240 codewords = E₈ roots = particle states
+- 81 cycles = (27,3) = 3 generations × 27 of E₆
+- 8 = dim(H) = gluons = octonion generators
+- |Aut| = |W(E₆)| = gauge symmetry
+
+-----
+
+## The Complete Number Dictionary
+
+|W33 Number|Value    |Physical Meaning            |
+|----------|---------|----------------------------|
+|40        |points   |Spacetime events            |
+|81        |3⁴       |Flux sectors / Matter (27,3)|
+|240       |codewords|E₈ roots / Particles        |
+|56        |E₇ fund  |Charge representation       |
+|1080      |         |Z_CS                        |
+|31        |2⁵-1     |F₂ correction               |
+|7         |Fano     |Octonion imaginary units    |
+|3240      |triangles|40 × 81 = spacetime × flux  |
+|360       |flat tri |Trivial holonomy            |
+|2880      |non-flat |Z₃ holonomy                 |
+
+-----
+
+## Physical Predictions
+
+|Quantity  |Formula               |Theory    |Experiment|Agreement|
+|----------|----------------------|----------|----------|---------|
+|α⁻¹       |81+56+40/(1080+31+1/7)|137.035999|137.035999|0.8 ppb  |
+|sin²θ_W   |40/173                |0.23121   |0.23122   |0.1σ     |
+|Ω_DM/Ω_b  |27/5                  |5.4       |5.4       |exact    |
+|N_gen     |81/27                 |3         |3         |exact    |
+|D_M-theory|√121                  |11        |11        |exact    |
+
+-----
+
+## The Three-Layer Structure
+
+The α formula has three distinct origins:
+
+### Layer 1: Topological (81)
+
+- F₃⁴ symplectic space has 3⁴ = 81 flux configurations
+- Each symplectic direction contributes F₃ = {0,1,2}
+- This is the **vacuum complexity**
+
+### Layer 2: Algebraic (56)
+
+- E₇ fundamental representation
+- Freudenthal triple system dimension
+- This is the **charge space**
+
+### Layer 3: Geometric (40/…)
+
+- Spacetime points divided by flat connections
+- The denominator is |Z_CS| + quantum corrections
+- This is the **geometric dilution**
+
+-----
+
+## Open Questions
+
+1. **Running**: The formula gives α at one scale. How does it run with energy?
+- *Hypothesis*: The W(3,q) ladder encodes energy scales
+1. **E₇ selection**: Why E₇ specifically, not E₆ or E₈?
+- *Partial answer*: E₇ is intermediate between gauge (E₆) and matter (E₈)
+1. **Masses**: Why are particle masses what they are?
+- *Conjecture*: Breaking pattern E₆ → SO(10) → SM determines ratios
+1. **Gravity**: Where is general relativity?
+- *Hint*: Klein quadric encodes spacetime geometry
+
+-----
+
+## What This Means
+
+If this structure is correct, then:
+
+1. **Physics is geometry** at the most fundamental level
+1. The fine structure constant is **topologically determined**
+1. The Standard Model is **embedded in exceptional mathematics**
+1. Spacetime is **discrete** at the Planck scale
+1. The universe is **self-consistent** (bootstrap closure Q = W33)
+
+-----
+
+## Status Assessment
+
+**Strengths:**
+
+- Numerical agreement to sub-ppm precision
+- Every number has independent geometric meaning
+- Connects to established mathematics (Lie algebras, codes, quadrics)
+- Partition function derivation (not just fitting)
+
+**Weaknesses:**
+
+- No rigorous QFT derivation
+- Running not explained
+- Individual masses not predicted
+- Gravity not fully incorporated
+
+**Verdict**: This is either a profound discovery or an extraordinary coincidence. The mathematical depth suggests the former, but definitive proof requires either:
+
+1. A first-principles derivation showing α **must** have this form
+1. A prediction of something **new** that is subsequently verified
+
+-----
+
+## Agent Verification Notes (Quick Checks)
+
+These are lightweight numerical cross-checks based on the formulas stated above. They are **not** independent derivations, but they do confirm internal arithmetic consistency.
+
+|Quantity|Formula|Computed Value|Note|
+|---|---|---|---|
+|α⁻¹|81 + 56 + 40/(1080 + 31 + 1/7)|137.0359989715|Matches the stated value to rounding.|
+|Cabibbo λ|√(1/20)|0.2236067977|Aligns with the stated 0.2236.|
+|Wolfenstein A|31/40|0.775|Matches the stated value.|
+|3³⁶|3^36|1.5009463529699912 × 10^17|Matches the stated 1.5 × 10^17 scale.|
+|Top mass (if v = 246 GeV)|v√(40/81)|172.87 GeV|Consistent with the stated 173.0 GeV (rounding).|
+
+-----
+
+*Document: January 24, 2026*
+*Exploration: 5 deep dives, ~400 lines of code*


### PR DESCRIPTION
### Motivation
- Provide lightweight, reproducible numerical checks in the January 24 deep-exploration summary to confirm internal arithmetic and make key formula evaluations explicit.

### Description
- Add an `Agent Verification Notes (Quick Checks)` section to `W33_DEEP_EXPLORATION_SUMMARY_JAN24_2026.md` containing a table that evaluates `α⁻¹ = 81 + 56 + 40/(1080 + 31 + 1/7)`, `λ = sqrt(1/20)`, `A = 31/40`, `3**36`, and `m_t = 246*sqrt(40/81)` and records the computed values.

### Testing
- Ran the quick numerical checks with `python` during the rollout and all evaluated values matched the numbers recorded in the document (e.g. `α⁻¹ ≈ 137.0359989715`, `λ ≈ 0.2236067977`, `A = 0.775`, `3**36 ≈ 1.50094635297e17`, `m_t ≈ 172.87 GeV`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975461a9f608330b2cf3d763a7050b2)