### PR TITLE
Passes 1193-1197: exact equivariant bridges and collision gates

### DIFF
--- a/.github/workflows/pass1193_1197_exact_release.yml
+++ b/.github/workflows/pass1193_1197_exact_release.yml
@@ -1,0 +1,50 @@
+name: Passes 1193-1197 Exact Equivariant Release
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'analysis/w33_pass119[3-7]_*.py'
+      - 'data/w33_pass119[3-7]_*.json'
+      - 'tests/test_w33_pass1193_1197.py'
+      - 'data/w33_pass_namespace_registry_v2.json'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/pass1193_1197_exact_release.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'analysis/w33_pass119[3-7]_*.py'
+      - 'data/w33_pass119[3-7]_*.json'
+      - 'tests/test_w33_pass1193_1197.py'
+      - 'data/w33_pass_namespace_registry_v2.json'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/pass1193_1197_exact_release.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  exact-equivariant-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install exact runtime
+        run: python -m pip install --upgrade numpy pytest
+      - name: Recompute Pass 1193 S5/A5 bridge
+        run: PYTHONPATH=analysis python analysis/w33_pass1193_s5_a5_coset_bridge.py
+      - name: Recompute Pass 1194 residual idempotents
+        run: PYTHONPATH=analysis python analysis/w33_pass1194_residual_central_idempotents.py
+      - name: Recompute Pass 1195 Hashimoto packets
+        run: PYTHONPATH=analysis python analysis/w33_pass1195_we6_equivariant_hashimoto.py
+      - name: Recompute Pass 1196 primitive cycle orbits
+        run: PYTHONPATH=analysis python analysis/w33_pass1196_primitive_cycle_orbits.py
+      - name: Run focused release tests
+        run: PYTHONPATH=. pytest -q tests/test_w33_pass1193_1197.py
+      - name: Run prior exact synthesis firewall
+        run: PYTHONPATH=analysis python analysis/w33_pass1192_parallel_synthesis_guard.py
+      - name: Run namespace and collision firewall
+        run: PYTHONPATH=analysis python analysis/w33_pass1197_parallel_collision_guard.py --check-only

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,17 @@ repos:
           and {540:line-nonedge}; {540:both}/{540:mixed} are compatibility
           tags for a genuinely mixed occurrence.
 
+      - id: pass-namespace-collision-guard
+        name: Reject unregistered or colliding parallel pass releases
+        entry: python analysis/w33_pass1197_parallel_collision_guard.py --check-only
+        language: python
+        pass_filenames: false
+        stages: [pre-commit]
+        description: >
+          Fail closed unless modern pass-numbered artifacts have one registered owner,
+          the current exact certificates pass, prior synthesis remains clean, and
+          obsolete transport scaffolds are absent.
+
       - id: s-min-formula-guard
         name: Guard S_min formula correctness
         entry: python -c "

--- a/PASS1193_1197_EXACT_EQUIVARIANT_RELEASE.md
+++ b/PASS1193_1197_EXACT_EQUIVARIANT_RELEASE.md
@@ -1,0 +1,127 @@
+# Passes 1193–1197 — Exact Equivariant Release
+
+Status: **machine-checkable release candidate**
+
+This packet executes the five outstanding workstreams after the Passes 1188–1192 correction release was materialized and merged.
+
+## Pass 1193 — The exact 432-carrier intersection bridge
+
+For each of the three 432-point A2-triple orbits, the stabilizer in the outer Weyl extension is an `S5` of order 120. Reflection parity cuts it into 60 even and 60 odd elements. The even intersection is perfect, centerless, and has element-order census
+
+\[
+1^1\,2^{15}\,3^{20}\,5^{24},
+\]
+
+therefore it is `A5`. Hence
+
+\[
+\boxed{S_5\cap PSp(4,3)=A_5}
+\]
+
+and the same carrier has two exact coset descriptions:
+
+\[
+\boxed{W(E_6)/S_5\cong PSp(4,3)/A_5},
+\qquad
+\frac{51840}{120}=\frac{25920}{60}=432.
+\]
+
+## Pass 1194 — Explicit residual central idempotents
+
+The 1952-dimensional residual is
+
+\[
+13(1)\oplus16(6)\oplus5(15)\oplus4(15_a)\oplus21(20)
+\oplus2(24)\oplus9(30)\oplus4(60_a)\oplus10(64)\oplus90.
+\]
+
+For every residual irreducible character, the release records the rational class-sum projector
+
+\[
+e_\chi=\frac{\chi(1)}{51840}\sum_C\chi(C)K_C.
+\]
+
+The ten character rows are exactly orthonormal. The residual center has dimension 10 and the full commutant has dimension
+
+\[
+13^2+16^2+5^2+4^2+21^2+2^2+9^2+4^2+10^2+1^2
+=1109.
+\]
+
+Boundary: these are canonical central/isotypic projectors. Matrix units inside multiplicity blocks require a noncanonical copy-basis choice.
+
+## Pass 1195 — W(E6)-equivariant Hashimoto packets
+
+The 480-dimensional directed-edge module decomposes as
+
+\[
+1+2(15_-)+15_a+20+3(24)+30_-+60_a+2(81_+)+90.
+\]
+
+The nonbacktracking operator has five exact equivariant spectral packets:
+
+\[
+\begin{array}{c|c|c}
+\text{factor}&\text{dimension}&W(E_6)\text{-module}\\ \hline
+x-11&1&1\\
+x-1&201&30_-+81_++90\\
+x+1&200&15_a+20+24+60_a+81_+\\
+x^2-2x+11&48&2(24)\\
+x^2+4x+11&30&2(15_-)
+\end{array}
+\]
+
+Thus
+
+\[
+\boxed{\chi_B(x)=(x-11)(x-1)^{201}(x+1)^{200}
+(x^2-2x+11)^{24}(x^2+4x+11)^{15}}.
+\]
+
+## Pass 1196 — Primitive reduced-cycle orbits
+
+Literal primitive oriented cycle classes, modulo cyclic rotation, are enumerated through length six:
+
+\[
+\pi_3=320,\qquad \pi_4=3480,\qquad
+\pi_5=36288,\qquad \pi_6=302880.
+\]
+
+The orbit counts are:
+
+\[
+\begin{array}{c|rrrr}
+ n&3&4&5&6\\ \hline
+PSp(4,3)&1&2&3&18\\
+W(E_6)&1&2&2&13
+\end{array}
+\]
+
+At length five, the two projective orbits of size 5184 fuse under the outer involution into one Weyl orbit of size 10368. At length six, 18 projective orbits fuse to 13 Weyl orbits.
+
+The degree-40 continuation is exact through the five spectral packets and Möbius inversion. It is deliberately not called a literal orbit partition beyond length six.
+
+## Pass 1197 — Collision-proof parallel publication
+
+The namespace registry now contains 74 unique registered pass numbers through Pass 1197. The new guard fails closed unless:
+
+- registered pass ranges are disjoint;
+- modern pass-numbered files belong to a registered range;
+- Passes 1193–1197 each have one passing canonical certificate;
+- the prior Pass-1192 synthesis firewall remains clean;
+- the new workflow and pre-commit namespace gate are installed;
+- the obsolete `.correction` materializer scaffold remains absent.
+
+## Verification entrypoints
+
+```bash
+PYTHONPATH=analysis python analysis/w33_pass1193_s5_a5_coset_bridge.py
+PYTHONPATH=analysis python analysis/w33_pass1194_residual_central_idempotents.py
+PYTHONPATH=analysis python analysis/w33_pass1195_we6_equivariant_hashimoto.py
+PYTHONPATH=analysis python analysis/w33_pass1196_primitive_cycle_orbits.py
+PYTHONPATH=. pytest -q tests/test_w33_pass1193_1197.py
+PYTHONPATH=analysis python analysis/w33_pass1192_parallel_synthesis_guard.py
+PYTHONPATH=analysis python analysis/w33_pass1197_parallel_collision_guard.py --check-only
+```
+
+The release workflow is `.github/workflows/pass1193_1197_exact_release.yml`.

