### PR TITLE
Set up Sage and PySymmetry tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ artifacts/
 
 # Extracted bundles (redundant with bundles/ directory)
 extracted/
+
+# Optional external dependencies
+external/pysymmetry/
+external/sage/

--- a/SAGE_PYSYMMETRY_NOTES.md
+++ b/SAGE_PYSYMMETRY_NOTES.md
@@ -2,8 +2,19 @@
 
 This repo includes:
 
-- `external/sage/` — a SageMath tree whose launcher is a **bash script** (`external/sage/bin/sage`).
-- `external/pysymmetry/` — **PySymmetry**, which is a SageMath-based package (it expects `sage.all`).
+- `external/sage/` — an optional SageMath tree whose launcher is a **bash script** (`external/sage/bin/sage`).
+- `external/pysymmetry/` — **PySymmetry**, a SageMath-based package (it expects `sage.all`).
+
+## Linux/container quickstart
+
+From the repo root:
+
+```bash
+./scripts/setup_sage_pysymmetry.sh
+```
+
+That script installs micromamba + Sage (conda-forge) and clones PySymmetry into
+`external/pysymmetry`, then runs a smoke test.
 
 ## Why `external/sage/bin/sage` won’t run in PowerShell
 
@@ -17,11 +28,11 @@ So from plain PowerShell you’ll typically need either:
 
 ## New Sage script added
 
-- `claude_workspace/w33_sage_incidence_and_h1.py`
+- `w33_sage_incidence_and_h1.py`
 
 What it does under Sage:
 
-1. Loads W33 lines from `claude_workspace/data/_workbench/02_geometry/W33_line_phase_map.csv`.
+1. Loads W33 lines from `data/_workbench/02_geometry/W33_line_phase_map.csv` (or `claude_workspace/data/...` if you keep a separate workspace layout).
 2. Builds the **bipartite incidence graph** (40 points + 40 lines).
 3. Computes the **bipartition-preserving automorphism group** using Sage/nauty.
 4. Builds the simplicial complex (edges + triangles + tetrahedra from each line).
@@ -30,26 +41,26 @@ What it does under Sage:
 
 Output:
 
-- `claude_workspace/data/w33_sage_incidence_h1.json`
+- `data/w33_sage_incidence_h1.json` (or `claude_workspace/data/...` if you keep a separate workspace layout)
 
 ## How to run (recommended: WSL + Sage)
 
 Inside WSL, from the repo root:
 
 ```bash
-bash ./claude_workspace/run_sage.sh claude_workspace/w33_sage_incidence_and_h1.py
+bash ./run_sage.sh w33_sage_incidence_and_h1.py
 ```
 
 Optional flags:
 
 ```bash
-bash ./claude_workspace/run_sage.sh claude_workspace/w33_sage_incidence_and_h1.py --pysymmetry
-bash ./claude_workspace/run_sage.sh claude_workspace/w33_sage_incidence_and_h1.py --field=GF --prime=1000003
+bash ./run_sage.sh w33_sage_incidence_and_h1.py --pysymmetry
+bash ./run_sage.sh w33_sage_incidence_and_h1.py --field=GF --prime=1000003
 ```
 
 If you prefer launching from Windows (PowerShell), you can use:
 
-- `claude_workspace/run_w33_sage_wsl.ps1`
+- `run_w33_sage_wsl.ps1`
 
 Or run the VS Code tasks:
 
@@ -62,7 +73,7 @@ From WSL, you can try running the repo’s launcher directly:
 
 ```bash
 ./external/sage/bin/sage -v
-./external/sage/bin/sage -python claude_workspace/w33_sage_incidence_and_h1.py
+./external/sage/bin/sage -python w33_sage_incidence_and_h1.py
 ```
 
 (If it fails, your best path is installing Sage inside WSL and using that `sage`.)
@@ -81,7 +92,7 @@ Option B (conda/mamba inside WSL):
 If you’re already using micromamba/mamba/conda in WSL, installing Sage from conda-forge is often easier to manage:
 
 ```bash
-micromamba create -n sage -c conda-forge sagemath
+micromamba create -n sage -c conda-forge sage
 micromamba activate sage
 sage -v
 ```

--- a/install_sage_wsl_micromamba.sh
+++ b/install_sage_wsl_micromamba.sh
@@ -3,20 +3,23 @@
 set -euo pipefail
 
 echo "=== Installing Sage via micromamba (no sudo required) ==="
+MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-$HOME/micromamba}"
+export MAMBA_ROOT_PREFIX
+export PATH="$HOME/bin:$PATH"
 
 # Check if micromamba exists
 if ! command -v micromamba >/dev/null 2>&1; then
   echo "Installing micromamba..."
   cd ~
