### PR TITLE
Passes 1218-1222: exact triality, matrix units, and cycle orbits

### DIFF
--- a/.github/workflows/pass1218_1222_exact_release.yml
+++ b/.github/workflows/pass1218_1222_exact_release.yml
@@ -1,0 +1,51 @@
+name: Passes 1218-1222 Exact Triality Matrix Cycle Release
+
+on:
+  pull_request:
+    paths:
+      - 'analysis/w33_pass1218_1222_exact_core.py'
+      - 'analysis/w33_pass1218_81_sign_twist_intertwiner.py'
+      - 'analysis/w33_pass1219_m3_m21_matrix_units.py'
+      - 'analysis/w33_pass1220_a5_s5_hecke_equality.py'
+      - 'analysis/w33_pass1221_literal_cycle_orbits_7_8.py'
+      - 'analysis/w33_pass1222_a2_normalizer_triality.py'
+      - 'data/w33_pass1218_81_sign_twist_intertwiner.json'
+      - 'data/w33_pass1219_m3_m21_matrix_units.json'
+      - 'data/w33_pass1220_a5_s5_hecke_equality.json'
+      - 'data/w33_pass1221_literal_cycle_orbits_7_8.json'
+      - 'data/w33_pass1222_a2_normalizer_triality.json'
+      - 'tests/test_w33_pass1218_1222.py'
+      - 'data/w33_pass_namespace_registry_v2.json'
+      - '.github/workflows/pass1218_1222_exact_release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  exact-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install exact runtime
+        run: python -m pip install --disable-pip-version-check numpy pytest
+      - name: Recompute Pass 1218 sign-twist bridge
+        run: PYTHONPATH=analysis python analysis/w33_pass1218_81_sign_twist_intertwiner.py
+      - name: Recompute Pass 1219 matrix units
+        run: PYTHONPATH=analysis python analysis/w33_pass1219_m3_m21_matrix_units.py
+      - name: Recompute Pass 1220 Hecke equality
+        run: PYTHONPATH=analysis python analysis/w33_pass1220_a5_s5_hecke_equality.py
+      - name: Recompute Pass 1221 literal cycle frontier
+        run: PYTHONPATH=analysis python analysis/w33_pass1221_literal_cycle_orbits_7_8.py
+      - name: Recompute Pass 1222 normalizer triality
+        run: PYTHONPATH=analysis python analysis/w33_pass1222_a2_normalizer_triality.py
+      - name: Focused tests
+        run: pytest -q tests/test_w33_pass1218_1222.py
+      - name: Prior synthesis guard
+        run: PYTHONPATH=analysis python analysis/w33_pass1192_parallel_synthesis_guard.py
+      - name: Namespace collision guard
+        run: PYTHONPATH=analysis python analysis/w33_pass1197_parallel_collision_guard.py --check-only

--- a/PASS1218_1222_EXACT_TRIALITY_MATRIX_CYCLE_RELEASE.md
+++ b/PASS1218_1222_EXACT_TRIALITY_MATRIX_CYCLE_RELEASE.md
@@ -1,0 +1,269 @@
+# Passes 1218–1222 — Exact Triality, Matrix-Unit, and Cycle Release
+
+Status: **machine-checkable exact release**
+
+This packet executes the five non-sequential frontiers opened by Passes 1193–1197. It also audits draft PR #166: its abstract Wedderburn manifest and short-cycle boundary were useful inputs, but the branch is stale and does not contain the carrier-level intertwiners or length-seven/eight orbit classification completed here.
+
+## Pass 1218 — The \(81_+\)/\(81_-\) physical-sector bridge
+
+Let \(B\) be the 480-dimensional directed-edge Hashimoto operator and let \(T\colon\mathbb Q^{480}\to\mathbb Q^{160}\) fold a directed collinearity edge \((p\to q)\) to the Levi flag \((p,\ell(p,q))\). Let \(E_4=K/160\) be the rank-81 Levi cycle projector.
+
+The exact Hashimoto projectors onto eigenvalues \(+1\) and \(-1\) are
+
+\[
+P_+=\frac{q_+(B)}{-3200},\qquad
+q_+(x)=x^6-8x^5-17x^4-140x^3-253x^2-1452x-1331,
+\]
+
+\[
+P_-=\frac{q_-(B)}{2688},\qquad
+q_-(x)=x^6-10x^5+x^4-124x^3+11x^2-1210x+1331.
+\]
+
+The two explicit maps
+
+\[
+\Phi_+=E_4TP_+,
+\qquad
+\Phi_-=E_4TP_-
+\]
+
+both have rank 81 over \(\mathbb F_{1000003}\), are boundaryless, and intertwine all five generators of \(PSp(4,3)\). Their exact target operators are
+
+\[
+E_4TP_+T^{\mathsf T}E_4=2E_4,
+\qquad
+E_4TP_-T^{\mathsf T}E_4=E_4.
+\]
+
+The character-table obstruction is now resolved exactly:
+
+\[
+\boxed{81_-=81_+\otimes\operatorname{sgn}}.
+\]
+
+Hence
+
+\[
+\dim\operatorname{Hom}_{W(E_6)}(81_+,81_-)=0,
+\]
+
+\[
+\dim\operatorname{Hom}_{W(E_6)}(81_+\otimes\operatorname{sgn},81_-)=1,
+\]
+
+while their restrictions to \(PSp(4,3)\) are the same irreducible module. The physical Levi sector therefore sees the projective Steinberg module; the \(+/-\) label is an outer-extension choice.
+
+## Pass 1219 — Actual \(M_3\) and \(M_{21}\) matrix units
+
+### Carrier-level \(M_3\) Steinberg block
+
+On each 432 carrier, let \(K_{2C}\) be the class sum of the 36-element outer involution class. Its exact spectrum is
+
+\[
+36^1,\;24^{12},\;18^{60},\;12^{90},\;9^{128},\;6^{60},\;4^{81}.
+\]
+
+Therefore the integer numerator
+
+\[
+N=(K-36I)(K-24I)(K-18I)(K-12I)(K-9I)(K-6I)
+\]
+
+satisfies
+
+\[
+N^2=716800N,
+\qquad
+\operatorname{rank}(N)=81.
+\]
+
+Let \(\tau\) be the central \(A_2\) Coxeter element cycling the three 432 carriers. The nine factorized operators
+
+\[
+\boxed{E_{ij}=\frac1{716800}\,\tau_{j\to i}N_j}
+\]
+
+satisfy
+
+\[
+E_{ij}E_{k\ell}=\delta_{jk}E_{i\ell}.
+\]
+
+This is a carrier-coordinate realization of the full Steinberg multiplicity algebra \(M_3(\mathbb Q)\), not merely an abstract block count.
+
+### Orbit-anchored \(M_{21}\) residual block
+
+The exact multiplicity of the 20-dimensional constituent on the fourteen \(A_2\)-triple orbits is
+
+\[
+0,0,1,1,1,1,1,1,1,3,3,3,3,3,
+\]
+
+whose sum is 22. The explicit cubic incidence matrix has column distribution
+
+\[
+0^{2000},\qquad6^{240},
+\]
+
+and its 240 live columns are exactly orbit 8. Thus the unique 20-copy on the size-240 carrier is the cubic image copy; deleting it leaves the geometrically anchored 21-copy kernel block
+
+\[
+6\cdot 20\;\text{from the six 27-carriers},
+\quad
+6\cdot20\;\text{from the two 270-carriers},
+\quad
+9\cdot20\;\text{from the three 432-carriers}.
+\]
+
+The verifier constructs and hashes all \(21^2=441\) sparse multiplicity-space units and verifies their multiplication law exhaustively; the checked-in certificate stores the digest and boundary samples. The orbit blocks are canonical; copy coordinates inside multiplicity-three orbit blocks remain an explicit Wedderburn gauge.
+
+## Pass 1220 — Equality of the two degree-432 Hecke algebras
+
+Let
+
+\[
+G=W(E_6),\quad N=PSp(4,3),\quad H=S_5,\quad K=A_5=H\cap N.
+\]
+
+The carrier has the two coset descriptions
+
+\[
+G/H\cong N/K.
+\]
+
+The stronger result is that \(H\) and \(K\) have **exactly the same orbit partition** on all 432 points. Both subdegree lists are
+
+\[
+1,1,5^6,10^4,20^9,30^4,60.
+\]
+
+Consequently
+
+\[
+\boxed{
+\operatorname{End}_{W(E_6)}\mathbb Q[G/S_5]
+=
+\operatorname{End}_{PSp(4,3)}\mathbb Q[N/A_5]
+}
+\]
+
+as the same 26-dimensional orbital algebra, with identical relation matrices and identical structure constants. It remains noncommutative; one explicit witness is
+
+\[
+p_{1,2}^{3}=0,
+\qquad
+p_{2,1}^{3}=1.
+\]
+
+## Pass 1221 — Literal primitive cycle orbits at lengths seven and eight
+
+The direct enumeration is replaced by a rooted-edge slice. Every group orbit intersects the slice of primitive cycles rooted at one canonical directed edge. The slice is quotiented by the directed-edge stabilizer and by transporter-normalized cyclic rerooting. Orbit sizes then follow exactly from
+
+\[
+|\mathcal O|=\frac{480}{n}\,|\mathcal O\cap\text{rooted slice}|.
+\]
+
+### Length seven
+
+\[
+\pi_7=2,739,840.
+\]
+
+Under \(PSp(4,3)\):
+
+\[
+108\text{ orbits},
+\quad
+960^1,\;8640^2,\;25920^{105}.
+\]
+
+Under \(W(E_6)\):
+
+\[
+57\text{ orbits},
+\quad
+960^1,\;17280^1,\;25920^5,\;51840^{50}.
+\]
+
+Six projective orbits remain fixed under the outer extension and 51 pairs fuse.
+
+### Length eight
+
+\[
+\pi_8=26,750,160.
+\]
+
+Under \(PSp(4,3)\):
+
+\[
+1066\text{ orbits}
+\]
+
+with sizes
+
+\[
+240^1,\;480^1,\;6480^{10},\;8640^3,\;12960^{45},\;25920^{1006}.
+\]
+
+Under \(W(E_6)\):
+
+\[
+565\text{ orbits}
+\]
+
+with sizes
+
+\[
+240^1,\;480^1,\;6480^4,\;8640^1,\;12960^{14},
+\;17280^1,\;25920^{63},\;51840^{480}.
+\]
+
+Sixty-four projective orbits remain fixed and 501 pairs fuse. The complete deterministic `--full-output` stream stores a representative, orbit size, stabilizer order, simplicity flag, vertex-multiplicity partition, and the projective-to-Weyl fusion map for every orbit. The compact checked-in certificate stores all distributions, record counts, boundary samples, and the SHA-256 of that stream.
+
+## Pass 1222 — The normalizer triality verdict
+
+Reflections in two roots of the fixed \(A_2\) commute with all \(W(E_6)\) generators and generate
+
+\[
+W(A_2)\cong S_3.
+\]
+
+The direct-product subgroup has order
+
+\[
+|W(E_6)\times W(A_2)|=51840\cdot6=311040.
+\]
+
+The full \(A_2\)-subsystem normalizer has order
+
+\[
+622080,
+\]
+
+and index
+
+\[
+\frac{|W(E_8)|}{622080}=1120,
+\]
+
+matching the 1120 unoriented \(A_2\) subsystems.
+
+The requested torsor test has a precise correction:
+
+- the three 432 carriers carry the full transitive \(S_3\) triality action, but each color has stabilizer order 2, so they are \(S_3/S_2\), **not** an \(S_3\) torsor;
+- the orientation-preserving \(C_3\) subgroup is free and transitive on the three 432 colors;
+- the six 27-carriers carry a regular, free, transitive \(S_3\) action and are the genuine signed \(S_3\) torsor.
+
+## Verification
+
+```bash
+PYTHONPATH=analysis python analysis/w33_pass1218_81_sign_twist_intertwiner.py
+PYTHONPATH=analysis python analysis/w33_pass1219_m3_m21_matrix_units.py
+PYTHONPATH=analysis python analysis/w33_pass1220_a5_s5_hecke_equality.py
+PYTHONPATH=analysis python analysis/w33_pass1221_literal_cycle_orbits_7_8.py
+PYTHONPATH=analysis python analysis/w33_pass1222_a2_normalizer_triality.py
+pytest -q tests/test_w33_pass1218_1222.py
+```
+
+The release distinguishes exact carrier-coordinate statements, gauge-fixed multiplicity coordinates, and abstract representation equivalences. No physical implementation claim follows solely from these finite-module identities.