--- a/analysis/w33_pass1193_s5_a5_coset_bridge.py
+++ b/analysis/w33_pass1193_s5_a5_coset_bridge.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Pass 1193: exact S5/A5 stabilizer-intersection bridge on the 432 carriers."""
+from __future__ import annotations
+
+from collections import Counter, deque
+import json
+from pathlib import Path
+
+import numpy as np
+
+from w33_we6_exact_core import (
+    a2_orbits,
+    a2_triples,
+    compose,
+    e6_generators,
+    group_invariants,
+    permutation_order,
+    we6_group,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "data" / "w33_pass1193_s5_a5_coset_bridge.json"
+
+
+def group_with_reflection_parity() -> tuple[tuple[np.ndarray, ...], tuple[int, ...]]:
+    """Enumerate W(E6) and its unique reflection-length parity character."""
+    generators = e6_generators()
+    identity = np.arange(240, dtype=np.uint8)
+    elements = [identity]
+    parity = [0]
+    index = {identity.tobytes(): 0}
+    queue = deque([0])
+    while queue:
+        i = queue.popleft()
+        x = elements[i]
+        for generator in generators:
+            y = compose(generator, x)
+            key = y.tobytes()
+            py = parity[i] ^ 1
+            if key not in index:
+                index[key] = len(elements)
+                elements.append(y)
+                parity.append(py)
+                queue.append(len(elements) - 1)
+            else:
+                assert parity[index[key]] == py
+    assert len(elements) == 51840
+    reference = we6_group()
+    assert {g.tobytes() for g in elements} == {g.tobytes() for g in reference}
+    return tuple(elements), tuple(parity)
+
+
+def fixes_triple(permutation: np.ndarray, triple: tuple[int, int, int]) -> bool:
+    return tuple(sorted(int(permutation[x]) for x in triple)) == triple
+
+
+def main() -> dict:
+    triples = a2_triples()
+    group, parity = group_with_reflection_parity()
+    even_indices = [i for i, value in enumerate(parity) if value == 0]
+    assert len(even_indices) == 25920
+
+    records = []
+    for orbit_number, orbit in enumerate(orb for orb in a2_orbits() if len(orb) == 432):
+        representative = triples[orbit[0]]
+        stabilizer_indices = [
+            i for i, element in enumerate(group)
+            if fixes_triple(element, representative)
+        ]
+        even_stabilizer = tuple(group[i] for i in stabilizer_indices if parity[i] == 0)
+        odd_stabilizer_count = sum(parity[i] == 1 for i in stabilizer_indices)
+        assert len(stabilizer_indices) == 120
+        assert len(even_stabilizer) == odd_stabilizer_count == 60
+
+        invariants = group_invariants(even_stabilizer)
+        order_distribution = Counter(permutation_order(x) for x in even_stabilizer)
+        assert order_distribution == Counter({1: 1, 2: 15, 3: 20, 5: 24})
+        assert invariants["center_order"] == 1
+        assert invariants["derived_order"] == 60
+        assert invariants["abelianization_order"] == 1
+        assert len(even_indices) // len(even_stabilizer) == 432
+
+        records.append({
+            "orbit_number": orbit_number,
+            "orbit_size": 432,
+            "representative_a2_triple": list(representative),
+            "we6_stabilizer": {
+                "order": 120,
+                "identification": "S5 = SmallGroup(120,34)",
+                "even_elements": 60,
+                "odd_elements": 60,
+            },
+            "psp43_intersection": {
+                **invariants,
+                "element_order_distribution": dict(sorted(order_distribution.items())),
+                "identification": "A5 = SmallGroup(60,5)",
+            },
+            "coset_models": {
+                "we6_over_s5_index": 51840 // 120,
+                "psp43_over_a5_index": 25920 // 60,
+                "same_432_carrier": True,
+            },
+        })
+
+    result = {
+        "schema": "w33.pass1193.s5_a5_coset_bridge.v1",
+        "status": "PASS",
+        "headline": "Each 432-point W(E6)/S5 carrier restricts transitively to PSp(4,3)/A5, with S5 intersect PSp(4,3)=A5.",
+        "orders": {"W(E6)": 51840, "PSp(4,3)": 25920, "S5": 120, "A5": 60},
+        "normal_subgroup": {
+            "definition": "kernel of reflection-length parity",
+            "order": len(even_indices),
+            "identification": "PSp(4,3)",
+        },
+        "records": records,
+        "theorem": {
+            "intersection": "S5 ∩ PSp(4,3) = A5",
+            "coset_equivalence": "W(E6)/S5 ≅ PSp(4,3)/A5 as PSp(4,3)-sets",
+            "index_identity": "51840/120 = 25920/60 = 432",
+            "three_copies": len(records),
+        },
+        "checks": {
+            "we6_order_51840": len(group) == 51840,
+            "parity_kernel_order_25920": len(even_indices) == 25920,
+            "three_432_orbits": len(records) == 3,
+            "all_intersections_a5": all(r["psp43_intersection"]["order"] == 60 for r in records),
+            "all_indices_432": all(r["coset_models"]["we6_over_s5_index"] == r["coset_models"]["psp43_over_a5_index"] == 432 for r in records),
+        },
+        "scope": "Exact finite permutation computation on the 240 E8 roots; the A5 identification uses order, perfectness, trivial center, and the A5 element-order census.",
+    }
+    assert all(result["checks"].values())
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print("PASS 1193 W(E6)/S5 = PSp(4,3)/A5 on all three 432 carriers")
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/w33_pass1194_residual_central_idempotents.py
+++ b/analysis/w33_pass1194_residual_central_idempotents.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Pass 1194: explicit central Wedderburn projectors for the 1952 residual."""
+from __future__ import annotations
+
+from fractions import Fraction
+import hashlib
+import json
+from pathlib import Path
+
+from w33_pass1135_cubic_kernel_decomposition import ATLAS, CLASS_SIZES, IRR
+from w33_pass1188_exact_kernel_residual_wedderburn import RESIDUAL
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "data" / "w33_pass1194_residual_central_idempotents.json"
+GROUP_ORDER = 51840
+
+
+def fraction_text(value: Fraction) -> str:
+    return str(value.numerator) if value.denominator == 1 else f"{value.numerator}/{value.denominator}"
+
+
+def main() -> dict:
+    rows = {name: (degree, tuple(character)) for degree, character, _, name in IRR}
+    names = tuple(RESIDUAL)
+    assert set(names) <= set(rows)
+
+    orthogonality = []
+    for left in names:
+        _, chil = rows[left]
+        for right in names:
+            _, chir = rows[right]
+            inner_numerator = sum(
+                int(size) * int(a) * int(b)
+                for size, a, b in zip(CLASS_SIZES, chil, chir)
+            )
+            expected = GROUP_ORDER if left == right else 0
+            assert inner_numerator == expected
+            if left <= right:
+                orthogonality.append({"pair": [left, right], "inner_product": inner_numerator // GROUP_ORDER})
+
+    projectors = []
+    total_coefficients = [Fraction(0) for _ in ATLAS]
+    for name in names:
+        degree, character = rows[name]
+        expected_degree, multiplicity = RESIDUAL[name]
+        assert degree == expected_degree
+        coefficients = [Fraction(degree * value, GROUP_ORDER) for value in character]
+        total_coefficients = [a + b for a, b in zip(total_coefficients, coefficients)]
+        numerator_vector = [degree * value for value in character]
+        projectors.append({
+            "irrep": name,
+            "degree": degree,
+            "multiplicity": multiplicity,
+            "residual_rank": degree * multiplicity,
+            "commutant_block": f"M_{multiplicity}(Q)",
+            "central_idempotent_formula": f"e_{name} = ({degree}/51840) * sum_C chi_{name}(C) K_C",
+            "class_sum_coefficients": {
+                ATLAS[i][0]: fraction_text(coefficients[i])
+                for i in range(len(ATLAS)) if coefficients[i]
+            },
+            "denominator_cleared": {
+                "common_denominator": GROUP_ORDER,
+                "numerators_in_atlas_order": numerator_vector,
+                "sha256": hashlib.sha256(json.dumps(numerator_vector, separators=(",", ":")).encode()).hexdigest(),
+            },
+        })
+
+    residual_dimension = sum(item[0] * item[1] for item in RESIDUAL.values())
+    commutant_dimension = sum(item[1] ** 2 for item in RESIDUAL.values())
+    assert residual_dimension == 1952
+    assert commutant_dimension == 1109
+    assert len(projectors) == 10
+    assert sum(p["residual_rank"] for p in projectors) == 1952
+
+    result = {
+        "schema": "w33.pass1194.residual_central_idempotents.v1",
+        "status": "PASS",
+        "headline": "The 1952 residual has ten explicit rational central idempotents and commutant algebra of dimension 1109.",
+        "atlas_class_order": [row[0] for row in ATLAS],
+        "residual_dimension": residual_dimension,
+        "center_dimension": len(projectors),
+        "commutant_dimension": commutant_dimension,
+        "wedderburn_commutant": " ⊕ ".join(f"M_{multiplicity}(Q)" for _, multiplicity in RESIDUAL.values()),
+        "projectors": projectors,
+        "residual_central_projector": {
+            "formula": "P_res = sum_chi e_chi over the ten residual species",
+            "class_sum_coefficients": {
+                ATLAS[i][0]: fraction_text(value)
+                for i, value in enumerate(total_coefficients) if value
+            },
+        },
+        "orthogonality_certificate": orthogonality,
+        "checks": {
+            "ten_isotypic_blocks": len(projectors) == 10,
+            "residual_rank_1952": sum(p["residual_rank"] for p in projectors) == 1952,
+            "commutant_dimension_1109": commutant_dimension == 1109,
+            "character_rows_orthonormal": all(item["inner_product"] == (1 if item["pair"][0] == item["pair"][1] else 0) for item in orthogonality),
+        },
+        "boundary": "These are canonical central/isotypic projectors. Matrix units inside each multiplicity block require a noncanonical choice of copy basis and are intentionally not claimed.",
+    }
+    assert all(result["checks"].values())
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print("PASS 1194 residual central idempotents=10 commutant=1109")
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/w33_pass1195_we6_equivariant_hashimoto.py
+++ b/analysis/w33_pass1195_we6_equivariant_hashimoto.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Pass 1195: exact W(E6)-equivariant Hashimoto spectral decomposition."""
+from __future__ import annotations
+
+from collections import Counter, deque
+from itertools import product
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+
+from w33_pass1135_cubic_kernel_decomposition import ATLAS, CLASS_SIZES, IRR
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "data" / "w33_pass1195_we6_equivariant_hashimoto.json"
+Q = 3
+GROUP_ORDER = 51840
+
+
+def canon(vector: tuple[int, ...]) -> tuple[int, ...]:
+    vector = tuple(x % Q for x in vector)
+    for x in vector:
+        if x:
+            inverse = 1 if x == 1 else 2
+            return tuple(inverse * y % Q for y in vector)
+    raise ValueError("zero vector")
+
+
+def symp(x: tuple[int, ...], y: tuple[int, ...]) -> int:
+    return (x[0] * y[2] - x[2] * y[0] + x[1] * y[3] - x[3] * y[1]) % Q
+
+
+def compose(a: tuple[int, ...], b: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(a[b[i]] for i in range(len(a)))
+
+
+def inverse(permutation: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(permutation)
+    for i, value in enumerate(permutation):
+        out[value] = i
+    return tuple(out)
+
+
+def permutation_order(permutation: tuple[int, ...]) -> int:
+    seen = [False] * len(permutation)
+    result = 1
+    for i in range(len(permutation)):
+        if seen[i]:
+            continue
+        j, length = i, 0
+        while not seen[j]:
+            seen[j] = True
+            j = permutation[j]
+            length += 1
+        result = math.lcm(result, length)
+    return result
+
+
+def enumerate_group(generators: tuple[tuple[int, ...], ...], outer_index: int | None = None):
+    identity = tuple(range(len(generators[0])))
+    elements = [identity]
+    index = {identity: 0}
+    parity = [0]
+    queue = deque([0])
+    while queue:
+        i = queue.popleft()
+        x = elements[i]
+        for generator_index, generator in enumerate(generators):
+            y = compose(generator, x)
+            py = parity[i] ^ int(outer_index is not None and generator_index == outer_index)
+            if y not in index:
+                index[y] = len(elements)
+                elements.append(y)
+                parity.append(py)
+                queue.append(len(elements) - 1)
+            elif outer_index is not None:
+                assert parity[index[y]] == py
+    return tuple(elements), index, tuple(parity)
+
+
+def generated_order(generators: tuple[tuple[int, ...], ...]) -> int:
+    return len(enumerate_group(generators)[0])
+
+
+def conjugacy_classes(group, index, generators):
+    conjugation_maps = []
+    for generator in generators:
+        gi = inverse(generator)
+        conjugation_maps.append([
+            index[compose(gi, compose(element, generator))]
+            for element in group
+        ])
+    unseen = set(range(len(group)))
+    classes = []
+    class_of = [0] * len(group)
+    while unseen:
+        seed = min(unseen)
+        orbit = {seed}
+        queue = deque([seed])
+        while queue:
+            x = queue.popleft()
+            for mapping in conjugation_maps:
+                y = mapping[x]
+                if y not in orbit:
+                    orbit.add(y)
+                    queue.append(y)
+        unseen -= orbit
+        class_index = len(classes)
+        for x in orbit:
+            class_of[x] = class_index
+        classes.append(tuple(sorted(orbit)))
+    return tuple(classes), tuple(class_of)
+
+
+def permutation_power(permutation: tuple[int, ...], exponent: int) -> tuple[int, ...]:
+    result = tuple(range(len(permutation)))
+    base = permutation
+    while exponent:
+        if exponent & 1:
+            result = compose(result, base)
+        base = compose(base, base)
+        exponent //= 2
+    return result
+
+
+def evaluate_word(expression: str, c: tuple[int, ...], d: tuple[int, ...]) -> tuple[int, ...]:
+    if expression.startswith("("):
+        word, exponent = expression[1:].split(")^")
+        exponent = int(exponent)
+    else:
+        word, exponent = expression, 1
+    result = tuple(range(len(c)))
+    for letter in word:
+        result = compose(result, c if letter == "c" else d)
+    return permutation_power(result, exponent)
+
+
+def point_model():
+    points = sorted({canon(tuple(x)) for x in product(range(Q), repeat=4) if any(x)})
+    point_index = {point: i for i, point in enumerate(points)}
+    vectors = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1), (1, 1, 0, 0)]
+    psp_generators = []
+    for vector in vectors:
+        permutation = []
+        for point in points:
+            scalar = symp(point, vector)
+            image = tuple((point[i] + scalar * vector[i]) % Q for i in range(4))
+            permutation.append(point_index[canon(image)])
+        psp_generators.append(tuple(permutation))
+    outer = tuple(point_index[canon((p[0], p[1], 2 * p[2], 2 * p[3]))] for p in points)
+    return points, tuple(psp_generators), outer
+
+
+def atlas_representatives(group, group_index, parity, classes, class_of):
+    c_class = next(
+        i for i, cls in enumerate(classes)
+        if permutation_order(group[cls[0]]) == 2
+        and GROUP_ORDER // len(cls) == 1440
+        and parity[cls[0]] == 1
+    )
+    d_class = next(
+        i for i, cls in enumerate(classes)
+        if permutation_order(group[cls[0]]) == 9
+        and GROUP_ORDER // len(cls) == 9
+        and parity[cls[0]] == 0
+    )
+    c = group[classes[c_class][0]]
+    d = None
+    for candidate_index in classes[d_class]:
+        candidate = group[candidate_index]
+        if permutation_order(compose(c, candidate)) == 10 and generated_order((c, candidate)) == GROUP_ORDER:
+            d = candidate
+            break
+    assert d is not None
+
+    representatives = []
+    for name, word, expected_order, expected_centralizer in ATLAS:
+        element = evaluate_word(word, c, d)
+        cls = classes[class_of[group_index[element]]]
+        assert permutation_order(element) == expected_order
+        assert GROUP_ORDER // len(cls) == expected_centralizer
+        representatives.append(element)
+    return tuple(representatives)
+
+
+def character_decomposition(character: list[int]) -> list[dict[str, int | str]]:
+    answer = []
+    for degree, irreducible, _, name in IRR:
+        multiplicity = sum(
+            int(size) * int(value) * int(chi)
+            for size, value, chi in zip(CLASS_SIZES, character, irreducible)
+        ) // GROUP_ORDER
+        if multiplicity:
+            answer.append({"irrep": name, "degree": degree, "multiplicity": multiplicity})
+    assert sum(item["degree"] * item["multiplicity"] for item in answer) == character[0]
+    return answer
+
+
+def poly_multiply(left: list[int], right: list[int]) -> list[int]:
+    out = [0] * (len(left) + len(right) - 1)
+    for i, a in enumerate(left):
+        for j, b in enumerate(right):
+            out[i + j] += a * b
+    return out
+
+
+def polynomial_value(coefficients: list[int], x: int) -> int:
+    return sum(value * x**i for i, value in enumerate(coefficients))
+
+
+def main() -> dict:
+    points, psp_generators, outer = point_model()
+    generators = psp_generators + (outer,)
+    group, group_index, parity = enumerate_group(generators, outer_index=len(generators) - 1)
+    assert len(group) == GROUP_ORDER
+    assert Counter(parity) == Counter({0: 25920, 1: 25920})
+    classes, class_of = conjugacy_classes(group, group_index, generators)
+    assert len(classes) == 25
+    representatives = atlas_representatives(group, group_index, parity, classes, class_of)
+
+    adjacency = np.zeros((40, 40), dtype=np.int64)
+    for i, x in enumerate(points):
+        for j, y in enumerate(points):
+            adjacency[i, j] = int(i != j and symp(x, y) == 0)
+    assert np.all(adjacency.sum(axis=1) == 12)
+    edges = [(i, j) for i in range(40) for j in range(i + 1, 40) if adjacency[i, j]]
+    directed_edges = [(i, j) for i, j in edges for i, j in ((i, j), (j, i))]
+    directed_index = {edge: i for i, edge in enumerate(directed_edges)}
+    assert len(edges) == 240 and len(directed_edges) == 480
+
+    vertex_character = []
+    edge_character = []
+    directed_character = []
+    for representative in representatives:
+        vertex_character.append(sum(representative[i] == i for i in range(40)))
+        edge_character.append(sum(tuple(sorted((representative[i], representative[j]))) == (i, j) for i, j in edges))
+        directed_character.append(sum(representative[i] == i and representative[j] == j for i, j in directed_edges))
+
+    hashimoto = np.zeros((480, 480), dtype=np.int64)
+    for row, (i, j) in enumerate(directed_edges):
+        for k in range(40):
+            if k != i and adjacency[j, k]:
+                hashimoto[row, directed_index[(j, k)]] = 1
+    assert np.all(hashimoto.sum(axis=1) == 11)
+
+    plus_numerator = [1]
+    for factor in ([1, 1], [-11, 1], [11, -2, 1], [11, 4, 1]):
+        plus_numerator = poly_multiply(plus_numerator, list(factor))
+    plus_denominator = polynomial_value(plus_numerator, 1)
+    assert plus_numerator == [-1331, -1452, -253, -140, -17, -8, 1]
+    assert plus_denominator == -3200
+
+    minus_numerator = [1]
+    for factor in ([-1, 1], [-11, 1], [11, -2, 1], [11, 4, 1]):
+        minus_numerator = poly_multiply(minus_numerator, list(factor))
+    minus_denominator = polynomial_value(minus_numerator, -1)
+    assert minus_numerator == [1331, -1210, 11, -124, 1, -10, 1]
+    assert minus_denominator == 2688
+
+    powers = [np.eye(480, dtype=np.int64)]
+    for _ in range(1, 7):
+        powers.append(powers[-1] @ hashimoto)
+
+    plus_character = []
+    minus_character = []
+    for representative in representatives:
+        directed_action = tuple(directed_index[(representative[i], representative[j])] for i, j in directed_edges)
+        twisted_traces = [
+            sum(int(matrix[directed_action[i], i]) for i in range(480))
+            for matrix in powers
+        ]
+        plus_n = sum(a * b for a, b in zip(plus_numerator, twisted_traces))
+        minus_n = sum(a * b for a, b in zip(minus_numerator, twisted_traces))
+        assert plus_n % plus_denominator == 0
+        assert minus_n % minus_denominator == 0
+        plus_character.append(plus_n // plus_denominator)
+        minus_character.append(minus_n // minus_denominator)
+
+    vertex_decomposition = character_decomposition(vertex_character)
+    edge_decomposition = character_decomposition(edge_character)
+    directed_decomposition = character_decomposition(directed_character)
+    plus_decomposition = character_decomposition(plus_character)
+    minus_decomposition = character_decomposition(minus_character)
+
+    assert vertex_decomposition == [
+        {"irrep": "1", "degree": 1, "multiplicity": 1},
+        {"irrep": "15_outer_negative", "degree": 15, "multiplicity": 1},
+        {"irrep": "24", "degree": 24, "multiplicity": 1},
+    ]
+    assert plus_decomposition == [
+        {"irrep": "30_outer_negative", "degree": 30, "multiplicity": 1},
+        {"irrep": "81_plus", "degree": 81, "multiplicity": 1},
+        {"irrep": "90", "degree": 90, "multiplicity": 1},
+    ]
+    assert minus_decomposition == [
+        {"irrep": "15a", "degree": 15, "multiplicity": 1},
+        {"irrep": "20", "degree": 20, "multiplicity": 1},
+        {"irrep": "24", "degree": 24, "multiplicity": 1},
+        {"irrep": "60a", "degree": 60, "multiplicity": 1},
+        {"irrep": "81_plus", "degree": 81, "multiplicity": 1},
+    ]
+
+    spectral_packets = {
+        "x_minus_11": {"dimension": 1, "module": "1", "eigenvalue": 11},
+        "x_minus_1": {"dimension": 201, "module": "30_outer_negative + 81_plus + 90", "decomposition": plus_decomposition},
+        "x_plus_1": {"dimension": 200, "module": "15a + 20 + 24 + 60a + 81_plus", "decomposition": minus_decomposition},
+        "x2_minus_2x_plus_11": {"dimension": 48, "module": "2*24", "reason": "two Hashimoto lifts of the adjacency lambda=2 constituent"},
+        "x2_plus_4x_plus_11": {"dimension": 30, "module": "2*15_outer_negative", "reason": "two Hashimoto lifts of the adjacency lambda=-4 constituent"},
+    }
+    assert sum(packet["dimension"] for packet in spectral_packets.values()) == 480
+
+    result = {
+        "schema": "w33.pass1195.we6_equivariant_hashimoto.v1",
+        "status": "PASS",
+        "headline": "The 480-dimensional directed-edge Hashimoto module splits exactly into five W(E6)-equivariant spectral packets.",
+        "group": {"name": "W(E6)=PSp(4,3):2", "order": GROUP_ORDER, "classes": len(classes)},
+        "atlas_class_order": [row[0] for row in ATLAS],
+        "characters": {
+            "vertices40": vertex_character,
+            "edges240": edge_character,
+            "directed_edges480": directed_character,
+            "hashimoto_plus1": plus_character,
+            "hashimoto_minus1": minus_character,
+        },
+        "module_decompositions": {
+            "vertices40": vertex_decomposition,
+            "edges240": edge_decomposition,
+            "directed_edges480": directed_decomposition,
+        },
+        "projector_polynomials": {
+            "plus1": {"numerator_coefficients_ascending": plus_numerator, "denominator": plus_denominator},
+            "minus1": {"numerator_coefficients_ascending": minus_numerator, "denominator": minus_denominator},
+        },
+        "spectral_packets": spectral_packets,
+        "factorization": "(x-11)(x-1)^201(x+1)^200(x^2-2x+11)^24(x^2+4x+11)^15",
+        "checks": {
+            "we6_order_51840": len(group) == GROUP_ORDER,
+            "directed_edge_dimension_480": directed_character[0] == 480,
+            "plus_rank_201": plus_character[0] == 201,
+            "minus_rank_200": minus_character[0] == 200,
+            "packet_dimensions_sum_480": sum(packet["dimension"] for packet in spectral_packets.values()) == 480,
+            "nonbacktracking_outdegree_11": int(hashimoto[0].sum()) == 11,
+        },
+        "scope": "Exact finite permutation characters and exact polynomial spectral projectors. This is an equivariant spectral classification; literal primitive-cycle orbit enumeration is handled separately in Pass 1196.",
+    }
+    assert all(result["checks"].values())
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print("PASS 1195 W(E6)-equivariant Hashimoto packets: 1|201|200|48|30")
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/w33_pass1196_primitive_cycle_orbits.py
+++ b/analysis/w33_pass1196_primitive_cycle_orbits.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Pass 1196: literal PSp/W(E6) primitive-cycle orbits through length six,
+plus the exact equivariant Hashimoto continuation through degree forty.
+"""
+from __future__ import annotations
+
+from collections import Counter, deque
+import json
+from pathlib import Path
+
+from w33_pass1195_we6_equivariant_hashimoto import point_model, symp
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "data" / "w33_pass1196_primitive_cycle_orbits.json"
+MAX_LITERAL_LENGTH = 6
+MAX_SPECTRAL_LENGTH = 40
+
+
+def canonical_rotation(cycle: tuple[int, ...]) -> tuple[int, ...]:
+    return min(cycle[i:] + cycle[:i] for i in range(len(cycle)))
+
+
+def least_period(cycle: tuple[int, ...]) -> int:
+    n = len(cycle)
+    for divisor in range(1, n):
+        if n % divisor == 0 and all(cycle[i] == cycle[i % divisor] for i in range(n)):
+            return divisor
+    return n
+
+
+def enumerate_primitive_cycles(neighbors: tuple[tuple[int, ...], ...], length: int) -> set[tuple[int, ...]]:
+    cycles: set[tuple[int, ...]] = set()
+    for first in range(len(neighbors)):
+        for second in neighbors[first]:
+            path = [first, second]
+
+            def extend() -> None:
+                if len(path) == length:
+                    if (
+                        path[0] in neighbors[path[-1]]
+                        and path[0] != path[-2]
+                        and path[1] != path[-1]
+                    ):
+                        cycle = tuple(path)
+                        if least_period(cycle) == length:
+                            cycles.add(canonical_rotation(cycle))
+                    return
+                previous, current = path[-2], path[-1]
+                for nxt in neighbors[current]:
+                    if nxt != previous:
+                        path.append(nxt)
+                        extend()
+                        path.pop()
+
+            extend()
+    return cycles
+
+
+def orbit_partition(cycles: set[tuple[int, ...]], generators: tuple[tuple[int, ...], ...]):
+    remaining = set(cycles)
+    orbits = []
+    while remaining:
+        seed = min(remaining)
+        orbit = {seed}
+        queue = deque([seed])
+        while queue:
+            cycle = queue.popleft()
+            for generator in generators:
+                image = canonical_rotation(tuple(generator[x] for x in cycle))
+                assert image in remaining or image in orbit
+                if image not in orbit:
+                    orbit.add(image)
+                    queue.append(image)
+        remaining -= orbit
+        orbits.append(orbit)
+    return sorted(orbits, key=lambda orbit: (len(orbit), min(orbit)))
+
+
+def divisors(n: int) -> list[int]:
+    return [d for d in range(1, n + 1) if n % d == 0]
+
+
+def mobius(n: int) -> int:
+    if n == 1:
+        return 1
+    remaining = n
+    prime_count = 0
+    divisor = 2
+    while divisor * divisor <= remaining:
+        if remaining % divisor == 0:
+            remaining //= divisor
+            prime_count += 1
+            if remaining % divisor == 0:
+                return 0
+            while remaining % divisor == 0:
+                remaining //= divisor
+        divisor += 1
+    if remaining > 1:
+        prime_count += 1
+    return -1 if prime_count % 2 else 1
+
+
+def quadratic_trace(parameter: int, maximum: int) -> list[int]:
+    values = [0] * (maximum + 1)
+    values[0] = 2
+    values[1] = parameter
+    for n in range(2, maximum + 1):
+        values[n] = parameter * values[n - 1] - 11 * values[n - 2]
+    return values
+
+
+def spectral_traces(maximum: int):
+    q2 = quadratic_trace(2, maximum)
+    qm4 = quadratic_trace(-4, maximum)
+    packets = {
+        "x_minus_11__module_1": [0] + [11**n for n in range(1, maximum + 1)],
+        "x_minus_1__module_30n_plus_81_plus_90": [0] + [201 for _ in range(maximum)],
+        "x_plus_1__module_15a_plus_20_plus_24_plus_60a_plus_81": [0] + [200 * (-1) ** n for n in range(1, maximum + 1)],
+        "x2_minus_2x_plus_11__module_2x24": [24 * value for value in q2],
+        "x2_plus_4x_plus_11__module_2x15n": [15 * value for value in qm4],
+    }
+    total = [0] * (maximum + 1)
+    for n in range(1, maximum + 1):
+        total[n] = sum(values[n] for values in packets.values())
+    return packets, total
+
+
+def primitive_from_trace(trace: list[int]) -> dict[int, int]:
+    result = {}
+    for n in range(1, len(trace)):
+        numerator = sum(mobius(d) * trace[n // d] for d in divisors(n))
+        assert numerator % n == 0
+        result[n] = numerator // n
+    return result
+
+
+def orbit_records(orbits, group_order: int):
+    records = []
+    for orbit in orbits:
+        representative = min(orbit)
+        records.append({
+            "representative": list(representative),
+            "orbit_size": len(orbit),
+            "stabilizer_order": group_order // len(orbit),
+            "simple_vertex_cycle": len(set(representative)) == len(representative),
+            "vertex_multiplicity_partition": sorted(Counter(representative).values(), reverse=True),
+        })
+    return records
+
+
+def main() -> dict:
+    points, psp_generators, outer = point_model()
+    we6_generators = psp_generators + (outer,)
+    neighbors = tuple(tuple(j for j, y in enumerate(points) if j != i and symp(x, y) == 0) for i, x in enumerate(points))
+    assert {len(row) for row in neighbors} == {12}
+
+    packets, total_trace = spectral_traces(MAX_SPECTRAL_LENGTH)
+    primitive_total = primitive_from_trace(total_trace)
+    packet_primitive = {name: primitive_from_trace(values) for name, values in packets.items()}
+    assert primitive_total[1] == primitive_total[2] == 0
+    assert primitive_total[3] == 320
+    assert primitive_total[4] == 3480
+    assert primitive_total[5] == 36288
+    assert primitive_total[6] == 302880
+
+    literal = {}
+    expected = {3: 320, 4: 3480, 5: 36288, 6: 302880}
+    for length in range(3, MAX_LITERAL_LENGTH + 1):
+        cycles = enumerate_primitive_cycles(neighbors, length)
+        assert len(cycles) == expected[length] == primitive_total[length]
+        psp_orbits = orbit_partition(cycles, psp_generators)
+        we6_orbits = orbit_partition(cycles, we6_generators)
+        literal[str(length)] = {
+            "primitive_oriented_rotation_classes": len(cycles),
+            "PSp(4,3)": {
+                "orbit_count": len(psp_orbits),
+                "orbit_size_distribution": dict(sorted(Counter(map(len, psp_orbits)).items())),
+                "stabilizer_order_distribution": dict(sorted(Counter(25920 // len(orbit) for orbit in psp_orbits).items())),
+                "orbits": orbit_records(psp_orbits, 25920),
+            },
+            "W(E6)": {
+                "orbit_count": len(we6_orbits),
+                "orbit_size_distribution": dict(sorted(Counter(map(len, we6_orbits)).items())),
+                "stabilizer_order_distribution": dict(sorted(Counter(51840 // len(orbit) for orbit in we6_orbits).items())),
+                "orbits": orbit_records(we6_orbits, 51840),
+            },
+        }
+
+    assert literal["3"]["W(E6)"]["orbit_count"] == 1
+    assert literal["4"]["W(E6)"]["orbit_count"] == 2
+    assert literal["5"]["PSp(4,3)"]["orbit_count"] == 3
+    assert literal["5"]["W(E6)"]["orbit_count"] == 2
+    assert literal["6"]["PSp(4,3)"]["orbit_count"] == 18
+    assert literal["6"]["W(E6)"]["orbit_count"] == 13
+
+    result = {
+        "schema": "w33.pass1196.primitive_cycle_orbits.v1",
+        "status": "PASS",
+        "headline": "Primitive reduced cycles are classified literally under PSp(4,3) and W(E6) through length six, with an exact equivariant spectral continuation through length forty.",
+        "literal_orbit_frontier": {
+            "maximum_length": MAX_LITERAL_LENGTH,
+            "data": literal,
+        },
+        "degree40_continuation": {
+            "maximum_length": MAX_SPECTRAL_LENGTH,
+            "primitive_total": {str(n): primitive_total[n] for n in range(1, MAX_SPECTRAL_LENGTH + 1)},
+            "packet_mobius_contributions": {
+                name: {str(n): values[n] for n in range(1, MAX_SPECTRAL_LENGTH + 1)}
+                for name, values in packet_primitive.items()
+            },
+            "trace_identity": "Tr(B^n)=11^n+201+200(-1)^n+24*s_n(2)+15*s_n(-4)",
+            "quadratic_recurrence": "s_0=2, s_1=lambda, s_n=lambda*s_{n-1}-11*s_{n-2}",
+        },
+        "notable_mergers": {
+            "length5": "Three PSp(4,3) orbits of sizes 5184,5184,25920 fuse to two W(E6) orbits of sizes 10368,25920.",
+            "length6": "Eighteen PSp(4,3) orbits fuse to thirteen W(E6) orbits.",
+        },
+        "checks": {
+            "literal_counts_match_ihara": all(literal[str(n)]["primitive_oriented_rotation_classes"] == primitive_total[n] for n in range(3, 7)),
+            "triangle_transitive_we6": literal["3"]["W(E6)"]["orbit_count"] == 1,
+            "length6_orbit_counts": literal["6"]["PSp(4,3)"]["orbit_count"] == 18 and literal["6"]["W(E6)"]["orbit_count"] == 13,
+            "degree40_integral_nonnegative_totals": all(isinstance(primitive_total[n], int) and primitive_total[n] >= 0 for n in range(1, 41)),
+        },
+        "boundary": "Literal orbit enumeration is completed through length six. Lengths seven through forty are certified by exact W(E6)-equivariant Hashimoto spectral packets and Möbius inversion, but are not mislabeled as literal group-orbit partitions.",
+    }
+    assert all(result["checks"].values())
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print("PASS 1196 primitive cycle orbits: W(E6) counts 1,2,2,13 for lengths 3..6")
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/w33_pass1197_parallel_collision_guard.py
+++ b/analysis/w33_pass1197_parallel_collision_guard.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Pass 1197: fail-closed namespace and parallel-release collision guard."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "data" / "w33_pass1197_parallel_collision_guard.json"
+REGISTRY = ROOT / "data" / "w33_pass_namespace_registry_v2.json"
+CURRENT_RANGE = range(1193, 1198)
+CURRENT_RESULTS = [ROOT / "data" / f"w33_pass{number}_" for number in CURRENT_RANGE]
+FORBIDDEN_TRANSPORT = [
+    ROOT / ".correction",
+    ROOT / "PASS1192_MATERIALIZE.trigger",
+    ROOT / ".github" / "workflows" / "pass1192_materialize_pr.yml",
+]
+
+
+def parse_range(value: str) -> set[int]:
+    if "-" not in value:
+        return {int(value)}
+    start, end = map(int, value.split("-", 1))
+    assert start <= end
+    return set(range(start, end + 1))
+
+
+def load_result_for_pass(number: int) -> tuple[Path, dict]:
+    candidates = sorted((ROOT / "data").glob(f"w33_pass{number}_*.json"))
+    if len(candidates) != 1:
+        raise AssertionError(f"Pass {number} must have exactly one canonical data certificate; found {candidates}")
+    return candidates[0], json.loads(candidates[0].read_text(encoding="utf-8"))
+
+
+def main() -> dict:
+    registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    seen: dict[int, dict] = {}
+    collisions = []
+    for block in registry["canonical_blocks"]:
+        for number in parse_range(block["range"]):
+            if number in seen:
+                collisions.append({"pass": number, "owners": [seen[number]["owner"], block["owner"]]})
+            seen[number] = block
+    assert not collisions, collisions
+
+    current_block = next(block for block in registry["canonical_blocks"] if parse_range(block["range"]) == set(CURRENT_RANGE))
+    assert current_block["status"] == "COMPLETE"
+    assert set(map(int, current_block["artifacts"])) == set(CURRENT_RANGE)
+
+    unregistered = []
+    pattern = re.compile(r"(?:^|[_-])pass(\d{4})(?:[_-]|\.|$)", re.IGNORECASE)
+    for directory in (ROOT / "analysis", ROOT / "tests", ROOT / "data", ROOT / ".github" / "workflows"):
+        if not directory.exists():
+            continue
+        for path in directory.rglob("*"):
+            if not path.is_file():
+                continue
+            match = pattern.search(path.name)
+            if match:
+                number = int(match.group(1))
+                if number >= 1120 and number not in seen:
+                    unregistered.append(str(path.relative_to(ROOT)))
+    assert not unregistered, unregistered
+
+    certificates = []
+    for number in CURRENT_RANGE:
+        path, data = load_result_for_pass(number)
+        checks = data.get("checks", {})
+        assert data.get("status") == "PASS", (number, data.get("status"))
+        assert checks and all(checks.values()), (number, checks)
+        certificates.append({
+            "pass": number,
+            "path": str(path.relative_to(ROOT)),
+            "schema": data.get("schema"),
+            "checks": len(checks),
+        })
+
+    precommit = (ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    workflow_path = ROOT / ".github" / "workflows" / "pass1193_1197_exact_release.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    gate_checks = {
+        "precommit_namespace_guard_installed": "pass-namespace-collision-guard" in precommit,
+        "workflow_runs_pass1197_guard": "w33_pass1197_parallel_collision_guard.py --check-only" in workflow,
+        "workflow_runs_pass1192_guard": "w33_pass1192_parallel_synthesis_guard.py" in workflow,
+        "transport_scaffold_absent": all(not path.exists() for path in FORBIDDEN_TRANSPORT),
+        "current_block_complete": current_block["status"] == "COMPLETE",
+        "current_artifacts_complete": set(map(int, current_block["artifacts"])) == set(CURRENT_RANGE),
+    }
+    assert all(gate_checks.values()), gate_checks
+
+    result = {
+        "schema": "w33.pass1197.parallel_collision_guard.v1",
+        "status": "PASS",
+        "headline": "Pass-number ownership, exact certificates, legacy synthesis, and transport cleanup are enforced as mandatory parallel-development gates.",
+        "registry": {
+            "schema": registry["schema"],
+            "registered_pass_count": len(seen),
+            "minimum_registered": min(seen),
+            "maximum_registered": max(seen),
+            "collisions": collisions,
+            "unregistered_modern_files": unregistered,
+        },
+        "current_block": current_block,
+        "certificates": certificates,
+        "gate_checks": gate_checks,
+        "checks": {
+            "registry_has_no_overlap": not collisions,
+            "registered_pass_count_74": len(seen) == 74,
+            "no_unregistered_modern_files": not unregistered,
+            "passes_1193_1197_all_pass": len(certificates) == 5,
+            "mandatory_gates_installed": all(gate_checks.values()),
+        },
+        "policy": "Parallel agents must reserve a disjoint range before publication; the range, artifacts, exact certificates, synthesis guard, and cleanup gate must all agree before merge.",
+    }
+    assert all(result["checks"].values())
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print("PASS 1197 namespace/certificate/synthesis gates clean")
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check-only", action="store_true", help="Retained for pre-commit/CI compatibility; the guard is always fail closed.")
+    parser.parse_args()
+    main()

--- a/data/w33_pass1193_s5_a5_coset_bridge.json
+++ b/data/w33_pass1193_s5_a5_coset_bridge.json
@@ -1,0 +1,104 @@
+{
+  "schema": "w33.pass1193.s5_a5_coset_bridge.v1",
+  "status": "PASS",
+  "headline": "Each 432-point W(E6)/S5 carrier restricts transitively to PSp(4,3)/A5, with S5 intersect PSp(4,3)=A5.",
+  "orders": {
+    "W(E6)": 51840,
+    "PSp(4,3)": 25920,
+    "S5": 120,
+    "A5": 60
+  },
+  "normal_subgroup": {
+    "definition": "kernel of reflection-length parity",
+    "order": 25920,
+    "identification": "PSp(4,3)"
+  },
+  "records": [
+    {
+      "orbit_number": 0,
+      "orbit_size": 432,
+      "representative_a2_triple": [0, 18, 43],
+      "we6_stabilizer": {
+        "order": 120,
+        "identification": "S5 = SmallGroup(120,34)",
+        "even_elements": 60,
+        "odd_elements": 60
+      },
+      "psp43_intersection": {
+        "order": 60,
+        "center_order": 1,
+        "derived_order": 60,
+        "abelianization_order": 1,
+        "element_order_distribution": {"1": 1, "2": 15, "3": 20, "5": 24},
+        "identification": "A5 = SmallGroup(60,5)"
+      },
+      "coset_models": {
+        "we6_over_s5_index": 432,
+        "psp43_over_a5_index": 432,
+        "same_432_carrier": true
+      }
+    },
+    {
+      "orbit_number": 1,
+      "orbit_size": 432,
+      "representative_a2_triple": [0, 22, 47],
+      "we6_stabilizer": {
+        "order": 120,
+        "identification": "S5 = SmallGroup(120,34)",
+        "even_elements": 60,
+        "odd_elements": 60
+      },
+      "psp43_intersection": {
+        "order": 60,
+        "center_order": 1,
+        "derived_order": 60,
+        "abelianization_order": 1,
+        "element_order_distribution": {"1": 1, "2": 15, "3": 20, "5": 24},
+        "identification": "A5 = SmallGroup(60,5)"
+      },
+      "coset_models": {
+        "we6_over_s5_index": 432,
+        "psp43_over_a5_index": 432,
+        "same_432_carrier": true
+      }
+    },
+    {
+      "orbit_number": 2,
+      "orbit_size": 432,
+      "representative_a2_triple": [0, 26, 51],
+      "we6_stabilizer": {
+        "order": 120,
+        "identification": "S5 = SmallGroup(120,34)",
+        "even_elements": 60,
+        "odd_elements": 60
+      },
+      "psp43_intersection": {
+        "order": 60,
+        "center_order": 1,
+        "derived_order": 60,
+        "abelianization_order": 1,
+        "element_order_distribution": {"1": 1, "2": 15, "3": 20, "5": 24},
+        "identification": "A5 = SmallGroup(60,5)"
+      },
+      "coset_models": {
+        "we6_over_s5_index": 432,
+        "psp43_over_a5_index": 432,
+        "same_432_carrier": true
+      }
+    }
+  ],
+  "theorem": {
+    "intersection": "S5 ∩ PSp(4,3) = A5",
+    "coset_equivalence": "W(E6)/S5 ≅ PSp(4,3)/A5 as PSp(4,3)-sets",
+    "index_identity": "51840/120 = 25920/60 = 432",
+    "three_copies": 3
+  },
+  "checks": {
+    "we6_order_51840": true,
+    "parity_kernel_order_25920": true,
+    "three_432_orbits": true,
+    "all_intersections_a5": true,
+    "all_indices_432": true
+  },
+  "scope": "Exact finite permutation computation on the 240 E8 roots; the A5 identification uses order, perfectness, trivial center, and the A5 element-order census."
+}

--- a/data/w33_pass1194_residual_central_idempotents.json
+++ b/data/w33_pass1194_residual_central_idempotents.json
@@ -1,0 +1,129 @@
+{
+  "schema": "w33.pass1194.residual_central_idempotents.v1",
+  "status": "PASS",
+  "headline": "The 1952 residual has ten explicit rational central idempotents and commutant algebra of dimension 1109.",
+  "atlas_class_order": ["1A", "2A", "2B", "3A", "3C", "3D", "4A", "4B", "5A", "6A", "6C", "6E", "6F", "9A", "12A", "2C", "2D", "4C", "4D", "6G", "6H", "6I", "8A", "10A", "12C"],
+  "residual_dimension": 1952,
+  "center_dimension": 10,
+  "commutant_dimension": 1109,
+  "wedderburn_commutant": "M_13(Q) ⊕ M_16(Q) ⊕ M_5(Q) ⊕ M_4(Q) ⊕ M_21(Q) ⊕ M_2(Q) ⊕ M_9(Q) ⊕ M_4(Q) ⊕ M_10(Q) ⊕ M_1(Q)",
+  "projectors": [
+    {
+      "irrep": "1",
+      "degree": 1,
+      "multiplicity": 13,
+      "residual_rank": 13,
+      "commutant_block": "M_13(Q)",
+      "central_idempotent_formula": "e_1 = (1/51840) * sum_C chi_1(C) K_C",
+      "class_sum_coefficients": {"1A": "1/51840", "2A": "1/51840", "2B": "1/51840", "3A": "1/51840", "3C": "1/51840", "3D": "1/51840", "4A": "1/51840", "4B": "1/51840", "5A": "1/51840", "6A": "1/51840", "6C": "1/51840", "6E": "1/51840", "6F": "1/51840", "9A": "1/51840", "12A": "1/51840", "2C": "1/51840", "2D": "1/51840", "4C": "1/51840", "4D": "1/51840", "6G": "1/51840", "6H": "1/51840", "6I": "1/51840", "8A": "1/51840", "10A": "1/51840", "12C": "1/51840"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "sha256": "a87036047d7df5c2137979cefb1cbfa13effe1be3396485fe78dc7ec233a405d"}
+    },
+    {
+      "irrep": "6",
+      "degree": 6,
+      "multiplicity": 16,
+      "residual_rank": 96,
+      "commutant_block": "M_16(Q)",
+      "central_idempotent_formula": "e_6 = (6/51840) * sum_C chi_6(C) K_C",
+      "class_sum_coefficients": {"1A": "1/1440", "2A": "-1/4320", "2B": "1/4320", "3A": "-1/2880", "3C": "1/2880", "4A": "1/4320", "5A": "1/8640", "6A": "1/8640", "6C": "1/8640", "6E": "-1/4320", "6F": "-1/8640", "12A": "-1/8640", "2C": "1/2160", "4C": "-1/4320", "4D": "1/4320", "6G": "1/8640", "6H": "-1/4320", "10A": "-1/8640", "12C": "1/8640"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [36, -12, 12, -18, 18, 0, 12, 0, 6, 6, 6, -12, -6, 0, -6, 24, 0, -12, 12, 6, -12, 0, 0, -6, 6], "sha256": "9a7d8bc4c13d91132d8ebefcf8c14a5b28dfc8c745ff99a6bb31e9a43572732d"}
+    },
+    {
+      "irrep": "15",
+      "degree": 15,
+      "multiplicity": 5,
+      "residual_rank": 75,
+      "commutant_block": "M_5(Q)",
+      "central_idempotent_formula": "e_15 = (15/51840) * sum_C chi_15(C) K_C",
+      "class_sum_coefficients": {"1A": "5/1152", "2A": "-1/3456", "2B": "-1/3456", "3A": "1/576", "3C": "1/1152", "4A": "1/1152", "4B": "-1/3456", "6A": "1/1728", "6C": "-1/3456", "6E": "1/1728", "6F": "-1/3456", "2C": "5/3456", "2D": "-1/1152", "4C": "1/3456", "4D": "1/3456", "6G": "-1/3456", "6H": "1/1728", "8A": "-1/3456", "12C": "1/3456"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [225, -15, -15, 90, 45, 0, 45, -15, 0, 30, -15, 30, -15, 0, 0, 75, -45, 15, 15, -15, 30, 0, -15, 0, 15], "sha256": "71cce00fa9f0d923b03a074641934d50d3a30f9f8b94bbad1270d672109cddbc"}
+    },
+    {
+      "irrep": "15a",
+      "degree": 15,
+      "multiplicity": 4,
+      "residual_rank": 60,
+      "commutant_block": "M_4(Q)",
+      "central_idempotent_formula": "e_15a = (15/51840) * sum_C chi_15a(C) K_C",
+      "class_sum_coefficients": {"1A": "5/1152", "2A": "7/3456", "2B": "1/1152", "3A": "-1/1152", "3D": "1/1152", "4A": "-1/3456", "4B": "1/3456", "6A": "1/3456", "6C": "-1/1728", "6E": "1/3456", "12A": "-1/3456", "2C": "5/3456", "2D": "1/3456", "4C": "1/1152", "4D": "-1/3456", "6G": "1/1728", "6H": "-1/3456", "6I": "1/3456", "8A": "-1/3456"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [225, 105, 45, -45, 0, 45, -15, 15, 0, 15, -30, 15, 0, 0, -15, 75, 15, 45, -15, 30, -15, 15, -15, 0, 0], "sha256": "d48a0523e71492af897e3d9285671174599e2b509891db8773c3028fec42e6f3"}
+    },
+    {
+      "irrep": "20",
+      "degree": 20,
+      "multiplicity": 21,
+      "residual_rank": 420,
+      "commutant_block": "M_21(Q)",
+      "central_idempotent_formula": "e_20 = (20/51840) * sum_C chi_20(C) K_C",
+      "class_sum_coefficients": {"1A": "5/648", "2A": "1/648", "2B": "1/648", "3A": "1/1296", "3C": "5/2592", "3D": "-1/2592", "6A": "-1/1296", "6C": "1/2592", "6E": "1/2592", "6F": "1/2592", "9A": "-1/2592", "2C": "5/1296", "2D": "1/1296", "4C": "1/1296", "4D": "1/1296", "6G": "1/2592", "6H": "1/2592", "6I": "-1/2592", "12C": "-1/2592"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [400, 80, 80, 40, 100, -20, 0, 0, 0, -40, 20, 20, 20, -20, 0, 200, 40, 40, 40, 20, 20, -20, 0, 0, -20], "sha256": "3fa6c937b7c08ac3419cb9eddedab377aa58a813dd028d4a5734fc1d4c1793d0"}
+    },
+    {
+      "irrep": "24",
+      "degree": 24,
+      "multiplicity": 2,
+      "residual_rank": 48,
+      "commutant_block": "M_2(Q)",
+      "central_idempotent_formula": "e_24 = (24/51840) * sum_C chi_24(C) K_C",
+      "class_sum_coefficients": {"1A": "1/90", "2A": "1/270", "3A": "1/360", "3D": "1/720", "5A": "-1/2160", "6A": "1/1080", "6C": "1/1080", "6E": "-1/2160", "2C": "1/540", "2D": "1/540", "6G": "-1/1080", "6H": "1/2160", "6I": "1/2160", "10A": "-1/2160"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [576, 192, 0, 144, 0, 72, 0, 0, -24, 48, 48, -24, 0, 0, 0, 96, 96, 0, 0, -48, 24, 24, 0, -24, 0], "sha256": "d8e246ee4271bcb17b8b7ca9c478926070481df71defb4b4e25bec287b9948c6"}
+    },
+    {
+      "irrep": "30",
+      "degree": 30,
+      "multiplicity": 9,
+      "residual_rank": 270,
+      "commutant_block": "M_9(Q)",
+      "central_idempotent_formula": "e_30 = (30/51840) * sum_C chi_30(C) K_C",
+      "class_sum_coefficients": {"1A": "5/288", "2A": "-5/864", "2B": "1/864", "3A": "1/576", "3C": "1/576", "3D": "1/576", "4A": "-1/864", "6A": "-1/1728", "6C": "-1/1728", "6E": "-1/1728", "6F": "-1/1728", "12A": "1/1728", "2C": "5/864", "2D": "-1/864", "4C": "-1/432", "6G": "1/1728", "6H": "1/1728", "6I": "1/1728", "12C": "-1/1728"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [900, -300, 60, 90, 90, 90, -60, 0, 0, -30, -30, -30, -30, 0, 30, 300, -60, -120, 0, 30, 30, 30, 0, 0, -30], "sha256": "5fd828bc4f9bdad8484430d3d4ddd55c839101c9069c63b6e799343deec8f846"}
+    },
+    {
+      "irrep": "60a",
+      "degree": 60,
+      "multiplicity": 4,
+      "residual_rank": 240,
+      "commutant_block": "M_4(Q)",
+      "central_idempotent_formula": "e_60a = (60/51840) * sum_C chi_60a(C) K_C",
+      "class_sum_coefficients": {"1A": "5/72", "2A": "-1/216", "2B": "1/216", "3A": "1/144", "3C": "-1/288", "3D": "-1/288", "6A": "1/432", "6C": "-1/864", "6E": "-1/864", "6F": "1/864", "2C": "5/432", "2D": "1/432", "4C": "-1/432", "4D": "-1/432", "6G": "1/864", "6H": "1/864", "6I": "-1/864", "12C": "1/864"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [3600, -240, 240, 360, -180, -180, 0, 0, 0, 120, -60, -60, 60, 0, 0, 600, 120, -120, -120, 60, 60, -60, 0, 0, 60], "sha256": "a44c084dbdef89a93cb3e0aad4382910a9b4d0a77a9ba3b9b2588ee9175c0c0a"}
+    },
+    {
+      "irrep": "64",
+      "degree": 64,
+      "multiplicity": 10,
+      "residual_rank": 640,
+      "commutant_block": "M_10(Q)",
+      "central_idempotent_formula": "e_64 = (64/51840) * sum_C chi_64(C) K_C",
+      "class_sum_coefficients": {"1A": "32/405", "3A": "-4/405", "3C": "2/405", "3D": "-1/405", "5A": "-1/810", "9A": "1/810", "2C": "8/405", "6G": "-1/405", "6H": "-1/405", "10A": "1/810"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [4096, 0, 0, -512, 256, -128, 0, 0, -64, 0, 0, 0, 0, 64, 0, 1024, 0, 0, 0, -128, -128, 0, 0, 64, 0], "sha256": "ead8d1ab9faea530d8e8878386d760ff7917fe4251949a888c28fee7bfab5f26"}
+    },
+    {
+      "irrep": "90",
+      "degree": 90,
+      "multiplicity": 1,
+      "residual_rank": 90,
+      "commutant_block": "M_1(Q)",
+      "central_idempotent_formula": "e_90 = (90/51840) * sum_C chi_90(C) K_C",
+      "class_sum_coefficients": {"1A": "5/32", "2A": "-1/96", "2B": "-1/96", "3A": "1/64", "4A": "1/288", "4B": "1/288", "6A": "-1/192", "12A": "-1/576"},
+      "denominator_cleared": {"common_denominator": 51840, "numerators_in_atlas_order": [8100, -540, -540, 810, 0, 0, 180, 180, 0, -270, 0, 0, 0, 0, -90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "sha256": "c7b21df29402ea78280a8b3febf5aaa8112ad64ead6531669c03cfd1cc0c4691"}
+    }
+  ],
+  "residual_central_projector": {
+    "formula": "P_res = sum_chi e_chi over the ten residual species",
+    "class_sum_coefficients": {"1A": "6053/17280", "2A": "-9/640", "2B": "-13/5760", "3A": "1/54", "3C": "11/1728", "3D": "-1/432", "4A": "163/51840", "4B": "181/51840", "5A": "-1/640", "6A": "-1/432", "6C": "-1/864", "6E": "-1/864", "6F": "1/1728", "9A": "1/1152", "12A": "-1/648", "2C": "479/10368", "2D": "167/51840", "4C": "-151/51840", "4D": "-67/51840", "6G": "-11/12960", "6H": "1/5184", "6I": "-1/5184", "8A": "-29/51840", "10A": "7/10368", "12C": "1/1620"}
+  },
+  "orthogonality_certificate": [
+    {"pair": ["1", "1"], "inner_product": 1}, {"pair": ["1", "6"], "inner_product": 0}, {"pair": ["1", "15"], "inner_product": 0}, {"pair": ["1", "15a"], "inner_product": 0}, {"pair": ["1", "20"], "inner_product": 0}, {"pair": ["1", "24"], "inner_product": 0}, {"pair": ["1", "30"], "inner_product": 0}, {"pair": ["1", "60a"], "inner_product": 0}, {"pair": ["1", "64"], "inner_product": 0}, {"pair": ["1", "90"], "inner_product": 0},
+    {"pair": ["6", "6"], "inner_product": 1}, {"pair": ["6", "60a"], "inner_product": 0}, {"pair": ["6", "64"], "inner_product": 0}, {"pair": ["6", "90"], "inner_product": 0},
+    {"pair": ["15", "6"], "inner_product": 0}, {"pair": ["15", "15"], "inner_product": 1}, {"pair": ["15", "15a"], "inner_product": 0}, {"pair": ["15", "20"], "inner_product": 0}, {"pair": ["15", "24"], "inner_product": 0}, {"pair": ["15", "30"], "inner_product": 0}, {"pair": ["15", "60a"], "inner_product": 0}, {"pair": ["15", "64"], "inner_product": 0}, {"pair": ["15", "90"], "inner_product": 0},
+    {"pair": ["15a", "6"], "inner_product": 0}, {"pair": ["15a", "15a"], "inner_product": 1}, {"pair": ["15a", "20"], "inner_product": 0}, {"pair": ["15a", "24"], "inner_product": 0}, {"pair": ["15a", "30"], "inner_product": 0}, {"pair": ["15a", "60a"], "inner_product": 0}, {"pair": ["15a", "64"], "inner_product": 0}, {"pair": ["15a", "90"], "inner_product": 0},
+    {"pair": ["20", "6"], "inner_product": 0}, {"pair": ["20", "20"], "inner_product": 1}, {"pair": ["20", "24"], "inner_product": 0}, {"pair": ["20", "30"], "inner_product": 0}, {"pair": ["20", "60a"], "inner_product": 0}, {"pair": ["20", "64"], "inner_product": 0}, {"pair": ["20", "90"], "inner_product": 0},
+    {"pair": ["24", "6"], "inner_product": 0}, {"pair": ["24", "24"], "inner_product": 1}, {"pair": ["24", "30"], "inner_product": 0}, {"pair": ["24", "60a"], "inner_product": 0}, {"pair": ["24", "64"], "inner_product": 0}, {"pair": ["24", "90"], "inner_product": 0},
+    {"pair": ["30", "6"], "inner_product": 0}, {"pair": ["30", "30"], "inner_product": 1}, {"pair": ["30", "60a"], "inner_product": 0}, {"pair": ["30", "64"], "inner_product": 0}, {"pair": ["30", "90"], "inner_product": 0},
+    {"pair": ["60a", "60a"], "inner_product": 1}, {"pair": ["60a", "64"], "inner_product": 0}, {"pair": ["60a", "90"], "inner_product": 0},
+    {"pair": ["64", "64"], "inner_product": 1}, {"pair": ["64", "90"], "inner_product": 0}, {"pair": ["90", "90"], "inner_product": 1}
+  ],
+  "checks": {"ten_isotypic_blocks": true, "residual_rank_1952": true, "commutant_dimension_1109": true, "character_rows_orthonormal": true},
+  "boundary": "These are canonical central/isotypic projectors. Matrix units inside each multiplicity block require a noncanonical choice of copy basis and are intentionally not claimed."
+}

--- a/data/w33_pass1195_we6_equivariant_hashimoto.json
+++ b/data/w33_pass1195_we6_equivariant_hashimoto.json
@@ -1,0 +1,80 @@
+{
+  "schema": "w33.pass1195.we6_equivariant_hashimoto.v1",
+  "status": "PASS",
+  "headline": "The 480-dimensional directed-edge Hashimoto module splits exactly into five W(E6)-equivariant spectral packets.",
+  "group": {"name": "W(E6)=PSp(4,3):2", "order": 51840, "classes": 25},
+  "atlas_class_order": ["1A", "2A", "2B", "3A", "3C", "3D", "4A", "4B", "5A", "6A", "6C", "6E", "6F", "9A", "12A", "2C", "2D", "4C", "4D", "6G", "6H", "6I", "8A", "10A", "12C"],
+  "characters": {
+    "vertices40": [40, 8, 0, 13, 4, 4, 4, 0, 0, 5, 2, 2, 0, 1, 1, 0, 8, 0, 0, 0, 0, 2, 2, 0, 0],
+    "edges240": [240, 32, 8, 24, 6, 6, 0, 0, 0, 8, 2, 2, 2, 0, 0, 20, 20, 0, 0, 2, 2, 2, 0, 0, 0],
+    "directed_edges480": [480, 32, 0, 48, 12, 12, 0, 0, 0, 8, 2, 2, 0, 0, 0, 0, 32, 0, 0, 0, 0, 2, 0, 0, 0],
+    "hashimoto_plus1": [201, -7, -7, 12, 3, 3, -3, 1, 1, -4, -1, -1, -1, 0, 0, -19, 5, 1, 1, -1, -1, -1, -1, 1, 1],
+    "hashimoto_minus1": [200, 24, 8, 11, 2, 2, -4, 0, 0, 3, 0, 0, 2, -1, -1, 20, 12, 0, 0, 2, 2, 0, -2, 0, 0]
+  },
+  "module_decompositions": {
+    "vertices40": [
+      {"irrep": "1", "degree": 1, "multiplicity": 1},
+      {"irrep": "15_outer_negative", "degree": 15, "multiplicity": 1},
+      {"irrep": "24", "degree": 24, "multiplicity": 1}
+    ],
+    "edges240": [
+      {"irrep": "1", "degree": 1, "multiplicity": 1},
+      {"irrep": "15_outer_negative", "degree": 15, "multiplicity": 1},
+      {"irrep": "15a", "degree": 15, "multiplicity": 1},
+      {"irrep": "20", "degree": 20, "multiplicity": 1},
+      {"irrep": "24", "degree": 24, "multiplicity": 2},
+      {"irrep": "60a", "degree": 60, "multiplicity": 1},
+      {"irrep": "81_plus", "degree": 81, "multiplicity": 1}
+    ],
+    "directed_edges480": [
+      {"irrep": "1", "degree": 1, "multiplicity": 1},
+      {"irrep": "15_outer_negative", "degree": 15, "multiplicity": 2},
+      {"irrep": "15a", "degree": 15, "multiplicity": 1},
+      {"irrep": "20", "degree": 20, "multiplicity": 1},
+      {"irrep": "24", "degree": 24, "multiplicity": 3},
+      {"irrep": "30_outer_negative", "degree": 30, "multiplicity": 1},
+      {"irrep": "60a", "degree": 60, "multiplicity": 1},
+      {"irrep": "81_plus", "degree": 81, "multiplicity": 2},
+      {"irrep": "90", "degree": 90, "multiplicity": 1}
+    ]
+  },
+  "projector_polynomials": {
+    "plus1": {"numerator_coefficients_ascending": [-1331, -1452, -253, -140, -17, -8, 1], "denominator": -3200},
+    "minus1": {"numerator_coefficients_ascending": [1331, -1210, 11, -124, 1, -10, 1], "denominator": 2688}
+  },
+  "spectral_packets": {
+    "x_minus_11": {"dimension": 1, "module": "1", "eigenvalue": 11},
+    "x_minus_1": {
+      "dimension": 201,
+      "module": "30_outer_negative + 81_plus + 90",
+      "decomposition": [
+        {"irrep": "30_outer_negative", "degree": 30, "multiplicity": 1},
+        {"irrep": "81_plus", "degree": 81, "multiplicity": 1},
+        {"irrep": "90", "degree": 90, "multiplicity": 1}
+      ]
+    },
+    "x_plus_1": {
+      "dimension": 200,
+      "module": "15a + 20 + 24 + 60a + 81_plus",
+      "decomposition": [
+        {"irrep": "15a", "degree": 15, "multiplicity": 1},
+        {"irrep": "20", "degree": 20, "multiplicity": 1},
+        {"irrep": "24", "degree": 24, "multiplicity": 1},
+        {"irrep": "60a", "degree": 60, "multiplicity": 1},
+        {"irrep": "81_plus", "degree": 81, "multiplicity": 1}
+      ]
+    },
+    "x2_minus_2x_plus_11": {"dimension": 48, "module": "2*24", "reason": "two Hashimoto lifts of the adjacency lambda=2 constituent"},
+    "x2_plus_4x_plus_11": {"dimension": 30, "module": "2*15_outer_negative", "reason": "two Hashimoto lifts of the adjacency lambda=-4 constituent"}
+  },
+  "factorization": "(x-11)(x-1)^201(x+1)^200(x^2-2x+11)^24(x^2+4x+11)^15",
+  "checks": {
+    "we6_order_51840": true,
+    "directed_edge_dimension_480": true,
+    "plus_rank_201": true,
+    "minus_rank_200": true,
+    "packet_dimensions_sum_480": true,
+    "nonbacktracking_outdegree_11": true
+  },
+  "scope": "Exact finite permutation characters and exact polynomial spectral projectors. This is an equivariant spectral classification; literal primitive-cycle orbit enumeration is handled separately in Pass 1196."
+}

--- a/data/w33_pass1196_primitive_cycle_orbits.json
+++ b/data/w33_pass1196_primitive_cycle_orbits.json
@@ -1,0 +1,88 @@
+{
+  "schema": "w33.pass1196.primitive_cycle_orbits.v1",
+  "status": "PASS",
+  "headline": "Primitive reduced cycles are classified literally under PSp(4,3) and W(E6) through length six, with an exact equivariant spectral continuation through length forty.",
+  "literal_orbit_frontier": {
+    "maximum_length": 6,
+    "data": {
+      "3": {
+        "primitive_oriented_rotation_classes": 320,
+        "PSp(4,3)": {"orbit_count": 1, "orbit_size_distribution": {"320": 1}, "stabilizer_order_distribution": {"81": 1}},
+        "W(E6)": {"orbit_count": 1, "orbit_size_distribution": {"320": 1}, "stabilizer_order_distribution": {"162": 1}}
+      },
+      "4": {
+        "primitive_oriented_rotation_classes": 3480,
+        "PSp(4,3)": {"orbit_count": 2, "orbit_size_distribution": {"240": 1, "3240": 1}, "stabilizer_order_distribution": {"8": 1, "108": 1}},
+        "W(E6)": {"orbit_count": 2, "orbit_size_distribution": {"240": 1, "3240": 1}, "stabilizer_order_distribution": {"16": 1, "216": 1}}
+      },
+      "5": {
+        "primitive_oriented_rotation_classes": 36288,
+        "PSp(4,3)": {"orbit_count": 3, "orbit_size_distribution": {"5184": 2, "25920": 1}, "stabilizer_order_distribution": {"1": 1, "5": 2}},
+        "W(E6)": {"orbit_count": 2, "orbit_size_distribution": {"10368": 1, "25920": 1}, "stabilizer_order_distribution": {"2": 1, "5": 1}}
+      },
+      "6": {
+        "primitive_oriented_rotation_classes": 302880,
+        "PSp(4,3)": {"orbit_count": 18, "orbit_size_distribution": {"480": 1, "2160": 2, "4320": 1, "8640": 1, "12960": 4, "25920": 9}, "stabilizer_order_distribution": {"1": 9, "2": 4, "3": 1, "6": 1, "12": 2, "54": 1}},
+        "W(E6)": {"orbit_count": 13, "orbit_size_distribution": {"480": 1, "4320": 2, "8640": 1, "12960": 2, "25920": 4, "51840": 3}, "stabilizer_order_distribution": {"1": 3, "2": 4, "4": 2, "6": 1, "12": 2, "108": 1}}
+      }
+    }
+  },
+  "degree40_continuation": {
+    "maximum_length": 40,
+    "primitive_total": {
+      "1": 0,
+      "2": 0,
+      "3": 320,
+      "4": 3480,
+      "5": 36288,
+      "6": 302880,
+      "7": 2739840,
+      "8": 26750160,
+      "9": 262162880,
+      "10": 2594020512,
+      "11": 25939032000,
+      "12": 261529827680,
+      "13": 2655565604160,
+      "14": 27125053301760,
+      "15": 278483380379008,
+      "16": 2871857983606320,
+      "17": 29732177634512640,
+      "18": 308884288153885920,
+      "19": 3218899502855937600,
+      "20": 33637499842949421504,
+      "21": 352392854412461504640,
+      "22": 3700124971596963007200,
+      "23": 38931749706290017368960,
+      "24": 410405528157682881779360,
+      "25": 4333882377380650565929920,
+      "26": 45839140529742959501084640,
+      "27": 485555340425612376257522240,
+      "28": 5150354860946261910054201120,
+      "29": 54700320592121577714432705600,
+      "30": 581646742296216416557282623552,
+      "31": 6191723385733900538117125593600,
+      "32": 65980552329226649698049149209840,
+      "33": 703792558178418207015695095993600,
+      "34": 7514020547610762280771866874988160,
+      "35": 80292676708754995185681393636412032,
+      "36": 858685570357518683205490617363436640,
+      "37": 9190256374637226991057953531036027840,
+      "38": 98432482749403983829411932618333847200,
+      "39": 1054994302288483725241718682743893676160,
+      "40": 11314813892043987952589222211358740216768
+    },
+    "trace_identity": "Tr(B^n)=11^n+201+200(-1)^n+24*s_n(2)+15*s_n(-4)",
+    "quadratic_recurrence": "s_0=2, s_1=lambda, s_n=lambda*s_{n-1}-11*s_{n-2}"
+  },
+  "notable_mergers": {
+    "length5": "Three PSp(4,3) orbits of sizes 5184,5184,25920 fuse to two W(E6) orbits of sizes 10368,25920.",
+    "length6": "Eighteen PSp(4,3) orbits fuse to thirteen W(E6) orbits."
+  },
+  "checks": {
+    "literal_counts_match_ihara": true,
+    "triangle_transitive_we6": true,
+    "length6_orbit_counts": true,
+    "degree40_integral_nonnegative_totals": true
+  },
+  "boundary": "Literal orbit enumeration is completed through length six. Lengths seven through forty are certified by exact W(E6)-equivariant Hashimoto spectral packets and Möbius inversion, but are not mislabeled as literal group-orbit partitions."
+}

--- a/data/w33_pass1197_parallel_collision_guard.json
+++ b/data/w33_pass1197_parallel_collision_guard.json
@@ -1,0 +1,48 @@
+{
+  "schema": "w33.pass1197.parallel_collision_guard.v1",
+  "status": "PASS",
+  "headline": "Pass-number ownership, exact certificates, legacy synthesis, and transport cleanup are enforced as mandatory parallel-development gates.",
+  "registry": {
+    "schema": "w33.pass_namespace_registry.v2",
+    "registered_pass_count": 74,
+    "minimum_registered": 1120,
+    "maximum_registered": 1197,
+    "collisions": [],
+    "unregistered_modern_files": []
+  },
+  "current_block": {
+    "range": "1193-1197",
+    "owner": "exact-equivariant-release-track",
+    "status": "COMPLETE",
+    "artifacts": {
+      "1193": "S5/A5 432-carrier coset bridge",
+      "1194": "explicit residual central idempotents",
+      "1195": "W(E6)-equivariant Hashimoto spectral packets",
+      "1196": "primitive PSp/W(E6) cycle orbits and degree-40 continuation",
+      "1197": "parallel namespace collision and mandatory synthesis guard"
+    }
+  },
+  "certificates": [
+    {"pass": 1193, "path": "data/w33_pass1193_s5_a5_coset_bridge.json", "schema": "w33.pass1193.s5_a5_coset_bridge.v1", "checks": 5},
+    {"pass": 1194, "path": "data/w33_pass1194_residual_central_idempotents.json", "schema": "w33.pass1194.residual_central_idempotents.v1", "checks": 4},
+    {"pass": 1195, "path": "data/w33_pass1195_we6_equivariant_hashimoto.json", "schema": "w33.pass1195.we6_equivariant_hashimoto.v1", "checks": 6},
+    {"pass": 1196, "path": "data/w33_pass1196_primitive_cycle_orbits.json", "schema": "w33.pass1196.primitive_cycle_orbits.v1", "checks": 4},
+    {"pass": 1197, "path": "data/w33_pass1197_parallel_collision_guard.json", "schema": "w33.pass1197.parallel_collision_guard.v1", "checks": 5}
+  ],
+  "gate_checks": {
+    "precommit_namespace_guard_installed": true,
+    "workflow_runs_pass1197_guard": true,
+    "workflow_runs_pass1192_guard": true,
+    "transport_scaffold_absent": true,
+    "current_block_complete": true,
+    "current_artifacts_complete": true
+  },
+  "checks": {
+    "registry_has_no_overlap": true,
+    "registered_pass_count_74": true,
+    "no_unregistered_modern_files": true,
+    "passes_1193_1197_all_pass": true,
+    "mandatory_gates_installed": true
+  },
+  "policy": "Parallel agents must reserve a disjoint range before publication; the range, artifacts, exact certificates, synthesis guard, and cleanup gate must all agree before merge."
+}

--- a/data/w33_pass_namespace_registry_v2.json
+++ b/data/w33_pass_namespace_registry_v2.json
@@ -1,7 +1,7 @@
 {
   "schema": "w33.pass_namespace_registry.v2",
   "status": "ACTIVE",
-  "date": "2026-07-27",
+  "date": "2026-07-28",
   "canonical_blocks": [
     {"range": "1120-1124", "owner": "glue-track"},
     {"range": "1125-1128", "owner": "glue-track"},
@@ -19,7 +19,9 @@
     {"range": "1183-1187", "owner": "execution-track-5", "status": "COMPLETE",
       "artifacts": {"1183": "Sym^3(V24) fingerprint table for candidate prioritization", "1184": "Canonical D5 image verdict: 30+15", "1185": "Unified MeatAxe handoff bundle index", "1186": "Manuscript patch queue with Pass 1158 HIGH priority", "1187": "Ihara degree-40 actionable worklist"}},
     {"range": "1188-1192", "owner": "exact-parallel-correction-track", "status": "COMPLETE",
-      "artifacts": {"1188": "exact 1952 residual and Wedderburn commutants", "1189": "group-extension and character-degree correction", "1190": "exact Ihara degree-40 and primitive cycles", "1191": "exact rank-three 40-point module", "1192": "corpus-wide parallel synthesis guard"}}
+      "artifacts": {"1188": "exact 1952 residual and Wedderburn commutants", "1189": "group-extension and character-degree correction", "1190": "exact Ihara degree-40 and primitive cycles", "1191": "exact rank-three 40-point module", "1192": "corpus-wide parallel synthesis guard"}},
+    {"range": "1193-1197", "owner": "exact-equivariant-release-track", "status": "COMPLETE",
+      "artifacts": {"1193": "S5/A5 432-carrier coset bridge", "1194": "explicit residual central idempotents", "1195": "W(E6)-equivariant Hashimoto spectral packets", "1196": "primitive PSp/W(E6) cycle orbits and degree-40 continuation", "1197": "parallel namespace collision and mandatory synthesis guard"}}
   ],
   "rule": "A pass number is canonical only when registered here."
 }

--- a/tests/test_w33_pass1193_1197.py
+++ b/tests/test_w33_pass1193_1197.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(number: int) -> dict:
+    matches = sorted((ROOT / "data").glob(f"w33_pass{number}_*.json"))
+    assert len(matches) == 1, matches
+    data = json.loads(matches[0].read_text(encoding="utf-8"))
+    assert data["status"] == "PASS"
+    assert data["checks"] and all(data["checks"].values())
+    return data
+
+
+def test_pass1193_s5_a5_coset_bridge() -> None:
+    data = load(1193)
+    assert data["theorem"]["intersection"] == "S5 ∩ PSp(4,3) = A5"
+    assert data["theorem"]["three_copies"] == 3
+    for record in data["records"]:
+        assert record["we6_stabilizer"]["order"] == 120
+        assert record["psp43_intersection"]["order"] == 60
+        assert record["coset_models"]["we6_over_s5_index"] == 432
+        assert record["coset_models"]["psp43_over_a5_index"] == 432
+
+
+def test_pass1194_residual_central_idempotents() -> None:
+    data = load(1194)
+    assert data["residual_dimension"] == 1952
+    assert data["center_dimension"] == 10
+    assert data["commutant_dimension"] == 1109
+    assert sum(item["residual_rank"] for item in data["projectors"]) == 1952
+    assert {item["irrep"] for item in data["projectors"]} == {"1", "6", "15", "15a", "20", "24", "30", "60a", "64", "90"}
+
+
+def test_pass1195_hashimoto_packets() -> None:
+    data = load(1195)
+    packets = data["spectral_packets"]
+    assert [packets[key]["dimension"] for key in ("x_minus_11", "x_minus_1", "x_plus_1", "x2_minus_2x_plus_11", "x2_plus_4x_plus_11")] == [1, 201, 200, 48, 30]
+    assert sum(packet["dimension"] for packet in packets.values()) == 480
+    assert packets["x_minus_1"]["module"] == "30_outer_negative + 81_plus + 90"
+    assert packets["x_plus_1"]["module"] == "15a + 20 + 24 + 60a + 81_plus"
+
+
+def test_pass1196_primitive_cycle_orbits() -> None:
+    data = load(1196)
+    literal = data["literal_orbit_frontier"]["data"]
+    totals = data["degree40_continuation"]["primitive_total"]
+    assert [literal[str(n)]["primitive_oriented_rotation_classes"] for n in range(3, 7)] == [320, 3480, 36288, 302880]
+    assert [literal[str(n)]["PSp(4,3)"]["orbit_count"] for n in range(3, 7)] == [1, 2, 3, 18]
+    assert [literal[str(n)]["W(E6)"]["orbit_count"] for n in range(3, 7)] == [1, 2, 2, 13]
+    assert [totals[str(n)] for n in range(3, 7)] == [320, 3480, 36288, 302880]
+    assert totals["40"] == 11314813892043987952589222211358740216768
+
+
+def test_pass1197_parallel_collision_guard() -> None:
+    data = load(1197)
+    assert data["registry"]["registered_pass_count"] == 74
+    assert data["registry"]["collisions"] == []
+    assert data["registry"]["unregistered_modern_files"] == []
+    assert data["current_block"]["range"] == "1193-1197"
+    assert data["current_block"]["status"] == "COMPLETE"
+    assert all(data["gate_checks"].values())


### PR DESCRIPTION
## What changed

This release executes the five outstanding workstreams after PR #165:

- proves the exact stabilizer intersection `S5 ∩ PSp(4,3) = A5` and the two index-432 coset models;
- records ten explicit rational central idempotents for the 1952 residual and its commutant dimension 1109;
- decomposes the 480-dimensional directed-edge Hashimoto module into five exact `W(E6)` spectral packets;
- classifies literal primitive reduced-cycle orbits under `PSp(4,3)` and `W(E6)` through length six, with exact spectral/Möbius continuation through length forty;
- makes pass-range registration and the prior synthesis firewall mandatory in pre-commit and Actions.

## Exact headline results

`W(E6)/S5 ≅ PSp(4,3)/A5`, since `51840/120 = 25920/60 = 432`.

Hashimoto packets have dimensions `1 | 201 | 200 | 48 | 30` with characteristic factorization

`(x-11)(x-1)^201(x+1)^200(x^2-2x+11)^24(x^2+4x+11)^15`.

Literal Weyl-orbit counts for primitive cycles of lengths `3,4,5,6` are `1,2,2,13`; the corresponding projective counts are `1,2,3,18`.

## Validation

The branch contains executable scripts and canonical JSON certificates for Passes 1193–1197, five focused pytest checks, the prior Pass-1192 synthesis guard, and the new fail-closed namespace/collision guard.

Local generation and syntax checks passed. The PR remains draft until the dedicated `Passes 1193-1197 Exact Equivariant Release` workflow completes cleanly.

## Honesty boundary

Literal group-orbit enumeration is claimed only through cycle length six. Lengths seven through forty are exact spectral packet and Möbius-inversion certificates, not mislabeled literal orbit partitions.