### PR TITLE
Pass 1030: rule out the 80-carrier point-line identification

### DIFF
--- a/PASS1030_EIGHTY_CARRIER_ORIENTATION_OBSTRUCTION.md
+++ b/PASS1030_EIGHTY_CARRIER_ORIENTATION_OBSTRUCTION.md
@@ -1,0 +1,93 @@
+# Pass 1030 — Eighty-carrier orientation obstruction
+
+**Certificate:** `analysis/w33_pass1030_eighty_carrier_orientation_obstruction.py` →
+`data/w33_pass1030_eighty_carrier_orientation_obstruction.json` (`14/14`,
+deterministic, standard-library Python).
+
+## The tempting identification
+
+Pass 1023 supplies the order-three quotient
+
+\[
+240/C_3=80,
+\]
+
+leaving a residual binary \(C_2\) fibre. Independently, the point-line Levi graph
+has
+
+\[
+40\text{ points}+40\text{ lines}=80\text{ vertices}.
+\]
+
+This suggests identifying binary chirality with a point-versus-line label. The
+identification is false for the natural verified actions.
+
+## Orbit obstruction
+
+The E8 omega-triple carrier is transitive:
+
+\[
+|\mathrm{Sp}(4,3)|/648=51840/648=80.
+\]
+
+Its orbit partition is therefore
+
+\[
+[80].
+\]
+
+The natural incidence action on Levi vertices preserves type, so its orbit
+partition is
+
+\[
+[40,40].
+\]
+
+Moreover, Pass 1021 proves the point and line actions are nonconjugate. Therefore
+no natural equivariant bijection can identify the transitive E8 80-carrier with
+the raw Levi point-line union.
+
+## Exact-cover asymmetry
+
+The two Levi halves also differ by a sharp combinatorial invariant:
+
+\[
+W(3,3)=(36\text{ spreads},0\text{ ovoids}),
+\]
+
+while the dual satisfies
+
+\[
+Q(4,3)=(0\text{ spreads},36\text{ ovoids}).
+\]
+
+Thus the two 40-object halves are not interchangeable even as bare incidence
+orientations. E8 selects the point action, the zero-ovoid/KS-uncolourable side.
+
+## Combined no-go with Pass 1029
+
+Pass 1029 proves the whole Eisenstein normalizer is real-orientation preserving.
+Pass 1030 proves that the obvious \(40+40\) surrogate has the wrong orbit
+structure. Together:
+
+> The chirality controller is neither an internal determinant switch nor the raw
+> point-versus-line label. It must lie outside the Eisenstein tower and act above
+> the incidence geometry.
+
+## Experimental falsifier
+
+A proposal claiming that chirality is implemented by swapping W33 points and
+lines must exhibit all of the following:
+
+1. one physical 80-state carrier;
+2. an involution acting transitively across the proposed halves;
+3. explicit transport of incidence and phase labels;
+4. behavior compatible with the exact \(0\)-versus-\(36\) ovoid boundary.
+
+Two disconnected 40-state banks or a mere relabeling fail automatically.
+
+## Boundary
+
+The dual line reading is combinatorial, not a second physical Witting-ray
+realization. This theorem rules out the natural internal identification; it does
+not construct the required external controller.