-  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-  export PATH="$HOME/bin:$PATH"
-  micromamba shell init -s bash -p ~/micromamba
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest -o /tmp/micromamba.tar.bz2
+  tar -xvjf /tmp/micromamba.tar.bz2 -C "$HOME" bin/micromamba
+  micromamba shell init -s bash -r "$MAMBA_ROOT_PREFIX"
   source ~/.bashrc || true
 fi
 
 # Create sage environment
 echo "Creating sage environment..."
-micromamba create -n sage -c conda-forge sagemath -y
+micromamba create -n sage -c conda-forge sage -y
 
 echo ""
 echo "=== Installation complete! ==="

--- a/lib/w33_io.py
+++ b/lib/w33_io.py
@@ -21,11 +21,17 @@ class W33DataPaths:
         for parent in [p] + list(p.parents):
             if parent.name == "claude_workspace":
                 return W33DataPaths(repo_root=parent.parent)
-        raise ValueError(f"Could not locate claude_workspace above: {p}")
+        # Fallback: locate the git repo root if present.
+        for parent in [p] + list(p.parents):
+            if (parent / ".git").exists():
+                return W33DataPaths(repo_root=parent)
+        # Final fallback: assume the file lives under the repo root.
+        return W33DataPaths(repo_root=p.parent)
 
     @property
     def claude_workspace(self) -> Path:
-        return self.repo_root / "claude_workspace"
+        candidate = self.repo_root / "claude_workspace"
+        return candidate if candidate.exists() else self.repo_root
 
     @property
     def data_root(self) -> Path:

--- a/run_sage.sh
+++ b/run_sage.sh
@@ -10,9 +10,12 @@ set -euo pipefail
 #   wsl.exe -e bash -lc "cd \"$(wslpath 'C:\\path\\to\\repo')\"; ./run_sage.sh ..."
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+REPO_ROOT="${SCRIPT_DIR}"
 
-PYSYM_ROOT="${REPO_ROOT}/lib/pysymmetry_deck_z2_integration_patch"
+PYSYM_PATHS=(
+    "${REPO_ROOT}/external/pysymmetry"
+    "${REPO_ROOT}/lib/pysymmetry_deck_z2_integration_patch"
+)
 
 # Prefer micromamba sage env, then system sage
 if [ -x "$HOME/bin/micromamba" ]; then
@@ -28,7 +31,22 @@ else
     exit 1
 fi
 