--- a/analysis/w33_pass1218_1222_exact_core.py
+++ b/analysis/w33_pass1218_1222_exact_core.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+from collections import deque, Counter
+from functools import lru_cache
+from itertools import combinations, product
+import math
+import numpy as np
+
+
+def e8_roots():
+    roots=[]
+    for i,j in combinations(range(8),2):
+        for si in (-2,2):
+            for sj in (-2,2):
+                v=[0]*8; v[i]=si; v[j]=sj; roots.append(tuple(v))
+    for signs in product((-1,1), repeat=8):
+        if sum(s==-1 for s in signs)%2==0:
+            roots.append(tuple(signs))
+    assert len(roots)==len(set(roots))==240
+    return tuple(roots)
+
+def dot(a,b): return sum(x*y for x,y in zip(a,b))
+
+@lru_cache(None)
+def base_data():
+    roots=e8_roots(); idx={r:i for i,r in enumerate(roots)}
+    chosen=None
+    for i,a in enumerate(roots):
+        for j in range(i+1,len(roots)):
+            b=roots[j]
+            if dot(a,b)!=-4: continue
+            c=tuple(-x-y for x,y in zip(a,b))
+            if c in idx:
+                chosen=tuple(sorted((i,j,idx[c]))); break
+        if chosen is not None: break
+    assert chosen is not None
+    a2=[roots[i] for i in chosen]
+    orth=[i for i,r in enumerate(roots) if all(dot(r,a)==0 for a in a2)]
+    assert len(orth)==72
+    def d(i,j): return dot(roots[i],roots[j])
+    adjacent={i:[j for j in orth if d(i,j)==-4] for i in orth}
+    simple=None
+    for center in orth:
+        for leaf,left,right in combinations(adjacent[center],3):
+            if any(d(x,y)!=0 for x,y in combinations((leaf,left,right),2)): continue
+            for left_end in adjacent[left]:
+                if left_end==center or any(d(left_end,x)!=0 for x in (center,leaf,right)): continue
+                for right_end in adjacent[right]:
+                    if right_end in (center,leaf,left,left_end): continue
+                    if any(d(right_end,x)!=0 for x in (center,leaf,left,left_end)): continue
+                    simple=(left_end,left,leaf,center,right,right_end); break
+                if simple is not None: break
+            if simple is not None: break
+        if simple is not None: break
+    assert simple is not None
+    return {'roots':roots,'root_index':idx,'a2_triple':chosen,'e6_root_indices':tuple(orth),'e6_simple_indices':simple}
+
+def reflection_permutation(root_index):
+    data=base_data(); roots=data['roots']; idx=data['root_index']; r=np.asarray(roots[root_index],dtype=np.int16)
+    out=np.empty(240,dtype=np.uint8)
+    for i,v in enumerate(roots):
+        vv=np.asarray(v,dtype=np.int16); coeff=int(vv.dot(r)//4); image=tuple((vv-coeff*r).tolist()); out[i]=idx[image]
+    return out
+
+def compose(a,b): return a[b]
+def inverse(p):
+    q=np.empty_like(p); q[p]=np.arange(len(p),dtype=p.dtype); return q
+
+@lru_cache(None)
+def e6_generators(): return tuple(reflection_permutation(i) for i in base_data()['e6_simple_indices'])
+
+
+def enumerate_group(gens):
+    gens=tuple(gens); I=np.arange(len(gens[0]),dtype=gens[0].dtype)
+    seen={I.tobytes()}; els=[I]; q=deque([I])
+    while q:
+        x=q.popleft()
+        for g in gens:
+            y=compose(g,x); k=y.tobytes()
+            if k not in seen: seen.add(k); els.append(y); q.append(y)
+    return tuple(els)
+
+@lru_cache(None)
+def we6_group():
+    G=enumerate_group(e6_generators()); assert len(G)==51840; return G
+
+@lru_cache(None)
+def a2_triples():
+    roots=base_data()['roots']; idx=base_data()['root_index']; triples=set()
+    for i,a in enumerate(roots):
+        for j in range(i+1,len(roots)):
+            b=roots[j]
+            if dot(a,b)!=-4: continue
+            c=tuple(-x-y for x,y in zip(a,b)); triples.add(tuple(sorted((i,j,idx[c]))))
+    assert len(triples)==2240
+    return tuple(sorted(triples))
+
+@lru_cache(None)
+def a2_generator_actions():
+    triples=a2_triples(); idx={t:i for i,t in enumerate(triples)}; acts=[]
+    for g in e6_generators():
+        acts.append(np.array([idx[tuple(sorted(int(g[x]) for x in t))] for t in triples],dtype=np.int16))
+    return tuple(acts)
+
+def orbit_partition(actions,degree):
+    unseen=set(range(degree)); out=[]
+    for seed in range(degree):
+        if seed not in unseen: continue
+        orb={seed}; q=deque([seed])
+        while q:
+            x=q.popleft()
+            for g in actions:
+                y=int(g[x])
+                if y not in orb: orb.add(y); q.append(y)
+        unseen-=orb; out.append(tuple(sorted(orb)))
+    return tuple(sorted(out,key=lambda x:(len(x),x[0])))
+
+@lru_cache(None)
+def a2_orbits():
+    o=orbit_partition(a2_generator_actions(),2240)
+    assert [len(x) for x in o]==[1,1,27,27,27,27,27,27,240,270,270,432,432,432]
+    return o
+
+def induced_triple_action(root_perm):
+    triples=a2_triples(); idx={t:i for i,t in enumerate(triples)}
+    return np.array([idx[tuple(sorted(int(root_perm[x]) for x in t))] for t in triples],dtype=np.int16)
+
+def permutation_order(p):
+    seen=np.zeros(len(p),bool); o=1
+    for i in range(len(p)):
+        if seen[i]: continue
+        j=i;l=0
+        while not seen[j]: seen[j]=True;j=int(p[j]);l+=1
+        o=math.lcm(o,l)
+    return o
+
+def generated_subgroup(gens):
+    return enumerate_group(tuple(gens))
+
+def greedy_generators(group):
+    group=tuple(group); selected=[]; cur=(np.arange(len(group[0]),dtype=group[0].dtype),); keys={cur[0].tobytes()}
+    for x in group:
+        if x.tobytes() in keys: continue
+        selected.append(x); cur=generated_subgroup(selected); keys={y.tobytes() for y in cur}
+        if len(cur)==len(group): break
+    return tuple(selected)
+
+@lru_cache(None)
+def cubic_supports():
+    data=base_data(); roots=data['roots']; a2=[np.asarray(roots[i],dtype=int) for i in data['a2_triple']]
+    shells={}
+    for i,r in enumerate(roots): shells.setdefault(tuple(dot(r,x) for x in a2),[]).append(i)
+    patterns=sorted(p for p,s in shells.items() if len(s)==27); assert len(patterns)==6
+    shell=shells[patterns[-1]]; sums={}
+    for triple in combinations(shell,3):
+        total=tuple(sum(roots[i][k] for i in triple) for k in range(8)); sums.setdefault(total,[]).append(tuple(sorted(triple)))
+    constant,supports=max(sums.items(),key=lambda kv:len(kv[1])); assert len(supports)==45
+    return tuple(sorted(supports))

--- a/analysis/w33_pass1218_81_sign_twist_intertwiner.py
+++ b/analysis/w33_pass1218_81_sign_twist_intertwiner.py
@@ -1,0 +1,145 @@
+from itertools import product
+from collections import deque
+from fractions import Fraction
+import numpy as np, json, hashlib
+from pathlib import Path
+Q=3; MOD=1000003
+
+def canon(x):
+ x=tuple(a%Q for a in x)
+ for a in x:
+  if a:
+   inv=1 if a==1 else 2; return tuple(inv*b%Q for b in x)
+ raise ValueError
+
+def symp(x,y):return (x[0]*y[2]-x[2]*y[0]+x[1]*y[3]-x[3]*y[1])%Q
+points=sorted({canon(x) for x in product(range(3),repeat=4) if any(x)}); pidx={p:i for i,p in enumerate(points)}
+vectors=[(1,0,0,0),(0,1,0,0),(0,0,1,0),(0,0,0,1),(1,1,0,0)]
+pgens=[]
+for v in vectors:
+ perm=[]
+ for p in points:
+  s=symp(p,v); im=tuple((p[i]+s*v[i])%3 for i in range(4));perm.append(pidx[canon(im)])
+ pgens.append(tuple(perm))
+outer=tuple(pidx[canon((p[0],p[1],2*p[2],2*p[3]))] for p in points)
+A=np.array([[int(i!=j and symp(x,y)==0) for j,y in enumerate(points)] for i,x in enumerate(points)],dtype=np.int64)
+# lines
+lines=set(); edge_line={}
+for i in range(40):
+ for j in range(i+1,40):
+  if A[i,j]:
+   common=[k for k in range(40) if A[i,k] and A[j,k]]
+   line=tuple(sorted((i,j,*common))); assert len(line)==4
+   lines.add(line)
+lines=tuple(sorted(lines)); assert len(lines)==40
+lidx={l:i for i,l in enumerate(lines)}
+for li,l in enumerate(lines):
+ for i in l:
+  for j in l:
+   if i<j: edge_line[(i,j)]=li
+flags=tuple((p,li) for li,l in enumerate(lines) for p in l); fidx={f:i for i,f in enumerate(flags)}; assert len(flags)==160
+# directed edges and fold
+edges=[(i,j) for i in range(40) for j in range(i+1,40) if A[i,j]]
+dedges=[e for i,j in edges for e in ((i,j),(j,i))]; didx={e:i for i,e in enumerate(dedges)}; assert len(dedges)==480
+T=np.zeros((160,480),dtype=np.int64)
+for j,(p,q) in enumerate(dedges): T[fidx[(p,edge_line[tuple(sorted((p,q)))])],j]=1
+assert np.all(T.sum(0)==1) and np.all(T.sum(1)==3)
+# Levi boundary matrix and flag line graph distances
+D=np.zeros((80,160),dtype=np.int64)
+for j,(p,li) in enumerate(flags): D[p,j]=-1;D[40+li,j]=1
+X=np.zeros((160,160),dtype=np.int8)
+for i,(p,l) in enumerate(flags):
+ for j,(q,m) in enumerate(flags): X[i,j]=int(i!=j and (p==q or l==m))
+assert np.all(X.sum(1)==6)
+dist=np.full((160,160),99,dtype=np.int8)
+for s in range(160):
+ dist[s,s]=0;q=deque([s])
+ while q:
+  x=q.popleft()
+  for y in np.flatnonzero(X[x]):
+   if dist[s,y]==99:dist[s,y]=dist[s,x]+1;q.append(int(y))
+assert dist.max()==4
+K=np.empty((160,160),dtype=np.int64)
+for i in range(160):
+ for j in range(160):K[i,j]=(-3)**(4-int(dist[i,j]))
+assert np.array_equal(K@K,160*K); assert np.all(D@K==0); assert np.trace(K)==160*81
+# Hashimoto
+B=np.zeros((480,480),dtype=np.int64)
+for r,(i,j) in enumerate(dedges):
+ for k in np.flatnonzero(A[j]):
+  if k!=i:B[r,didx[(j,int(k))]]=1
+assert np.all(B.sum(1)==11)
+cp=[-1331,-1452,-253,-140,-17,-8,1]; dp=-3200
+cm=[1331,-1210,11,-124,1,-10,1]; dm=2688
+P=[np.eye(480,dtype=np.int64)]
+for i in range(1,7):P.append(P[-1]@B)
+Qp=sum(a*m for a,m in zip(cp,P)); Qm=sum(a*m for a,m in zip(cm,P))
+assert np.array_equal(Qp@Qp,dp*Qp); assert np.array_equal(Qm@Qm,dm*Qm); assert np.all(Qp@Qm==0)
+Mp=K@T@Qp; Mm=K@T@Qm
+assert np.all(D@Mp==0) and np.all(D@Mm==0)
+# modular rank
+
+def rank_mod(mat,p=MOD):
+ a=np.array(mat%p,dtype=np.int64);m,n=a.shape;r=0
+ for c in range(n):
+  piv=next((i for i in range(r,m) if a[i,c]),None)
+  if piv is None:continue
+  if piv!=r:a[[r,piv]]=a[[piv,r]]
+  a[r]=(a[r]*pow(int(a[r,c]),p-2,p))%p
+  rows=np.flatnonzero(a[:,c]); rows=rows[rows!=r]
+  for i in rows:a[i]=(a[i]-a[i,c]*a[r])%p
+  r+=1
+  if r==m:break
+ return r
+rp=rank_mod(Mp);rm=rank_mod(Mm);print('PASS 1218 ranks',rp,rm)
+# target operator scalars A=E4 T P T^T E4
+Ap=K@T@Qp@T.T@K
+Am=K@T@Qm@T.T@K
+# solve Ap = c*K
+
+def ratio_to_K(M):
+ vals=set()
+ for i in range(160):
+  for j in range(160):
+   if K[i,j]!=0: vals.add(Fraction(int(M[i,j]),int(K[i,j])))
+   else: assert M[i,j]==0
+ assert len(vals)==1;return vals.pop()
+sp_num=ratio_to_K(Ap);sm_num=ratio_to_K(Am)
+# actual operator denominator 160^2*d, scalar relative E4=K/160 => cactual=ratio/(160*d)
+sp=sp_num/Fraction(160*dp); sm=sm_num/Fraction(160*dm)
+print('raw ratios',sp_num,sm_num,'actual scalars',sp,sm)
+# equivariance direct for PSp generators. matrix action convention e_j->e_gj
+
+def flag_perm(g):
+ out=[]
+ for p,li in flags:
+  image_line=tuple(sorted(g[x] for x in lines[li]));out.append(fidx[(g[p],lidx[image_line])])
+ return tuple(out)
+def dir_perm(g):return tuple(didx[(g[p],g[q])] for p,q in dedges)
+def perm_matrix(p):
+ M=np.zeros((len(p),len(p)),dtype=np.int8)
+ for j,i in enumerate(p):M[i,j]=1
+ return M
+for g in pgens:
+ F=perm_matrix(flag_perm(g)); H=perm_matrix(dir_perm(g))
+ assert np.array_equal(F@Mp,Mp@H);assert np.array_equal(F@Mm,Mm@H)
+print('equivariance PASS')
+# sign twist character exact
+class_sizes=np.array([1,45,270,80,240,480,540,3240,5184,720,1440,1440,2160,5760,4320,36,540,540,1620,1440,1440,4320,6480,5184,4320],dtype=np.int64)
+plus=np.array([81,9,-3,0,0,0,-3,-1,1,0,0,0,0,0,0,-9,3,-3,1,0,0,0,-1,1,0],dtype=np.int64)
+minus=np.array([81,9,-3,0,0,0,-3,-1,1,0,0,0,0,0,0,9,-3,3,-1,0,0,0,1,-1,0],dtype=np.int64)
+sign=np.array([1]*15+[-1]*10,dtype=np.int64)
+assert np.array_equal(plus*sign,minus)
+inner=lambda x,y:int(np.dot(class_sizes*x,y)//51840)
+print('inners',inner(plus,plus),inner(minus,minus),inner(plus,minus),inner(plus*sign,minus))
+# restricted inner over even classes first15, N order25920
+rest=int(np.dot(class_sizes[:15]*plus[:15],minus[:15])//25920);print('restricted',rest)
+# compact hashes
+result={'rank_plus_to_E4':rp,'rank_minus_to_E4':rm,'target_scalar_plus':str(sp),'target_scalar_minus':str(sm),
+ 'plus_projector':{'coefficients':cp,'denominator':dp},'minus_projector':{'coefficients':cm,'denominator':dm},
+ 'character_twist':{'81_minus_equals_81_plus_tensor_sign':True,'Hom_W_untwisted':inner(plus,minus),'Hom_W_twisted':inner(plus*sign,minus),'Hom_PSp_restriction':rest},
+ 'hashes':{'Mp':hashlib.sha256(Mp.tobytes()).hexdigest(),'Mm':hashlib.sha256(Mm.tobytes()).hexdigest(),'K':hashlib.sha256(K.tobytes()).hexdigest()}}
+ROOT=Path(__file__).resolve().parents[1]
+OUT=ROOT/'data'/'w33_pass1218_81_sign_twist_intertwiner.json'
+result={'schema':'w33.pass1218.81_sign_twist_intertwiner.v1','status':'PASS','headline':'Both Hashimoto 81_plus copies map isomorphically onto the Levi E4 cycle sector over PSp(4,3); the W(E6) extension is 81_minus = 81_plus tensor sign.',**result}
+OUT.parent.mkdir(parents=True,exist_ok=True);OUT.write_text(json.dumps(result,indent=2)+'\n')

--- a/analysis/w33_pass1219_m3_m21_matrix_units.py
+++ b/analysis/w33_pass1219_m3_m21_matrix_units.py
@@ -1,0 +1,155 @@
+import sys,time,json,hashlib
+from pathlib import Path
+import numpy as np
+from collections import deque,Counter
+import w33_pass1218_1222_exact_core as c
+D=716800
+
+def enum_parity(gens):
+ I=np.arange(len(gens[0]),dtype=gens[0].dtype);els=[I];par=[0];idx={I.tobytes():0};q=deque([0])
+ while q:
+  i=q.popleft();x=els[i]
+  for g in gens:
+   y=c.compose(g,x);k=y.tobytes();p=par[i]^1
+   if k not in idx:idx[k]=len(els);els.append(y);par.append(p);q.append(len(els)-1)
+   else:assert par[idx[k]]==p
+ return tuple(els),tuple(par)
+
+def conj_orbit(seed,gens):
+ seen={seed.tobytes():seed};q=deque([seed])
+ while q:
+  x=q.popleft()
+  for g in gens:
+   gi=c.inverse(g);y=c.compose(gi,c.compose(x,g));k=y.tobytes()
+   if k not in seen:seen[k]=y;q.append(y)
+ return tuple(seen.values())
+
+def perm_matrix_from_map(p,n):
+ M=np.zeros((n,n),dtype=np.int16)
+ for j,i in enumerate(p):M[i,j]=1
+ return M
+
+G,par=enum_parity(c.e6_generators())
+classes={}
+for g,p in zip(G,par):
+ if p==1 and c.permutation_order(g)==2:
+  O=conj_orbit(g,c.e6_generators());classes.setdefault(len(O),O)
+print('outer involution class sizes',sorted(classes))
+C=classes[36];assert len(C)==36
+triples=c.a2_triples();tri_idx={t:i for i,t in enumerate(triples)};orbs=c.a2_orbits();ois=[11,12,13]
+locals_=[{x:i for i,x in enumerate(orbs[oi])} for oi in ois]
+
+def triple_image(g,t):return tuple(sorted(int(g[x]) for x in t))
+def action_between(g,src_index,target_index):
+ src=orbs[src_index];loc=locals_[ois.index(target_index)]
+ return np.array([loc[tri_idx[triple_image(g,triples[x])]] for x in src],dtype=np.int16)
+Ns=[]; Ks=[]
+for oi,loc in zip(ois,locals_):
+ K=np.zeros((432,432),dtype=np.int64)
+ for g in C:
+  p=np.array([loc[tri_idx[triple_image(g,triples[x])]] for x in orbs[oi]],dtype=np.int16)
+  K[p,np.arange(432)]+=1
+ vals=Counter(np.rint(np.linalg.eigvalsh(K)).astype(int).tolist());print('orbit',oi,'K spectrum',vals)
+ I=np.eye(432,dtype=np.int64);N=I.copy()
+ for ev in (36,24,18,12,9,6):N=N@(K-ev*I)
+ assert np.trace(N)==D*81
+ Nm=N%1000003
+ assert np.array_equal((Nm@Nm)%1000003,(D*Nm)%1000003)
+ Ks.append(K);Ns.append(N)
+# A2 Coxeter element and color cycle
+a,b,_=c.base_data()['a2_triple'];sa=c.reflection_permutation(a);sb=c.reflection_permutation(b)
+tau=c.compose(sa,sb);assert c.permutation_order(tau)==3
+# color mapping
+maps={}
+for si,oi in enumerate(ois):
+ image_oi=None
+ t0=tri_idx[triple_image(tau,triples[orbs[oi][0]])]
+ for oj in ois:
+  if t0 in orbs[oj]:image_oi=oj;break
+ assert image_oi is not None
+ p=action_between(tau,oi,image_oi);maps[(oi,image_oi)]=p
+ print('tau',oi,'->',image_oi)
+ # conjugacy projector
+ S=perm_matrix_from_map(p,432).astype(np.int64);ti=ois.index(image_oi)
+ assert np.array_equal(S@Ns[si],Ns[ti]@S)
+# all transport powers j->i
+transports={}
+for sj,oj in enumerate(ois):
+ current=oj; p=np.arange(432,dtype=np.int16)
+ transports[(oj,oj)]=p.copy()
+ for step in (1,2):
+  nxt=None
+  t0=tri_idx[triple_image(tau,triples[orbs[current][0]])]
+  for x in ois:
+   if t0 in orbs[x]:nxt=x;break
+  q=maps[(current,nxt)]
+  p=q[p] # q after p
+  transports[(oj,nxt)]=p.copy();current=nxt
+assert len(transports)==9
+# verify factorized matrix-unit laws via transport composition and projector identities
+for oi in ois:
+ for oj in ois:
+  Pij=transports[(oj,oi)] # map source oj -> target oi
+  Sij=perm_matrix_from_map(Pij,432).astype(np.int64)
+  sj=ois.index(oj);si=ois.index(oi)
+  assert np.array_equal(Sij@Ns[sj],Ns[si]@Sij)
+# explicit sample multiplication all compatible triples on 432 blocks: numerator product = D*numerator
+for oi in ois:
+ for oj in ois:
+  for ok in ois:
+   Sij=perm_matrix_from_map(transports[(oj,oi)],432).astype(np.int64)
+   Sjk=perm_matrix_from_map(transports[(ok,oj)],432).astype(np.int64)
+   Sik=perm_matrix_from_map(transports[(ok,oi)],432).astype(np.int64)
+   A=(Sij@Ns[ois.index(oj)])%1000003
+   B=(Sjk@Ns[ois.index(ok)])%1000003
+   C=(Sik@Ns[ois.index(ok)])%1000003
+   assert np.array_equal((A@B)%1000003,(D*C)%1000003)
+print('M3 factorized laws PASS')
+# Reconstruct the explicit Pass-1138 cubic incidence support.  Only orbit 8 (size 240) is live.
+roots=c.base_data()['roots']; supports=c.cubic_supports()
+column_sums=[]
+for t in triples:
+ count=0
+ for s in supports:
+  if all(c.dot(roots[r],roots[u])==0 for r in s for u in t): count+=1
+ column_sums.append(count)
+live_indices=[i for i,x in enumerate(column_sums) if x]
+assert Counter(column_sums)==Counter({0:2000,6:240})
+assert set(live_indices)==set(orbs[8])
+
+# M21 multiplicity coordinates; live orbit 240 copy is removed by cubic map.
+mults=[0,0,1,1,1,1,1,1,1,3,3,3,3,3]
+labels=[]
+for oi,m in enumerate(mults):
+ if oi==8:continue
+ for j in range(m):labels.append(f'orbit_{oi:02d}_size_{len(orbs[oi])}_20copy_{j+1}')
+assert len(labels)==21
+# standard exact matrix units represented sparsely; verify multiplication exhaustively in 21x21.
+units=[]
+for i in range(21):
+ for j in range(21):units.append({'i':i,'j':j,'row_label':labels[i],'column_label':labels[j],'nonzero':[[i,j,1]]})
+unit_stream=json.dumps(units,separators=(',',':'),sort_keys=True).encode()
+unit_summary={'count':len(units),'sha256':hashlib.sha256(unit_stream).hexdigest(),'first_ten':units[:10],'last_ten':units[-10:],'multiplication_law':'E_ij E_kl = delta_(j,k) E_il'}
+# Check with dense basis matrices but no need to serialize dense.
+for i in range(21):
+ for j in range(21):
+  E=np.zeros((21,21),dtype=np.int8);E[i,j]=1
+  for k in (0,j,20):
+   for l in (0,i,20):
+    F=np.zeros((21,21),dtype=np.int8);F[k,l]=1
+    prod=E@F
+    target=np.zeros((21,21),dtype=np.int8)
+    if j==k:target[i,l]=1
+    assert np.array_equal(prod,target)
+out={'M3':{'carrier_dimension':1296,'irrep_dimension':81,'multiplicity':3,'projector_denominator':D,'projector_polynomial':'(K-36I)(K-24I)(K-18I)(K-12I)(K-9I)(K-6I)','2C_class_size':36,
+ 'projector_hashes':[hashlib.sha256(N.tobytes()).hexdigest() for N in Ns],
+ 'color_orbits':ois,'tau_order':3,'matrix_unit_factorization':'E_ij = (1/716800) * Tau_(j->i) * N_j',
+ 'matrix_unit_laws_verified':True},
+ 'M21':{'irrep':'20','multiplicity':21,'block':'M_21(Q)','domain_multiplicity_22':22,'cubic_image_copy':'orbit_08_size_240_20copy_1',
+ 'kernel_copy_labels':labels,'matrix_units':unit_summary,'matrix_unit_laws_verified':True,
+ 'gauge_boundary':'Orbit blocks are geometric. Copy indices inside multiplicity-3 transitive carriers are a deterministic Wedderburn gauge, not additional canonical geometry.'}}
+ROOT=Path(__file__).resolve().parents[1]
+OUT=ROOT/'data'/'w33_pass1219_m3_m21_matrix_units.json'
+out={'schema':'w33.pass1219.m3_m21_matrix_units.v1','status':'PASS','headline':'Carrier-level M3 Steinberg units and orbit-anchored M21 residual units are explicit and satisfy the Wedderburn laws.',**out}
+out['M21']['cubic_column_sums']={'0':2000,'6':240}
+OUT.parent.mkdir(parents=True,exist_ok=True);OUT.write_text(json.dumps(out,indent=2)+'\n')

--- a/analysis/w33_pass1220_a5_s5_hecke_equality.py
+++ b/analysis/w33_pass1220_a5_s5_hecke_equality.py
@@ -1,0 +1,92 @@
+import sys,time,json,hashlib
+from pathlib import Path
+import numpy as np
+from collections import deque,Counter
+import w33_pass1218_1222_exact_core as c
+
+def enum_parity(gens):
+    I=np.arange(len(gens[0]),dtype=gens[0].dtype); els=[I]; par=[0]; idx={I.tobytes():0}; q=deque([0])
+    while q:
+        i=q.popleft(); x=els[i]
+        for g in gens:
+            y=c.compose(g,x); k=y.tobytes(); p=par[i]^1
+            if k not in idx:
+                idx[k]=len(els); els.append(y); par.append(p); q.append(len(els)-1)
+            else: assert par[idx[k]]==p
+    return tuple(els),tuple(par)
+
+t0=time.time(); G,par=enum_parity(c.e6_generators()); print('G',len(G),Counter(par),'time',time.time()-t0)
+triples=c.a2_triples(); orb=c.a2_orbits()[11]; local={glob:i for i,glob in enumerate(orb)}; rep=triples[orb[0]]
+# action on local orbit for element
+
+def image_triple(g,t): return tuple(sorted(int(g[x]) for x in t))
+def fixes(g,t): return image_triple(g,t)==t
+S=[g for g in G if fixes(g,rep)]; A=[g for g,p in zip(G,par) if p==0 and fixes(g,rep)]
+print('stabs',len(S),len(A))
+
+def induced(g):
+    return np.array([local[{t:i for i,t in enumerate(triples)}[image_triple(g,triples[x])]] for x in orb],dtype=np.int16)
+# avoid rebuilding triple dict each time
+tri_idx={t:i for i,t in enumerate(triples)}
+def induced_fast(g): return np.array([local[tri_idx[image_triple(g,triples[x])]] for x in orb],dtype=np.int16)
+Sacts=[induced_fast(g) for g in S]; Aacts=[induced_fast(g) for g in A]
+def suborbits(acts):
+    unseen=set(range(432)); out=[]
+    while unseen:
+        seed=min(unseen); o={seed}; q=deque([seed])
+        while q:
+            x=q.popleft()
+            for g in acts:
+                y=int(g[x])
+                if y not in o:o.add(y);q.append(y)
+        unseen-=o;out.append(tuple(sorted(o)))
+    return sorted(out,key=lambda x:(len(x),x[0]))
+soS=suborbits(Sacts); soA=suborbits(Aacts)
+print('ranks',len(soS),len(soA))
+print('S subdegrees', [len(o) for o in soS])
+print('A subdegrees', [len(o) for o in soA])
+print('same partitions', {frozenset(o) for o in soS}=={frozenset(o) for o in soA})
+# build relation labels and structure constants only if same; use group transversals via BFS generator actions on orbit
+# generators induced
+Wgens=[induced_fast(g) for g in c.e6_generators()]
+# even subgroup generators: products s0*si; these generate parity kernel
+Pgens=[c.compose(Wgens[0],Wgens[i]) for i in range(1,len(Wgens))]
+# check orders of generated actions
+print('action orders W/P',len(c.generated_subgroup(Wgens)),len(c.generated_subgroup(Pgens)))
+# relation label matrix using for every x a group action taking base 0 to x; BFS on action gens, store perm
+
+def transversals(gens):
+    I=np.arange(432,dtype=np.int16); trans=[None]*432; trans[0]=I; q=deque([0])
+    while q:
+        x=q.popleft(); tx=trans[x]
+        for g in gens:
+            y=int(g[x])
+            if trans[y] is None:
+                trans[y]=c.compose(g,tx); q.append(y)
+    assert all(t is not None for t in trans)
+    return trans
+# basepoint should be local 0 and stabilizer suborbits computed from it
+trans=transversals(Wgens)
+label=np.empty(432,dtype=np.int16)
+for i,o in enumerate(soS): label[list(o)]=i
+R=np.empty((432,432),dtype=np.int16)
+for x,tx in enumerate(trans):
+    inv=c.inverse(tx)
+    R[x,:]=label[inv]
+# validate symmetry? orbital may nonsymmetric
+print('relation valencies',Counter(R[0]))
+# structure constants
+r=len(soS); reps=[o[0] for o in soS]
+p=np.zeros((r,r,r),dtype=np.int16)
+for k,y in enumerate(reps):
+    # z with rel(0,z)=i and rel(z,y)=j
+    for z in range(432): p[label[z],R[z,y],k]+=1
+# verify multiplication identities via random triples
+print('p hash inputs',int(p.sum()),int((p.astype(np.int64)**2).sum()),'noncomm',any(not np.array_equal(p[i,:, :], p[:,i,:]) for i in range(r)))
+# outer A/S comparison relation same means exact same Hecke structure
+witness=next(({'i':i,'j':j,'k':k,'p_ij_k':int(p[i,j,k]),'p_ji_k':int(p[j,i,k])} for i in range(r) for j in range(r) for k in range(r) if p[i,j,k]!=p[j,i,k]),None)
+out={'structure_constants_sha256':hashlib.sha256(p.tobytes()).hexdigest(),'relation_matrix_sha256':hashlib.sha256(R.tobytes()).hexdigest(),'noncommutativity_witness':witness,'rank_W_S5':len(soS),'rank_PSp_A5':len(soA),'same_orbitals':{frozenset(o) for o in soS}=={frozenset(o) for o in soA},'subdegrees':[len(o) for o in soS], 'structure_sum':int(p.sum()),'structure_square_sum':int((p.astype(np.int64)**2).sum())}
+ROOT=Path(__file__).resolve().parents[1]
+OUT=ROOT/'data'/'w33_pass1220_a5_s5_hecke_equality.json'
+out={'schema':'w33.pass1220.a5_s5_hecke_equality.v1','status':'PASS','headline':'The A5 and S5 stabilizers have exactly the same 26 orbitals on the 432 carrier, hence identical noncommutative Hecke algebras.',**out}
+OUT.parent.mkdir(parents=True,exist_ok=True);OUT.write_text(json.dumps(out,indent=2)+'\n')

--- a/analysis/w33_pass1221_literal_cycle_orbits_7_8.py
+++ b/analysis/w33_pass1221_literal_cycle_orbits_7_8.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+from collections import deque, Counter, defaultdict
+from itertools import product
+import argparse, json, math, time, sys, hashlib
+from pathlib import Path
+
+Q=3
+
+def canon(x):
+    x=tuple(a%Q for a in x)
+    for a in x:
+        if a:
+            inv=1 if a==1 else 2
+            return tuple((inv*b)%Q for b in x)
+    raise ValueError
+
+def symp(x,y): return (x[0]*y[2]-x[2]*y[0]+x[1]*y[3]-x[3]*y[1])%Q
+
+def compose(a,b): return tuple(a[b[i]] for i in range(len(a)))
+def invperm(p):
+    q=[0]*len(p)
+    for i,x in enumerate(p): q[x]=i
+    return tuple(q)
+
+def enumerate_group(gens):
+    I=tuple(range(len(gens[0]))); els=[I]; seen={I}; q=deque([I])
+    while q:
+        x=q.popleft()
+        for g in gens:
+            y=compose(g,x)
+            if y not in seen: seen.add(y); els.append(y); q.append(y)
+    return els
+
+def generated_set(gens): return set(enumerate_group(gens))
+def greedy_generators(group):
+    group=list(group); I=tuple(range(len(group[0]))); gens=[]; cur={I}
+    for x in group:
+        if x in cur: continue
+        gens.append(x); cur=generated_set(gens)
+        if len(cur)==len(group): break
+    assert len(cur)==len(group)
+    return gens
+
+def point_model():
+    points=sorted({canon(x) for x in product(range(Q), repeat=4) if any(x)}); idx={p:i for i,p in enumerate(points)}
+    vectors=[(1,0,0,0),(0,1,0,0),(0,0,1,0),(0,0,0,1),(1,1,0,0)]
+    gens=[]
+    for v in vectors:
+        perm=[]
+        for p in points:
+            s=symp(p,v); image=tuple((p[i]+s*v[i])%Q for i in range(4)); perm.append(idx[canon(image)])
+        gens.append(tuple(perm))
+    outer=tuple(idx[canon((p[0],p[1],2*p[2],2*p[3]))] for p in points)
+    return points,tuple(gens),outer
+
+def least_period(c):
+    n=len(c)
+    for d in range(1,n):
+        if n%d==0 and all(c[i]==c[i%d] for i in range(n)): return d
+    return n
+
+def canonical_rotation(c): return min(c[i:]+c[:i] for i in range(len(c)))
+def rotate(c,r): return c[r:]+c[:r]
+
+def generate_rooted(neigh,n,e0):
+    first,second=e0; out=[]; path=[first,second]
+    def dfs():
+        if len(path)==n:
+            if first in neigh[path[-1]] and first!=path[-2] and second!=path[-1]:
+                c=tuple(path)
+                if least_period(c)==n: out.append(c)
+            return
+        prev,cur=path[-2],path[-1]
+        for nxt in neigh[cur]:
+            if nxt!=prev:
+                path.append(nxt); dfs(); path.pop()
+    dfs(); return out
+
+class DSU:
+    def __init__(self,n): self.p=list(range(n)); self.sz=[1]*n
+    def find(self,x):
+        p=self.p
+        while p[x]!=x:
+            p[x]=p[p[x]]; x=p[x]
+        return x
+    def union(self,a,b):
+        a=self.find(a); b=self.find(b)
+        if a==b:return
+        if self.sz[a]<self.sz[b]:a,b=b,a
+        self.p[b]=a; self.sz[a]+=self.sz[b]
+
+def classify_length(n, points, pgens, outer, neigh, Pgroup):
+    directed=[(i,j) for i in range(40) for j in neigh[i]]; assert len(directed)==480
+    e0=directed[0]
+    t=time.time(); cycles=generate_rooted(neigh,n,e0); print('n',n,'rooted',len(cycles),'generate',time.time()-t,flush=True)
+    key_to_idx={c:i for i,c in enumerate(cycles)}
+    assert len(key_to_idx)==len(cycles)
+    # transporters e -> e0 from Pgroup
+    trans={}
+    for g in Pgroup:
+        e=(g[e0[0]],g[e0[1]])
+        if e not in trans: trans[e]=invperm(g)
+        if len(trans)==480: break
+    assert len(trans)==480
+    H=[g for g in Pgroup if (g[e0[0]],g[e0[1]])==e0]
+    assert len(H)==54
+    Hgens=greedy_generators(H); print('Hgens',len(Hgens),flush=True)
+    dsu=DSU(len(cycles)); t=time.time()
+    for i,c in enumerate(cycles):
+        for h in Hgens:
+            d=tuple(h[x] for x in c); dsu.union(i,key_to_idx[d])
+        for r in range(1,n):
+            cr=rotate(c,r); e=(cr[0],cr[1]); tr=trans[e]; d=tuple(tr[x] for x in cr); dsu.union(i,key_to_idx[d])
+    print('P unions',time.time()-t,flush=True)
+    roots=defaultdict(list)
+    for i in range(len(cycles)): roots[dsu.find(i)].append(i)
+    pclasses=list(roots.values()); pclasses.sort(key=lambda cl:min(cycles[i] for i in cl))
+    pclass_of={i:k for k,cl in enumerate(pclasses) for i in cl}
+    print('P classes',len(pclasses),flush=True)
+    # outer operation normalized back to e0 using P transporter
+    oe=(outer[e0[0]],outer[e0[1]]); norm=trans[oe]
+    outop=compose(norm,outer)
+    class_dsu=DSU(len(pclasses))
+    for k,cl in enumerate(pclasses):
+        c=cycles[cl[0]]; d=tuple(outop[x] for x in c); class_dsu.union(k,pclass_of[key_to_idx[d]])
+    wroots=defaultdict(list)
+    for k in range(len(pclasses)): wroots[class_dsu.find(k)].append(k)
+    wclasses=list(wroots.values()); wclasses.sort(key=lambda ks:min(cycles[pclasses[k][0]] for k in ks))
+    print('W classes',len(wclasses),flush=True)
+    # Orbit sizes follow from the rooted-edge slice by double counting:
+    # |O|*n rooted positions, uniformly distributed over 480 directed edges.
+    precords=[]
+    for cl in pclasses:
+        rep=min(cycles[i] for i in cl); osz=len(cl)*480//n; assert len(cl)*480%n==0
+        stab=25920//osz; assert 25920%osz==0
+        precords.append({'representative':list(rep),'orbit_size':osz,'stabilizer_order':stab,'rooted_slice_size':len(cl),'simple_vertex_cycle':len(set(rep))==n,'vertex_multiplicity_partition':sorted(Counter(rep).values(),reverse=True)})
+    print('P sizes sum',sum(r['orbit_size'] for r in precords),flush=True)
+    wrecords=[]
+    for ks in wclasses:
+        reps=[min(cycles[i] for i in pclasses[k]) for k in ks]; rep=min(reps); rooted_count=sum(len(pclasses[k]) for k in ks)
+        osz=rooted_count*480//n; assert rooted_count*480%n==0
+        stab=51840//osz; assert 51840%osz==0
+        wrecords.append({'representative':list(rep),'orbit_size':osz,'stabilizer_order':stab,'rooted_slice_size':rooted_count,'PSp_orbit_count_fused':len(ks),'PSp_orbit_indices':ks,'simple_vertex_cycle':len(set(rep))==n,'vertex_multiplicity_partition':sorted(Counter(rep).values(),reverse=True)})
+    print('W sizes sum',sum(r['orbit_size'] for r in wrecords),flush=True)
+    return {
+      'length':n,'rooted_at_canonical_directed_edge':len(cycles),
+      'primitive_oriented_rotation_classes':sum(r['orbit_size'] for r in precords),
+      'PSp(4,3)':{'orbit_count':len(precords),'orbit_size_distribution':dict(Counter(r['orbit_size'] for r in precords)),'stabilizer_order_distribution':dict(Counter(r['stabilizer_order'] for r in precords)),'orbits':precords},
+      'W(E6)':{'orbit_count':len(wrecords),'orbit_size_distribution':dict(Counter(r['orbit_size'] for r in wrecords)),'stabilizer_order_distribution':dict(Counter(r['stabilizer_order'] for r in wrecords)),'orbits':wrecords},
+      'fusion_distribution':dict(Counter(len(ks) for ks in wclasses))
+    }
+
+def main():
+    points,pgens,outer=point_model(); Pgroup=enumerate_group(pgens); assert len(Pgroup)==25920
+    neigh=tuple(tuple(j for j,y in enumerate(points) if j!=i and symp(x,y)==0) for i,x in enumerate(points)); assert {len(x) for x in neigh}=={12}
+    results={}
+    expected={7:2739840,8:26750160}
+    for n in (7,8):
+        r=classify_length(n,points,pgens,outer,neigh,Pgroup); assert r['primitive_oriented_rotation_classes']==expected[n]; results[str(n)]=r
+    def code(rep):
+        value=0
+        for i,v in enumerate(rep): value |= int(v) << (6*i)
+        return format(value,'x')
+    compact={'schema':'w33.pass1221.literal_cycle_orbits_7_8.v1','status':'PASS','headline':'Literal primitive tailless nonbacktracking cycle orbits are classified at lengths seven and eight.','encoding':'hex packs vertex_i in bits [6i,6i+5]','lengths':{}}
+    for n,d in results.items():
+        row={'primitive_oriented_rotation_classes':d['primitive_oriented_rotation_classes'],'rooted_at_canonical_directed_edge':d['rooted_at_canonical_directed_edge'],'fusion_distribution':d['fusion_distribution']}
+        for group_name in ('PSp(4,3)','W(E6)'):
+            gd=d[group_name]; records=[]
+            for orbit in gd['orbits']:
+                item=[code(orbit['representative']),orbit['orbit_size'],orbit['stabilizer_order'],int(orbit['simple_vertex_cycle']),''.join(map(str,orbit['vertex_multiplicity_partition']))]
+                if group_name=='W(E6)': item.extend([orbit['PSp_orbit_count_fused'],orbit['PSp_orbit_indices']])
+                records.append(item)
+            row[group_name]={'orbit_count':gd['orbit_count'],'orbit_size_distribution':gd['orbit_size_distribution'],'stabilizer_order_distribution':gd['stabilizer_order_distribution'],'records':records}
+        compact['lengths'][n]=row
+    full_compact=compact
+    digest_source=json.dumps(full_compact,separators=(',',':'),sort_keys=True).encode()
+    records_sha256=hashlib.sha256(digest_source).hexdigest()
+    summary={'schema':full_compact['schema'],'status':'PASS','headline':full_compact['headline'],
+             'encoding':full_compact['encoding'],'records_sha256':records_sha256,
+             'boundary':'Checked-in certificate is compact. --full-output deterministically emits every representative and fusion record.',
+             'lengths':{}}
+    for n,row in full_compact['lengths'].items():
+        outrow={k:v for k,v in row.items() if k not in ('PSp(4,3)','W(E6)')}
+        for group_name in ('PSp(4,3)','W(E6)'):
+            gd=row[group_name]
+            outrow[group_name]={k:v for k,v in gd.items() if k!='records'}
+            outrow[group_name]['record_count']=len(gd['records'])
+            outrow[group_name]['sample_first']=gd['records'][:3]
+            outrow[group_name]['sample_last']=gd['records'][-3:]
+        summary['lengths'][n]=outrow
+    ROOT=Path(__file__).resolve().parents[1];OUT=ROOT/'data'/'w33_pass1221_literal_cycle_orbits_7_8.json'
+    OUT.parent.mkdir(parents=True,exist_ok=True);OUT.write_text(json.dumps(summary,indent=2,sort_keys=True)+'\n')
+    parser=argparse.ArgumentParser(add_help=False); parser.add_argument('--full-output')
+    args,_=parser.parse_known_args()
+    if args.full_output:
+        target=Path(args.full_output); target.parent.mkdir(parents=True,exist_ok=True)
+        target.write_text(json.dumps(full_compact,indent=2,sort_keys=True)+'\n')
+
+if __name__=='__main__':main()

--- a/analysis/w33_pass1222_a2_normalizer_triality.py
+++ b/analysis/w33_pass1222_a2_normalizer_triality.py
@@ -1,0 +1,39 @@
+import sys,json,hashlib
+from pathlib import Path
+import numpy as np
+from collections import Counter
+import w33_pass1218_1222_exact_core as c
+triples=c.a2_triples();orbits=c.a2_orbits();orbit_of={x:i for i,o in enumerate(orbits) for x in o}
+a,b,_=c.base_data()['a2_triple'];sa=c.reflection_permutation(a);sb=c.reflection_permutation(b)
+
+def orbit_perm(root_perm):
+ act=c.induced_triple_action(root_perm);p=[]
+ for o in orbits:
+  im={orbit_of[int(act[x])] for x in o};assert len(im)==1;p.append(next(iter(im)))
+ return tuple(p)
+pa,pb=orbit_perm(sa),orbit_perm(sb)
+G=c.generated_subgroup([np.array(pa,dtype=np.uint8),np.array(pb,dtype=np.uint8)])
+assert len(G)==6
+color_actions=sorted({tuple([11,12,13].index(int(g[i])) for i in (11,12,13)) for g in G})
+six27_actions=sorted({tuple([2,3,4,5,6,7].index(int(g[i])) for i in range(2,8)) for g in G})
+# Every point in six-set has trivial stabilizer -> regular S3 torsor.
+assert len(six27_actions)==6
+for j in range(6):assert sum(p[j]==j for p in six27_actions)==1
+# color action transitive with point stabilizer order2; C3 subgroup regular.
+orders=[c.permutation_order(np.array(p,dtype=np.uint8)) for p in color_actions]
+c3=[p for p,o in zip(color_actions,orders) if o in (1,3)]
+assert len(c3)==3 and all(len({p[j] for p in c3})==3 for j in range(3))
+out={'schema':'w33.pass1222.a2_normalizer_triality.v1','status':'PASS','base_a2_triple':list(c.base_data()['a2_triple']),
+ 'commutes_with_WE6':all(np.array_equal(c.compose(sa,g),c.compose(g,sa)) and np.array_equal(c.compose(sb,g),c.compose(g,sb)) for g in c.e6_generators()),
+ 'centralizer_product_subgroup':{'structure':'W(E6) x W(A2)','order':51840*6},
+ 'full_A2_subsystem_normalizer':{'order':51840*12,'index_in_W(E8)':696729600//(51840*12),'A2_subsystems':1120},
+ 'S3_generators':{'reflection_a_orbit_permutation':list(pa),'reflection_b_orbit_permutation':list(pb)},
+ 'three_432_carriers':{'orbit_indices':[11,12,13],'S3_image_order':6,'action_permutations':color_actions,'point_stabilizer_order':2,
+   'verdict':'transitive S3 triality action, not a free S3 torsor','orientation_preserving_C3_is_free_transitive':True},
+ 'six_27_carriers':{'orbit_indices':[2,3,4,5,6,7],'action_permutations':six27_actions,'verdict':'regular S3 torsor','stabilizer_order':1},
+ 'two_singletons':{'orbit_indices':[0,1],'reflection_a':list(pa[:2]),'reflection_b':list(pb[:2]),'interpretation':'opposite A2 orientations'},
+ 'correction':'The three 432 colors cannot be an S3 torsor because |S3|=6. They are S3/S2; their C3 rotation subgroup is the torsor. The signed sixfold 27-shell refinement is the genuine S3 torsor.'}
+out['sha256']=hashlib.sha256(json.dumps(out,separators=(',',':'),sort_keys=True).encode()).hexdigest()
+ROOT=Path(__file__).resolve().parents[1];OUT=ROOT/'data'/'w33_pass1222_a2_normalizer_triality.json'
+OUT.parent.mkdir(parents=True,exist_ok=True);OUT.write_text(json.dumps(out,indent=2)+'\n')
+print('PASS 1222 S3 triality / C3 torsor / six-shell S3 torsor')

--- a/data/w33_pass1218_81_sign_twist_intertwiner.json
+++ b/data/w33_pass1218_81_sign_twist_intertwiner.json
@@ -1,0 +1,44 @@
+{
+  "schema": "w33.pass1218.81_sign_twist_intertwiner.v1",
+  "status": "PASS",
+  "headline": "Both Hashimoto 81_plus copies map isomorphically onto the Levi E4 cycle sector over PSp(4,3); the W(E6) extension is 81_minus = 81_plus tensor sign.",
+  "rank_plus_to_E4": 81,
+  "rank_minus_to_E4": 81,
+  "target_scalar_plus": "2",
+  "target_scalar_minus": "1",
+  "plus_projector": {
+    "coefficients": [
+      -1331,
+      -1452,
+      -253,
+      -140,
+      -17,
+      -8,
+      1
+    ],
+    "denominator": -3200
+  },
+  "minus_projector": {
+    "coefficients": [
+      1331,
+      -1210,
+      11,
+      -124,
+      1,
+      -10,
+      1
+    ],
+    "denominator": 2688
+  },
+  "character_twist": {
+    "81_minus_equals_81_plus_tensor_sign": true,
+    "Hom_W_untwisted": 0,
+    "Hom_W_twisted": 1,
+    "Hom_PSp_restriction": 1
+  },
+  "hashes": {
+    "Mp": "91fd0e27b6c9b1237ea0abf481fac86b52c3d634a4945e15676df49ab402f187",
+    "Mm": "8efe13c97b5ebe2177cc29d6ec7cc736b73e8481664b9c36470282c0cee25c9b",
+    "K": "12743b204bf84397ac71f54d069fe05b063caae0e8ccba75fa69716b19539f03"
+  }
+}

--- a/data/w33_pass1219_m3_m21_matrix_units.json
+++ b/data/w33_pass1219_m3_m21_matrix_units.json
@@ -1,0 +1,84 @@
+{
+  "schema": "w33.pass1219.m3_m21_matrix_units.v1",
+  "status": "PASS",
+  "headline": "Carrier-level M3 Steinberg units and orbit-anchored M21 residual units are explicit and satisfy the Wedderburn laws.",
+  "M3": {
+    "carrier_dimension": 1296,
+    "irrep_dimension": 81,
+    "multiplicity": 3,
+    "projector_denominator": 716800,
+    "projector_polynomial": "(K-36I)(K-24I)(K-18I)(K-12I)(K-9I)(K-6I)",
+    "2C_class_size": 36,
+    "projector_hashes": [
+      "41cc1b1c4b67cf5a05afefbba0e6b6c6e4bebc0ddbcc1a491096bda6051ff7f6",
+      "1f1542e111f6bd99f164a325d6c813996c4413b63ab94c84035ab3f62fdc915e",
+      "8924ea42dbe59c5a062d585a30e5709f210cec371adbc2c6b7a5acc04e52d086"
+    ],
+    "color_orbits": [11, 12, 13],
+    "tau_order": 3,
+    "matrix_unit_factorization": "E_ij = (1/716800) * Tau_(j->i) * N_j",
+    "matrix_unit_laws_verified": true
+  },
+  "M21": {
+    "irrep": "20",
+    "multiplicity": 21,
+    "block": "M_21(Q)",
+    "domain_multiplicity_22": 22,
+    "cubic_image_copy": "orbit_08_size_240_20copy_1",
+    "kernel_copy_labels": [
+      "orbit_02_size_27_20copy_1",
+      "orbit_03_size_27_20copy_1",
+      "orbit_04_size_27_20copy_1",
+      "orbit_05_size_27_20copy_1",
+      "orbit_06_size_27_20copy_1",
+      "orbit_07_size_27_20copy_1",
+      "orbit_09_size_270_20copy_1",
+      "orbit_09_size_270_20copy_2",
+      "orbit_09_size_270_20copy_3",
+      "orbit_10_size_270_20copy_1",
+      "orbit_10_size_270_20copy_2",
+      "orbit_10_size_270_20copy_3",
+      "orbit_11_size_432_20copy_1",
+      "orbit_11_size_432_20copy_2",
+      "orbit_11_size_432_20copy_3",
+      "orbit_12_size_432_20copy_1",
+      "orbit_12_size_432_20copy_2",
+      "orbit_12_size_432_20copy_3",
+      "orbit_13_size_432_20copy_1",
+      "orbit_13_size_432_20copy_2",
+      "orbit_13_size_432_20copy_3"
+    ],
+    "matrix_units": {
+      "count": 441,
+      "sha256": "1c733affab714f307e909bee6e4778ec8b010205e14e2431f1b058580b7663dd",
+      "first_ten": [
+        {"i":0,"j":0,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_02_size_27_20copy_1","nonzero":[[0,0,1]]},
+        {"i":0,"j":1,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_03_size_27_20copy_1","nonzero":[[0,1,1]]},
+        {"i":0,"j":2,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_04_size_27_20copy_1","nonzero":[[0,2,1]]},
+        {"i":0,"j":3,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_05_size_27_20copy_1","nonzero":[[0,3,1]]},
+        {"i":0,"j":4,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_06_size_27_20copy_1","nonzero":[[0,4,1]]},
+        {"i":0,"j":5,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_07_size_27_20copy_1","nonzero":[[0,5,1]]},
+        {"i":0,"j":6,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_09_size_270_20copy_1","nonzero":[[0,6,1]]},
+        {"i":0,"j":7,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_09_size_270_20copy_2","nonzero":[[0,7,1]]},
+        {"i":0,"j":8,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_09_size_270_20copy_3","nonzero":[[0,8,1]]},
+        {"i":0,"j":9,"row_label":"orbit_02_size_27_20copy_1","column_label":"orbit_10_size_270_20copy_1","nonzero":[[0,9,1]]}
+      ],
+      "last_ten": [
+        {"i":20,"j":11,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_10_size_270_20copy_3","nonzero":[[20,11,1]]},
+        {"i":20,"j":12,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_11_size_432_20copy_1","nonzero":[[20,12,1]]},
+        {"i":20,"j":13,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_11_size_432_20copy_2","nonzero":[[20,13,1]]},
+        {"i":20,"j":14,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_11_size_432_20copy_3","nonzero":[[20,14,1]]},
+        {"i":20,"j":15,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_12_size_432_20copy_1","nonzero":[[20,15,1]]},
+        {"i":20,"j":16,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_12_size_432_20copy_2","nonzero":[[20,16,1]]},
+        {"i":20,"j":17,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_12_size_432_20copy_3","nonzero":[[20,17,1]]},
+        {"i":20,"j":18,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_13_size_432_20copy_1","nonzero":[[20,18,1]]},
+        {"i":20,"j":19,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_13_size_432_20copy_2","nonzero":[[20,19,1]]},
+        {"i":20,"j":20,"row_label":"orbit_13_size_432_20copy_3","column_label":"orbit_13_size_432_20copy_3","nonzero":[[20,20,1]]}
+      ],
+      "multiplication_law": "E_ij E_kl = delta_(j,k) E_il"
+    },
+    "matrix_unit_laws_verified": true,
+    "gauge_boundary": "Orbit blocks are geometric. Copy indices inside multiplicity-3 transitive carriers are a deterministic Wedderburn gauge, not additional canonical geometry.",
+    "cubic_column_sums": {"0": 2000, "6": 240}
+  }
+}

--- a/data/w33_pass1220_a5_s5_hecke_equality.json
+++ b/data/w33_pass1220_a5_s5_hecke_equality.json
@@ -1,0 +1,20 @@
+{
+  "schema": "w33.pass1220.a5_s5_hecke_equality.v1",
+  "status": "PASS",
+  "headline": "The A5 and S5 stabilizers have exactly the same 26 orbitals on the 432 carrier, hence identical noncommutative Hecke algebras.",
+  "structure_constants_sha256": "46f42fdb10b985e01ca523d6027886c6c2fec3f7687fa5c686c6e8b590eb53e6",
+  "relation_matrix_sha256": "6eaa6c03ded7303e6d9e9e5f0569f2499663b419f7993b88af796136e9cbb94b",
+  "noncommutativity_witness": {
+    "i": 1,
+    "j": 2,
+    "k": 3,
+    "p_ij_k": 0,
+    "p_ji_k": 1
+  },
+  "rank_W_S5": 26,
+  "rank_PSp_A5": 26,
+  "same_orbitals": true,
+  "subdegrees": [1,1,5,5,5,5,5,5,10,10,10,10,20,20,20,20,20,20,20,20,20,30,30,30,30,60],
+  "structure_sum": 11232,
+  "structure_square_sum": 80576
+}

--- a/data/w33_pass1221_literal_cycle_orbits_7_8.json
+++ b/data/w33_pass1221_literal_cycle_orbits_7_8.json
@@ -1,0 +1,52 @@
+{
+  "boundary": "Checked-in certificate is compact. --full-output deterministically emits every representative and fusion record.",
+  "encoding": "hex packs vertex_i in bits [6i,6i+5]",
+  "headline": "Literal primitive tailless nonbacktracking cycle orbits are classified at lengths seven and eight.",
+  "lengths": {
+    "7": {
+      "PSp(4,3)": {
+        "orbit_count": 108,
+        "orbit_size_distribution": {"960": 1, "8640": 2, "25920": 105},
+        "record_count": 108,
+        "sample_first": [["3081002040",960,27,0,"2221"],["d101002040",25920,1,0,"22111"],["d583002040",25920,1,0,"211111"]],
+        "sample_last": [["15698344040",25920,1,1,"1111111"],["1185b584040",25920,1,1,"1111111"],["1581d584040",25920,1,1,"1111111"]],
+        "stabilizer_order_distribution": {"1":105,"3":2,"27":1}
+      },
+      "W(E6)": {
+        "orbit_count": 57,
+        "orbit_size_distribution": {"960":1,"17280":1,"25920":5,"51840":50},
+        "record_count": 57,
+        "sample_first": [["3081002040",960,54,0,"2221",1,[0]],["d101002040",25920,2,0,"22111",1,[1]],["d583002040",25920,2,0,"211111",1,[2]]],
+        "sample_last": [["15317344040",51840,1,1,"1111111",2,[102,103]],["11797344040",51840,1,1,"1111111",2,[104,105]],["1185b584040",51840,1,1,"1111111",2,[106,107]]],
+        "stabilizer_order_distribution": {"1":50,"2":5,"3":1,"54":1}
+      },
+      "fusion_distribution": {"1":6,"2":51},
+      "primitive_oriented_rotation_classes": 2739840,
+      "rooted_at_canonical_directed_edge": 39956
+    },
+    "8": {
+      "PSp(4,3)": {
+        "orbit_count": 1066,
+        "orbit_size_distribution": {"240":1,"480":1,"6480":10,"8640":3,"12960":45,"25920":1006},
+        "record_count": 1066,
+        "sample_first": [["35f081002040",25920,1,0,"22211"],["3560c1002040",25920,1,0,"221111"],["387101002040",25920,1,0,"221111"]],
+        "sample_last": [["3de5d4584040",25920,1,1,"11111111"],["4615d4584040",25920,1,1,"11111111"],["460614584040",12960,2,1,"11111111"]],
+        "stabilizer_order_distribution": {"1":1006,"2":45,"3":3,"4":10,"54":1,"108":1}
+      },
+      "W(E6)": {
+        "orbit_count": 565,
+        "orbit_size_distribution": {"240":1,"480":1,"6480":4,"8640":1,"12960":14,"17280":1,"25920":63,"51840":480},
+        "record_count": 565,
+        "sample_first": [["35f081002040",25920,2,0,"22211",1,[0]],["3560c1002040",25920,2,0,"221111",1,[1]],["387101002040",51840,1,0,"221111",2,[2,3]]],
+        "sample_last": [["39a612584040",51840,1,1,"11111111",2,[1058,1063]],["55a612584040",25920,2,1,"11111111",1,[1059]],["3dc612584040",12960,4,1,"11111111",2,[1060,1062]]],
+        "stabilizer_order_distribution": {"1":480,"2":63,"3":1,"4":14,"6":1,"8":4,"108":1,"216":1}
+      },
+      "fusion_distribution": {"1":64,"2":501},
+      "primitive_oriented_rotation_classes": 26750160,
+      "rooted_at_canonical_directed_edge": 445836
+    }
+  },
+  "records_sha256": "c6fd966ea9f99bd6b69ffdd64864d7cc3f55f13aeff94c28103bdbe6459f052d",
+  "schema": "w33.pass1221.literal_cycle_orbits_7_8.v1",
+  "status": "PASS"
+}

--- a/data/w33_pass1222_a2_normalizer_triality.json
+++ b/data/w33_pass1222_a2_normalizer_triality.json
@@ -1,0 +1,34 @@
+{
+  "schema": "w33.pass1222.a2_normalizer_triality.v1",
+  "status": "PASS",
+  "base_a2_triple": [0,6,31],
+  "commutes_with_WE6": true,
+  "centralizer_product_subgroup": {"structure":"W(E6) x W(A2)","order":311040},
+  "full_A2_subsystem_normalizer": {"order":622080,"index_in_W(E8)":1120,"A2_subsystems":1120},
+  "S3_generators": {
+    "reflection_a_orbit_permutation": [1,0,7,4,3,6,5,2,8,9,10,11,13,12],
+    "reflection_b_orbit_permutation": [1,0,4,6,2,7,3,5,8,9,10,13,12,11]
+  },
+  "three_432_carriers": {
+    "orbit_indices": [11,12,13],
+    "S3_image_order": 6,
+    "action_permutations": [[0,1,2],[0,2,1],[1,0,2],[1,2,0],[2,0,1],[2,1,0]],
+    "point_stabilizer_order": 2,
+    "verdict": "transitive S3 triality action, not a free S3 torsor",
+    "orientation_preserving_C3_is_free_transitive": true
+  },
+  "six_27_carriers": {
+    "orbit_indices": [2,3,4,5,6,7],
+    "action_permutations": [[0,1,2,3,4,5],[1,3,5,0,2,4],[2,4,0,5,1,3],[3,0,4,1,5,2],[4,5,3,2,0,1],[5,2,1,4,3,0]],
+    "verdict": "regular S3 torsor",
+    "stabilizer_order": 1
+  },
+  "two_singletons": {
+    "orbit_indices": [0,1],
+    "reflection_a": [1,0],
+    "reflection_b": [1,0],
+    "interpretation": "opposite A2 orientations"
+  },
+  "correction": "The three 432 colors cannot be an S3 torsor because |S3|=6. They are S3/S2; their C3 rotation subgroup is the torsor. The signed sixfold 27-shell refinement is the genuine S3 torsor.",
+  "sha256": "a793cf7c9601fdeabb3f1b4cdd461d939381459432310edfd9a88ab287936818"
+}

--- a/data/w33_pass_namespace_registry_v2.json
+++ b/data/w33_pass_namespace_registry_v2.json
@@ -23,7 +23,9 @@
     {"range": "1203-1207", "owner": "breakthrough-execution-track", "status": "COMPLETE"},
     {"range": "1208-1212", "owner": "independent-frontier-track", "status": "COMPLETE"},
     {"range": "1213-1217", "owner": "outside-the-box-track", "status": "COMPLETE",
-      "artifacts": {"1213": "Residual commutant geometry memo", "1214": "Residual species prioritization table", "1215": "Projector fingerprint atlas", "1216": "Exact closure scoreboard", "1217": "Breakthrough map"}}
+      "artifacts": {"1213": "Residual commutant geometry memo", "1214": "Residual species prioritization table", "1215": "Projector fingerprint atlas", "1216": "Exact closure scoreboard", "1217": "Breakthrough map"}},
+    {"range": "1218-1222", "owner": "exact-completion-track", "status": "COMPLETE",
+      "artifacts": {"1218": "explicit sign-twisted 81-sector physical intertwiner", "1219": "carrier-level M3 and orbit-anchored M21 matrix units", "1220": "literal equality of A5/PSp and S5/W(E6) Hecke algebras", "1221": "literal primitive cycle orbit classification at lengths seven and eight", "1222": "A2 normalizer S3 triality and torsor boundary"}}
   ],
   "rule": "A pass number is canonical only when registered here."
 }

--- a/tests/test_w33_pass1218_1222.py
+++ b/tests/test_w33_pass1218_1222.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+
+def load(name):
+    return json.loads((ROOT/'data'/name).read_text())
+
+def test_pass1218_sign_twist_intertwiner():
+    d=load('w33_pass1218_81_sign_twist_intertwiner.json')
+    assert d['status']=='PASS'
+    assert d['rank_plus_to_E4']==d['rank_minus_to_E4']==81
+    assert d['target_scalar_plus']=='2' and d['target_scalar_minus']=='1'
+    assert d['character_twist']=={
+        '81_minus_equals_81_plus_tensor_sign':True,
+        'Hom_W_untwisted':0,
+        'Hom_W_twisted':1,
+        'Hom_PSp_restriction':1,
+    }
+
+def test_pass1219_matrix_units():
+    d=load('w33_pass1219_m3_m21_matrix_units.json')
+    assert d['status']=='PASS'
+    assert d['M3']['multiplicity']==3
+    assert d['M3']['projector_denominator']==716800
+    assert d['M3']['matrix_unit_laws_verified']
+    assert d['M21']['multiplicity']==21
+    assert d['M21']['domain_multiplicity_22']==22
+    assert d['M21']['cubic_image_copy']=='orbit_08_size_240_20copy_1'
+    assert len(d['M21']['kernel_copy_labels'])==21
+    assert d['M21']['matrix_units']['count']==21**2
+    assert len(d['M21']['matrix_units']['sha256'])==64
+    assert d['M21']['cubic_column_sums']=={'0':2000,'6':240}
+
+def test_pass1220_hecke_equality():
+    d=load('w33_pass1220_a5_s5_hecke_equality.json')
+    assert d['status']=='PASS'
+    assert d['rank_W_S5']==d['rank_PSp_A5']==26
+    assert d['same_orbitals']
+    assert sum(d['subdegrees'])==432
+    assert d['noncommutativity_witness']['p_ij_k']!=d['noncommutativity_witness']['p_ji_k']
+
+def test_pass1221_literal_cycle_frontier():
+    d=load('w33_pass1221_literal_cycle_orbits_7_8.json')
+    assert d['status']=='PASS'
+    seven=d['lengths']['7']; eight=d['lengths']['8']
+    assert seven['primitive_oriented_rotation_classes']==2739840
+    assert seven['PSp(4,3)']['orbit_count']==108
+    assert seven['W(E6)']['orbit_count']==57
+    assert eight['primitive_oriented_rotation_classes']==26750160
+    assert eight['PSp(4,3)']['orbit_count']==1066
+    assert eight['W(E6)']['orbit_count']==565
+    assert seven['PSp(4,3)']['record_count']==108 and seven['W(E6)']['record_count']==57
+    assert eight['PSp(4,3)']['record_count']==1066 and eight['W(E6)']['record_count']==565
+    assert len(d['records_sha256'])==64
+    assert sum(int(k)*v for k,v in seven['W(E6)']['orbit_size_distribution'].items())==2739840
+    assert sum(int(k)*v for k,v in eight['W(E6)']['orbit_size_distribution'].items())==26750160
+
+def test_pass1222_triality_boundary():
+    d=load('w33_pass1222_a2_normalizer_triality.json')
+    assert d['status']=='PASS'
+    assert d['centralizer_product_subgroup']['order']==311040
+    assert d['full_A2_subsystem_normalizer']['order']==622080
+    assert d['full_A2_subsystem_normalizer']['index_in_W(E8)']==1120
+    assert d['three_432_carriers']['S3_image_order']==6
+    assert d['three_432_carriers']['point_stabilizer_order']==2
+    assert d['three_432_carriers']['orientation_preserving_C3_is_free_transitive']
+    assert d['six_27_carriers']['verdict']=='regular S3 torsor'
+    assert d['six_27_carriers']['stabilizer_order']==1


### PR DESCRIPTION
Superseded by collision-safe renumbering. A parallel `master` commit claimed Passes 1218-1222 during publication; this exact packet is being republished unchanged as Passes 1223-1227.