--- a/analysis/w33_pass1030_eighty_carrier_orientation_obstruction.py
+++ b/analysis/w33_pass1030_eighty_carrier_orientation_obstruction.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Pass 1030: the 80-object count does not identify the chirality carrier with Levi vertices.
+
+After quotienting the 240 E8 roots by the order-three phase subgroup, the remaining
+binary carrier has 80 objects. The W(3,3) Levi graph also has 80 vertices,
+40 points plus 40 lines. This tempting count coincidence is false as a natural
+Sp(4,3)-set identification:
+
+* the E8 80-block carrier is one transitive orbit, with stabilizer 648;
+* the Levi vertex carrier has two invariant 40-orbits (points and lines);
+* those two 40-actions are nonconjugate;
+* the point quotient has 0 ovoids while the dual line quotient has 36.
+
+Together with Pass 1029, this proves that binary chirality is not an internal
+point-line switch of the raw W(3,3) incidence geometry. Any such switch requires
+an external extension and cannot be inferred from 80=40+40 alone.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+OUT = DATA / "w33_pass1030_eighty_carrier_orientation_obstruction.json"
+
+
+def load(name: str) -> dict[str, Any]:
+    return json.loads((DATA / name).read_text(encoding="utf-8"))
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> None:
+    fibration = load("w33_pass1021_e8_fibration_over_forty.json")
+    primary = load("w33_pass1023_chirality_and_phase_halves.json")
+    orientation = load("w33_pass1021_corollary_ovoid_orientation.json")
+    syndrome = load("w33_pass1028_primary_obstruction_syndrome.json")
+    determinant_no_go = load("w33_pass1029_no_orientation_switch_inside.json")
+
+    whole_group = next(
+        row for row in primary["subgroup_table"]
+        if row["name"] == "whole group Sp(4,3)"
+    )
+    group_order = whole_group["order"]
+    triple_stabilizer = primary["halves"]["phase"]["block_stabiliser"]
+    e8_orbit_size = group_order // triple_stabilizer
+
+    points = orientation["W33"]["points"]
+    lines = orientation["W33"]["lines"]
+    levi_vertex_count = points + lines
+    natural_levi_orbits = [points, lines]
+
+    checks = {
+        "all_source_certificates_pass": all(
+            artifact["status"] == "PASS"
+            for artifact in [fibration, primary, orientation, syndrome, determinant_no_go]
+        ),
+        "phase_quotient_is_eighty": primary["halves"]["phase"]["tower"] == "240 -> 80",
+        "phase_block_stabilizer_is_648": triple_stabilizer == 648,
+        "Sp43_order_is_51840": group_order == 51840,
+        "orbit_stabilizer_gives_transitive_eighty": e8_orbit_size == 80,
+        "levi_vertex_count_is_eighty": levi_vertex_count == 80,
+        "levi_natural_orbits_are_forty_plus_forty": natural_levi_orbits == [40, 40],
+        "point_and_line_actions_are_nonconjugate": not fibration["identification"]["point_and_line_actions_conjugate"],
+        "E8_quotient_selects_points_not_lines": (
+            fibration["identification"]["conjugate_to_point_action"]
+            and not fibration["identification"]["conjugate_to_line_action"]
+        ),
+        "point_orientation_has_zero_ovoids": orientation["W33"]["ovoids"] == 0,
+        "dual_line_orientation_has_36_ovoids": orientation["Q43_dual"]["ovoids"] == 36,
+        "orbit_partitions_disagree": [e8_orbit_size] != natural_levi_orbits,
+        "pass1028_marks_C2_as_distinct_eighty_carrier": (
+            syndrome["residual_carrier_square"]["phase_quotient"]["total"] == 80
+            and syndrome["residual_carrier_square"]["phase_quotient"]["remaining_fibre"] == "C2"
+        ),
+        "pass1029_forbids_internal_orientation_reversal": (
+            determinant_no_go["determinant_character"]["antipodal_map"] == 1
+            and determinant_no_go["checks"]["no_orientation_switch_inside_Sp43"]
+            and determinant_no_go["checks"]["whole_normaliser_is_orientation_preserving"]
+        ),
+    }
+    require(all(checks.values()), f"failed checks: {[k for k, v in checks.items() if not v]}")
+
+    result = {
+        "schema": "w33.pass1030.eighty_carrier_orientation_obstruction.python.v1",
+        "status": "PASS",
+        "headline": (
+            "Although 240/C3=80 and the Levi graph has 40+40=80 vertices, the two "
+            "natural Sp(4,3)-sets are inequivalent: the E8 omega-triple carrier is "
+            "one transitive 80-orbit, whereas Levi vertices split into nonconjugate "
+            "point and line 40-orbits with ovoid counts 0 and 36. Binary chirality "
+            "is therefore not an internal point-line switch."
+        ),
+        "count_coincidence": {
+            "E8_phase_quotient": "240/C3 = 80 omega triples",
+            "Levi_vertices": "40 points + 40 lines = 80",
+            "verdict": "equal cardinality only",
+        },
+        "action_obstruction": {
+            "E8_carrier": {
+                "group": "Sp(4,3)",
+                "group_order": group_order,
+                "stabilizer_order": triple_stabilizer,
+                "orbit_partition": [e8_orbit_size],
+                "transitive": True,
+            },
+            "Levi_vertex_carrier": {
+                "natural_group": "PSp(4,3) incidence action",
+                "orbit_partition": natural_levi_orbits,
+                "point_line_actions_conjugate": False,
+                "transitive_on_union": False,
+            },
+            "decisive_invariant": "orbit partition [80] versus [40,40]",
+            "conclusion": "no natural equivariant bijection under the verified actions",
+        },
+        "contextuality_asymmetry": {
+            "point_orientation": {
+                "ovoids": orientation["W33"]["ovoids"],
+                "spreads": orientation["W33"]["spreads"],
+                "reading": "E8-selected, KS-uncolourable",
+            },
+            "line_dual_orientation": {
+                "ovoids": orientation["Q43_dual"]["ovoids"],
+                "spreads": orientation["Q43_dual"]["spreads"],
+                "reading": "combinatorially colourable dual",
+            },
+            "forced_ovoid_size": orientation["forced_ovoid_size"],
+            "conclusion": (
+                "the two Levi halves are not interchangeable even combinatorially; "
+                "their exact-cover invariants differ"
+            ),
+        },
+        "combined_no_go": {
+            "pass1029": "the entire Eisenstein normaliser contains no real determinant-minus-one switch",
+            "pass1030": "the raw 80-vertex Levi carrier has the wrong orbit structure",
+            "architectural_consequence": (
+                "a chirality controller must lie outside the Eisenstein tower and act above "
+                "the incidence geometry; it cannot be identified with the raw "
+                "point-versus-line label"
+            ),
+        },
+        "experimental_falsifier": {
+            "claim_under_test": "the binary chirality bit is implemented by swapping W33 points and lines",
+            "required_evidence": [
+                "a physical involution acting on one 80-state carrier",
+                "transitivity across the proposed point and line halves",
+                "explicit transport of incidence and phase labels",
+                "a measured distinction compatible with the 0-versus-36 ovoid boundary",
+            ],
+            "automatic_failure": (
+                "a mere duplication into two 40-state banks, or a relabelling with no "
+                "cross-orbit symmetry, does not realize the E8 chirality carrier"
+            ),
+        },
+        "boundary": (
+            "The dual line reading is combinatorial, not a second physical Witting-ray "
+            "realization. This theorem rules out the natural internal identification; "
+            "it does not construct the required external controller."
+        ),
+        "check_count": len(checks),
+        "checks": checks,
+    }
+    OUT.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Pass1030 status=PASS checks={len(checks)} output={OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/w33_pass1030_eighty_carrier_orientation_obstruction.json
+++ b/data/w33_pass1030_eighty_carrier_orientation_obstruction.json
@@ -1,0 +1,74 @@
+{
+  "action_obstruction": {
+    "E8_carrier": {
+      "group": "Sp(4,3)",
+      "group_order": 51840,
+      "orbit_partition": [80],
+      "stabilizer_order": 648,
+      "transitive": true
+    },
+    "Levi_vertex_carrier": {
+      "natural_group": "PSp(4,3) incidence action",
+      "orbit_partition": [40, 40],
+      "point_line_actions_conjugate": false,
+      "transitive_on_union": false
+    },
+    "conclusion": "no natural equivariant bijection under the verified actions",
+    "decisive_invariant": "orbit partition [80] versus [40,40]"
+  },
+  "boundary": "The dual line reading is combinatorial, not a second physical Witting-ray realization. This theorem rules out the natural internal identification; it does not construct the required external controller.",
+  "check_count": 14,
+  "checks": {
+    "E8_quotient_selects_points_not_lines": true,
+    "Sp43_order_is_51840": true,
+    "all_source_certificates_pass": true,
+    "dual_line_orientation_has_36_ovoids": true,
+    "levi_natural_orbits_are_forty_plus_forty": true,
+    "levi_vertex_count_is_eighty": true,
+    "orbit_partitions_disagree": true,
+    "orbit_stabilizer_gives_transitive_eighty": true,
+    "pass1028_marks_C2_as_distinct_eighty_carrier": true,
+    "pass1029_forbids_internal_orientation_reversal": true,
+    "phase_block_stabilizer_is_648": true,
+    "phase_quotient_is_eighty": true,
+    "point_and_line_actions_are_nonconjugate": true,
+    "point_orientation_has_zero_ovoids": true
+  },
+  "combined_no_go": {
+    "architectural_consequence": "a chirality controller must lie outside the Eisenstein tower and act above the incidence geometry; it cannot be identified with the raw point-versus-line label",
+    "pass1029": "the entire Eisenstein normaliser contains no real determinant-minus-one switch",
+    "pass1030": "the raw 80-vertex Levi carrier has the wrong orbit structure"
+  },
+  "contextuality_asymmetry": {
+    "conclusion": "the two Levi halves are not interchangeable even combinatorially; their exact-cover invariants differ",
+    "forced_ovoid_size": 10,
+    "line_dual_orientation": {
+      "ovoids": 36,
+      "reading": "combinatorially colourable dual",
+      "spreads": 0
+    },
+    "point_orientation": {
+      "ovoids": 0,
+      "reading": "E8-selected, KS-uncolourable",
+      "spreads": 36
+    }
+  },
+  "count_coincidence": {
+    "E8_phase_quotient": "240/C3 = 80 omega triples",
+    "Levi_vertices": "40 points + 40 lines = 80",
+    "verdict": "equal cardinality only"
+  },
+  "experimental_falsifier": {
+    "automatic_failure": "a mere duplication into two 40-state banks, or a relabelling with no cross-orbit symmetry, does not realize the E8 chirality carrier",
+    "claim_under_test": "the binary chirality bit is implemented by swapping W33 points and lines",
+    "required_evidence": [
+      "a physical involution acting on one 80-state carrier",
+      "transitivity across the proposed point and line halves",
+      "explicit transport of incidence and phase labels",
+      "a measured distinction compatible with the 0-versus-36 ovoid boundary"
+    ]
+  },
+  "headline": "Although 240/C3=80 and the Levi graph has 40+40=80 vertices, the two natural Sp(4,3)-sets are inequivalent: the E8 omega-triple carrier is one transitive 80-orbit, whereas Levi vertices split into nonconjugate point and line 40-orbits with ovoid counts 0 and 36. Binary chirality is therefore not an internal point-line switch.",
+  "schema": "w33.pass1030.eighty_carrier_orientation_obstruction.python.v1",
+  "status": "PASS"
+}


### PR DESCRIPTION
## What changed

Adds a deterministic 14-check verifier, generated certificate, and theorem note for the residual binary 80-carrier.

## Main result

The count

```text
240/C3 = 80 = 40 points + 40 lines
```

is only a cardinality coincidence under the verified actions.

- The E8 omega-triple carrier is one transitive `Sp(4,3)` orbit because `51840/648 = 80`.
- The raw Levi vertex carrier has orbit partition `[40,40]` under the natural incidence action.
- The point and line actions are nonconjugate.
- Their exact-cover invariants differ: the E8-selected point orientation has `0` ovoids, while the dual line orientation has `36`.

Combined with the newly landed Pass 1029, which proves the entire Eisenstein normalizer is real-orientation preserving, this rules out both natural internal models for the chirality controller: it is neither a determinant switch inside the tower nor the raw point-versus-line label.

## Validation

Executed against the current committed Pass 1021, 1023, 1028, and 1029 certificates:

```text
Pass1030 status=PASS checks=14
```

## Boundary

The dual line reading is combinatorial, not a second physical Witting-ray realization. This PR proves a no-go and does not construct the required external controller.