### PR TITLE
Harden optional test dependencies, add pandas, and skip data/Sage tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,20 @@ m_g ~ ε^(2(3-g))  gives 12 orders of magnitude from GEOMETRY!
 ## Requirements
 
 - Python 3.8+
-- NumPy, SciPy
-- Optional: SageMath for verification
+- NumPy, SymPy, Pandas
+- Optional: SageMath + PySymmetry for verification
 - LaTeX for paper compilation
+
+### Testing
+
+Run the lightweight checks with:
+
+```
+pytest -q
+```
+
+Some research scripts depend on private datasets (for example, V23/W33 CSVs) or
+SageMath; those tests automatically skip if the data or tooling is not present.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies
 numpy>=1.20.0
 sympy>=1.9
+pandas>=1.5.0
 
 # Testing
 pytest>=7.0.0

--- a/src/color_singlet_test.py
+++ b/src/color_singlet_test.py
@@ -11,13 +11,24 @@ This is a STRONG constraint. Let me:
 4. Look for similar constraints in other special structures
 """
 
-import numpy as np
-import pandas as pd
 from pathlib import Path
 from collections import defaultdict
 import json
 
-W33_ROOT = Path(r"C:\Users\wiljd\OneDrive\Documents\GitHub\WilsManifold\claude_workspace\extracted\data\data")
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+W33_ROOT = Path(
+    r"C:\Users\wiljd\OneDrive\Documents\GitHub\WilsManifold\claude_workspace\extracted\data\data"
+)
+
+if not W33_ROOT.exists():
+    pytest.skip(
+        f"Required W33 data directory not available: {W33_ROOT}",
+        allow_module_level=True,
+    )
 
 def load_data():
     """Load W33 rays and collinearity (compute collinearity on the fly)."""

--- a/src/holonomy_correlation_test.py
+++ b/src/holonomy_correlation_test.py
@@ -7,12 +7,23 @@ Does holonomy (Z4, Z3) pair with specific S6 holonomy partitions?
 Key question: Do (2,0) states correlate with (2,2,2) holonomy (fermions)?
 """
 
-import numpy as np
-import pandas as pd
 from pathlib import Path
 from collections import defaultdict
 
-V23_PATH = Path(r"C:\Users\wiljd\OneDrive\Documents\GitHub\WilsManifold\claude_workspace\data\_v23\v23\Q_triangles_with_centers_Z2_S3_fiber6.csv")
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+V23_PATH = Path(
+    r"C:\Users\wiljd\OneDrive\Documents\GitHub\WilsManifold\claude_workspace\data\_v23\v23\Q_triangles_with_centers_Z2_S3_fiber6.csv"
+)
+
+if not V23_PATH.exists():
+    pytest.skip(
+        f"Required V23 data file not available: {V23_PATH}",
+        allow_module_level=True,
+    )
 
 def load_v23_data():
     """Load v23 triangle holonomy data."""

--- a/src/smoking_gun_test.py
+++ b/src/smoking_gun_test.py
@@ -19,12 +19,23 @@ OR if fiber states matter:
   Need to look at Z2 × Z3 fiber structure
 """
 
-import numpy as np
-import pandas as pd
 from pathlib import Path
 from collections import defaultdict
 
-V23_PATH = Path(r"C:\Users\wiljd\OneDrive\Documents\GitHub\WilsManifold\claude_workspace\data\_v23\v23\Q_triangles_with_centers_Z2_S3_fiber6.csv")
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+V23_PATH = Path(
+    r"C:\Users\wiljd\OneDrive\Documents\GitHub\WilsManifold\claude_workspace\data\_v23\v23\Q_triangles_with_centers_Z2_S3_fiber6.csv"
+)
+
+if not V23_PATH.exists():
+    pytest.skip(
+        f"Required V23 data file not available: {V23_PATH}",
+        allow_module_level=True,
+    )
 
 def analyze_triangle_composition():
     """Analyze what Q45 vertices compose each triangle type."""

--- a/src/test_sage_pysymmetry.py
+++ b/src/test_sage_pysymmetry.py
@@ -4,6 +4,11 @@ Test script for SageMath + PySymmetry environment.
 Run with: wsl -e bash run_sage.sh src/test_sage_pysymmetry.py
 """
 
+import pytest
+
+pytest.importorskip("sage")
+pytest.importorskip("pysymmetry")
+
 from sage.all import *
 from pysymmetry import FiniteGroup, MapRepresentation
 import numpy as np


### PR DESCRIPTION
### Motivation

- Make the local test suite robust when optional research datasets or heavy tooling (SageMath/PySymmetry) are not present. 
- Prevent `pytest` from failing on missing optional runtime dependencies such as `pandas` or `sage` so CI and developers can run lightweight checks. 

### Description

- Add `pandas>=1.5.0` to `requirements.txt` and document testing instructions in `README.md` so the expected test environment is explicit. 
- Use `pytest.importorskip("pandas")` in `src/*_test.py` test modules that rely on CSV data to gracefully skip those tests when `pandas` is not available. 
- Add file-existence checks and `pytest.skip(...)` for data-heavy tests so they automatically skip when required CSV datasets are absent. 
- Use `pytest.importorskip("sage")` and `pytest.importorskip("pysymmetry")` in the Sage/PySymmetry integration test to skip that test when Sage or PySymmetry are not installed. 

### Testing

- Installed updated requirements with `python -m pip install -r requirements.txt` and then ran `pytest -q`. 
- Result: `5 passed, 4 skipped` (the suite ran successfully with data/Sage-dependent tests skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697548d79bb48330aec40214e26df13a)