-export PYTHONPATH="${PYSYM_ROOT}:${REPO_ROOT}:${PYTHONPATH:-}"
+EXTRA_PYTHONPATH=""
+for path in "${PYSYM_PATHS[@]}"; do
+    if [ -d "${path}" ]; then
+        if [ -z "${EXTRA_PYTHONPATH}" ]; then
+            EXTRA_PYTHONPATH="${path}"
+        else
+            EXTRA_PYTHONPATH="${EXTRA_PYTHONPATH}:${path}"
+        fi
+    fi
+done
+
+if [ -n "${EXTRA_PYTHONPATH}" ]; then
+    export PYTHONPATH="${EXTRA_PYTHONPATH}:${REPO_ROOT}:${PYTHONPATH:-}"
+else
+    export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+fi
 cd "${REPO_ROOT}"
 
 if [ $# -eq 0 ]; then

--- a/run_w33_sage_wsl.ps1
+++ b/run_w33_sage_wsl.ps1
@@ -28,14 +28,14 @@ if (-not $wslRepo) {
 # Use single quotes so PowerShell does not expand bash's `$?`.
 $sageOk = & wsl.exe -d Ubuntu -e bash -lc 'command -v sage >/dev/null 2>&1; echo $?' 2>$null
 if ($sageOk -ne '0') {
-  throw "Sage is not available inside WSL (command 'sage' not found). Install in WSL, e.g.: sudo apt install -y sagemath  OR micromamba create -n sage -c conda-forge sagemath"
+  throw "Sage is not available inside WSL (command 'sage' not found). Install in WSL, e.g.: sudo apt install -y sagemath  OR micromamba create -n sage -c conda-forge sage"
 }
 
-$sageArgs = "claude_workspace/w33_sage_incidence_and_h1.py"
+$sageArgs = "w33_sage_incidence_and_h1.py"
 if ($PySymmetry) { $sageArgs += " --pysymmetry" }
 if ($Field -eq 'GF') { $sageArgs += " --field=GF --prime=$Prime" }
 
-$cmd = "cd '$wslRepo'; bash ./claude_workspace/run_sage.sh $sageArgs"
+$cmd = "cd '$wslRepo'; bash ./run_sage.sh $sageArgs"
 
 Write-Host "Running in WSL:" $cmd
 & wsl.exe -d Ubuntu -e bash -lc $cmd

--- a/scripts/setup_sage_pysymmetry.sh
+++ b/scripts/setup_sage_pysymmetry.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-$HOME/micromamba}"
+export MAMBA_ROOT_PREFIX
+export PATH="$HOME/bin:$PATH"
+
+ensure_micromamba() {
+  if ! command -v micromamba >/dev/null 2>&1; then
+    echo "Installing micromamba..."
+    mkdir -p "$HOME"
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest -o /tmp/micromamba.tar.bz2
+    tar -xvjf /tmp/micromamba.tar.bz2 -C "$HOME" bin/micromamba
+  fi
+}
+
+ensure_sage_env() {
+  if micromamba env list | awk '{print $1}' | grep -qx sage; then
+    echo "Sage env already exists."
+  else
+    echo "Creating sage env via conda-forge..."
+    micromamba create -n sage -c conda-forge sage -y
+  fi
+}
+
+ensure_pysymmetry() {
+  local target="$REPO_ROOT/external/pysymmetry"
+  if [ -d "$target/.git" ]; then
+    echo "PySymmetry already present at $target"
+  else
+    echo "Cloning PySymmetry into $target"
+    mkdir -p "$REPO_ROOT/external"
+    git clone https://github.com/ldsufrpe/pysymmetry "$target"
+  fi
+}
+
+smoke_test() {
+  echo "Running Sage + PySymmetry smoke test..."
+  local pysym_path="$REPO_ROOT/external/pysymmetry"
+  PYTHONPATH="$pysym_path:$REPO_ROOT:${PYTHONPATH:-}" \
+    micromamba run -n sage sage -python - <<'PY'
+import sys
+from pysymmetry import FiniteGroup, representation
+print("PySymmetry import OK", FiniteGroup, representation)
+PY
+}
+
+ensure_micromamba
+ensure_sage_env
+ensure_pysymmetry
+smoke_test
+
+echo ""
+echo "Setup complete. To run Sage scripts:"
+echo "  ./run_sage.sh w33_sage_incidence_and_h1.py"

--- a/w33_sage_incidence_and_h1.py
+++ b/w33_sage_incidence_and_h1.py
@@ -2,7 +2,7 @@
 
 Run (recommended):
 
-    sage -python claude_workspace/w33_sage_incidence_and_h1.py
+    sage -python w33_sage_incidence_and_h1.py
 
 Options:
 
@@ -14,7 +14,7 @@ Options:
 
 Outputs JSON to:
 
-    claude_workspace/data/w33_sage_incidence_h1.json
+    data/w33_sage_incidence_h1.json (or claude_workspace/data/w33_sage_incidence_h1.json)
 """
 
 from __future__ import annotations
@@ -64,7 +64,7 @@ def main() -> None:
     sys.path.insert(0, str(here))
 
     # Make the bundled PySymmetry importable (when running under Sage).
-    pysymmetry_root = here.parent / "external" / "pysymmetry"
+    pysymmetry_root = here / "external" / "pysymmetry"
     if pysymmetry_root.exists():
         sys.path.insert(0, str(pysymmetry_root))
 


### PR DESCRIPTION
### Motivation

- Provide an easy, repeatable way to install Sage inside a Linux/WSL environment and make the repo’s PySymmetry integrations usable.
- Make the Sage runner and data-path resolution resilient to different workspace layouts so the verification scripts run from the repo root.

### Description

- Add `scripts/setup_sage_pysymmetry.sh` to install `micromamba`, create a `sage` env from `conda-forge`, clone `external/pysymmetry`, and run a smoke test that imports `pysymmetry`.
- Harden the micromamba-based installer `install_sage_wsl_micromamba.sh` (fixed bundle extraction, set `MAMBA_ROOT_PREFIX`, update PATH, and use the correct conda package name `sage`).
- Update the Sage runner `run_sage.sh` to search multiple PySymmetry candidate paths and build `PYTHONPATH` only from existing paths, and simplify repository-root handling.
- Make `W33DataPaths.from_this_file` and `claude_workspace` resolution in `lib/w33_io.py` more robust with fallbacks to a git repo root and a sensible `data/` location.
- Update `w33_sage_incidence_and_h1.py`, `run_w33_sage_wsl.ps1`, `SAGE_PYSYMMETRY_NOTES.md`, and `.gitignore` to reflect the new script, paths, quickstart steps, and to ignore optional `external/` deps.

### Testing

- Ran `scripts/setup_sage_pysymmetry.sh` end-to-end which installed `micromamba` (local), created the `sage` environment via `micromamba create -n sage -c conda-forge sage`, and completed dependency linking for the environment (download/install transaction completed).
- The smoke test executed under the created env with `micromamba run -n sage sage -python` and successfully imported PySymmetry, printing `PySymmetry import OK`, indicating the `external/pysymmetry` clone and import path are functional.
- Fixes validated interactively in the environment (installer + smoke test); no other automated unit tests were modified or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754afa0b8c8330b19c255c82c5ad47)