### PR TITLE
Harden Passes 1400–1404 certificate verification

### DIFF
--- a/.github/workflows/pass1400_1404_five_frontiers.yml
+++ b/.github/workflows/pass1400_1404_five_frontiers.yml
@@ -3,19 +3,23 @@ name: Passes 1400-1404 Five Frontiers
 on:
   push:
     branches:
-      - agent/pass1400-1404-five-frontiers
+      - 'agent/pass1400-1404-*'
     paths:
       - 'analysis/_selector_five_frontiers_impl.py'
       - 'analysis/_selector_five_frontiers_impl.src/**'
       - 'analysis/w33_pass1400_1404_five_frontiers.py'
+      - 'data/w33_pass1400_1404_five_frontiers.json'
+      - 'tools/check_pass1400_1404_worker.py'
       - '.github/workflows/pass1400_1404_five_frontiers.yml'
   pull_request:
+    branches: [master]
     paths:
       - 'analysis/_selector_five_frontiers_impl.py'
       - 'analysis/_selector_five_frontiers_impl.src/**'
       - 'analysis/w33_pass1400_1404_five_frontiers.py'
       - 'data/w33_pass1400_1404_five_frontiers.json'
       - 'tests/test_w33_pass1400_1404_five_frontiers.py'
+      - 'tools/check_pass1400_1404_worker.py'
       - '.github/workflows/pass1400_1404_five_frontiers.yml'
   workflow_dispatch:
 
@@ -33,18 +37,30 @@ jobs:
       matrix:
         worker: ['1400', '1401', '1402', '1403', '1404']
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip
-      - run: python -m pip install --upgrade pip numpy sympy networkx pytest
-      - run: python -m py_compile analysis/_selector_five_frontiers_impl.py analysis/w33_pass1400_1404_five_frontiers.py
+      - run: python -m pip install --disable-pip-version-check numpy sympy networkx pytest
+      - run: python -m py_compile analysis/_selector_five_frontiers_impl.py analysis/w33_pass1400_1404_five_frontiers.py tools/check_pass1400_1404_worker.py
       - run: python analysis/w33_pass1400_1404_five_frontiers.py --worker '${{ matrix.worker }}' --output '/tmp/pass-${{ matrix.worker }}.json'
+      - run: python tools/check_pass1400_1404_worker.py '${{ matrix.worker }}' '/tmp/pass-${{ matrix.worker }}.json'
       - uses: actions/upload-artifact@v4
         with:
           name: pass-${{ matrix.worker }}
           path: /tmp/pass-${{ matrix.worker }}.json
           if-no-files-found: error
+
+  frozen-certificate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --disable-pip-version-check pytest
+      - run: python analysis/w33_pass1400_1404_five_frontiers.py --check
+      - run: pytest -q tests/test_w33_pass1400_1404_five_frontiers.py

--- a/.github/workflows/pass1400_1404_serial.yml
+++ b/.github/workflows/pass1400_1404_serial.yml
@@ -3,8 +3,14 @@ name: Passes 1400-1404 Serial Exact Fallback
 on:
   push:
     branches:
-      - agent/pass1400-1404-five-frontiers
+      - 'agent/pass1400-1404-*'
     paths:
+      - 'analysis/_selector_five_frontiers_impl.py'
+      - 'analysis/_selector_five_frontiers_impl.src/**'
+      - 'analysis/w33_pass1400_1404_five_frontiers.py'
+      - 'data/w33_pass1400_1404_five_frontiers.json'
+      - 'tests/test_w33_pass1400_1404_five_frontiers.py'
+      - 'tools/check_pass1400_1404_worker.py'
       - '.github/workflows/pass1400_1404_serial.yml'
   pull_request:
     branches: [master]
@@ -14,6 +20,7 @@ on:
       - 'analysis/w33_pass1400_1404_five_frontiers.py'
       - 'data/w33_pass1400_1404_five_frontiers.json'
       - 'tests/test_w33_pass1400_1404_five_frontiers.py'
+      - 'tools/check_pass1400_1404_worker.py'
       - '.github/workflows/pass1400_1404_serial.yml'
   workflow_dispatch:
 
@@ -34,14 +41,16 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: python -m pip install --upgrade pip numpy sympy networkx pytest
-      - run: python -m py_compile analysis/_selector_five_frontiers_impl.py analysis/w33_pass1400_1404_five_frontiers.py
+      - run: python -m pip install --disable-pip-version-check numpy sympy networkx pytest
+      - run: python -m py_compile analysis/_selector_five_frontiers_impl.py analysis/w33_pass1400_1404_five_frontiers.py tools/check_pass1400_1404_worker.py
       - name: Run five exact frontiers
         run: |
           mkdir -p /tmp/pass1400-1404
           for worker in 1400 1401 1402 1403 1404; do
             python analysis/w33_pass1400_1404_five_frontiers.py --worker "$worker" --output "/tmp/pass1400-1404/$worker.json"
+            python tools/check_pass1400_1404_worker.py "$worker" "/tmp/pass1400-1404/$worker.json"
           done
+          python analysis/w33_pass1400_1404_five_frontiers.py --check
           pytest -q tests/test_w33_pass1400_1404_five_frontiers.py
       - uses: actions/upload-artifact@v4
         with:

--- a/analysis/BT1400_BT1404_five_frontiers.md
+++ b/analysis/BT1400_BT1404_five_frontiers.md
@@ -6,7 +6,7 @@ Let \(X\) be the 120 line-matching selectors of \(W(3,3)\), let
 \(H\cong C_3^3\rtimes(D_8\times C_2)\) be the stabilizer of one selector, and let
 \(\mathcal A=\operatorname{End}_H(\mathbb Q^X)\) be the 83-dimensional orbital algebra.
 Passes 1370–1384 constructed its rational matrix units, modular radical profiles,
-and complete Mackey decomposition.  This packet executes the five open fronts left
+and complete Mackey decomposition. This packet executes the five open fronts left
 by that work.
 
 ## Pass 1400 — Modular Mackey localization
@@ -32,7 +32,7 @@ The full 83-dimensional orbital algebra independently has radical-power dimensio
 (72,49,27,14,4,0)\quad(p=3),
 \]
 
-and is semisimple at \(p=5\).  Its characteristic-five regular-module factor census is
+and is semisimple at \(p=5\). Its characteristic-five regular-module factor census is
 
 \[
 1^7,\;2^4,\;3^9,\;4^4,\;5^5,
@@ -48,8 +48,8 @@ alone determine modular extensions.
 ## Pass 1401 — Geometry of the six dual orbits
 
 The complement \(D_8\times C_2\) acts on \(\widehat{C_3^3}\cong\mathbb F_3^3\)
-with a unique invariant axis and invariant plane.  In an exact axis-plane basis, the
-plane admits an invariant nonsingular square form.  The six dual orbits are therefore
+with a unique invariant axis and invariant plane. In an exact axis-plane basis, the
+plane admits an invariant nonsingular square form. The six dual orbits are therefore
 intrinsically
 
 \[
@@ -57,7 +57,7 @@ intrinsically
 \]
 
 zero; two pure hinge-charge states; four neutral square-axis states; four neutral
-square-diagonal states; and the two charged lifts of those norm classes.  Their little
+square-diagonal states; and the two charged lifts of those norm classes. Their little
 groups are
 
 \[
@@ -70,13 +70,13 @@ chart and carry no hardware interpretation.
 ## Pass 1402 — Exact selector Fourier transform
 
 A deterministic rational matrix \(U\in GL_{120}(\mathbb Q)\) is formed by taking pivot
-columns from the images of the fourteen exact Mackey projectors.  Its block dimensions are
+columns from the images of the fourteen exact Mackey projectors. Its block dimensions are
 
 \[
 1,2,2,4,4,8,8,2,4,12,12,24,32,5.
 \]
 
-The inverse is verified exactly.  In this basis, the selector adjacency \(A\), shell
+The inverse is verified exactly. In this basis, the selector adjacency \(A\), shell
 operator \(D\), and minimum geometric splitter \(S\) are simultaneously block diagonal
 across all fourteen isotypic sectors.
 
@@ -85,13 +85,13 @@ Frozen transform data:
 - \(U\): 3,758 nonzero entries, maximum numerator 8, maximum denominator 54;
 - \(U^{-1}\): 1,944 nonzero entries, maximum numerator 2, maximum denominator 3.
 
-This is an exact isotypic Fourier transform.  Bases within repeated irreducible copies
+This is an exact isotypic Fourier transform. Bases within repeated irreducible copies
 remain a rational gauge; no canonical tensor-factor basis is asserted.
 
 ## Pass 1403 — Hinge-selected apartment bridge
 
 The selected \(1110_{r0}\) sheet contains 2,160 oriented apartment rows in 160 Levi
-flag coordinates.  It is boundaryless and has rank
+flag coordinates. It is boundaryless and has rank
 
 \[
 \boxed{81},
@@ -100,15 +100,15 @@ flag coordinates.  It is boundaryless and has rank
 so its row space is the complete Levi cycle/Steinberg sector.
 
 Composing this sheet with the selector–rectangle incidence and four side/edge sign
-characters produces four explicit 120-by-160 maps.  Every one is boundaryless and every
-one has rank 81.  For the deterministic `side1_edge1` representative, none of the
+characters produces four explicit 120-by-160 maps. Every one is boundaryless and every
+one has rank 81. For the deterministic `side1_edge1` representative, none of the
 fourteen selector Mackey sectors is killed: each sector contributes its full source
 isotypic dimension, while the combined target remains the common 81-dimensional cycle
 space.
 
 This does not contradict
 \(\operatorname{Hom}_G(\mathbb Q^{120},E_4\mathbb Q^{160})=0\): the hinge and sign
-characters break full \(G\)-equivariance.  The result is a gauge-fixed Steinberg bridge,
+characters break full \(G\)-equivariance. The result is a gauge-fixed Steinberg bridge,
 not a natural Morita equivalence.
 
 ## Pass 1404 — Integral-order commensurability
@@ -120,7 +120,7 @@ M=\mathbb Z^7\oplus M_2(\mathbb Z)^2\oplus M_3(\mathbb Z)^3
 \oplus M_4(\mathbb Z)\oplus M_5(\mathbb Z)
 \]
 
-be the split maximal order selected by the frozen rational matrix units.  Exact Smith
+be the split maximal order selected by the frozen rational matrix units. Exact Smith
 reduction corrects the initial containment guess:
 
 \[
@@ -137,38 +137,38 @@ For \(L=O\cap M\),
 [O:L]=2^2.
 \]
 
-The transition determinant has absolute value \(2^{36}3^{113}\).  The reduced-trace
+The transition determinant has absolute value \(2^{36}3^{113}\). The reduced-trace
 discriminant of the orbital order is
 
 \[
 \boxed{\operatorname{disc}(O)=2^{72}3^{226}}.
 \]
 
-Moreover, \(2O\subset M\), while \(108M\subset O\).  The rational Smith factors are
+Moreover, \(2O\subset M\), while \(108M\subset O\). The rational Smith factors are
 
 ```text
 (1/2)^2, 1^21, 3^22, 9^6, 18^17, 54^9, 108^6.
 ```
 
 Thus only 2 and 3 obstruct maximality; the selected orders agree locally at 5.
-This is a commensurability theorem for the frozen matrix-unit gauge.  Constructing a
+This is a commensurability theorem for the frozen matrix-unit gauge. Constructing a
 conjugate maximal overorder containing \(O\) at 2 and 3 remains open.
 
 ## Reproducibility
 
-Five isolated exact workers regenerate the five certificates.  Focused tests verify the
-frozen packet and every embedded SHA-256.  The transparent verifier is split into source
+Five isolated exact workers regenerate the five certificates. Focused tests verify the
+frozen packet and every embedded SHA-256. The transparent verifier is split into source
 fragments solely to avoid transport truncation; the loader concatenates and compiles them
 verbatim.
 
-Frozen combined certificate SHA-256:
+Frozen compact certificate SHA-256:
 
 ```text
-a2e8a580576d6c38cb584f402c1d16ee49a029a4fe545cf239d39043fc890afd
+6a6f5e3fb2eb441214057186c974573e99e983e9b665994842538b2647587b2b
 ```
 
 ## Boundary
 
 These are exact finite-group, rational-algebra, modular-algebra, incidence, and integral-
-order results.  No literature-priority, Standard-Model, cosmological, optical-hardware,
+order results. No literature-priority, Standard-Model, cosmological, optical-hardware,
 or laboratory claim is made.

--- a/tests/test_w33_pass1400_1404_five_frontiers.py
+++ b/tests/test_w33_pass1400_1404_five_frontiers.py
@@ -2,10 +2,12 @@ import hashlib,json
 from pathlib import Path
 ROOT=Path(__file__).resolve().parents[1]
 CERT=ROOT/'data'/'w33_pass1400_1404_five_frontiers.json'
+REPORT=ROOT/'analysis'/'BT1400_BT1404_five_frontiers.md'
+DIGEST='6a6f5e3fb2eb441214057186c974573e99e983e9b665994842538b2647587b2b'
 def load(): return json.loads(CERT.read_text())
 def test_frozen():
  d=load(); assert d['schema']=='w33.pass1400_1404.five_frontiers.v1' and d['status']=='PASS'
- assert hashlib.sha256(CERT.read_bytes()).hexdigest()=='6a6f5e3fb2eb441214057186c974573e99e983e9b665994842538b2647587b2b'
+ assert hashlib.sha256(CERT.read_bytes()).hexdigest()==DIGEST
  assert set(d['workers'])=={'1400','1401','1402','1403','1404'}
 def test_1400():
  p=load()['pass1400']; assert p['localization']['2']=={'collapsed_projectors':13,'localizable_projectors':1}
@@ -29,3 +31,8 @@ def test_1404():
 def test_sources():
  parts=sorted((ROOT/'analysis'/'_selector_five_frontiers_impl.src').glob('part*.pyfrag'))
  assert len(parts)==9 and sum(len(p.read_text().splitlines()) for p in parts)==678
+def test_report_digest_is_current():
+ text=REPORT.read_text()
+ assert DIGEST in text
+ assert 'a2e8a580576d6c38cb584f402c1d16ee49a029a4fe545cf239d39043fc890afd' not in text
+ assert (ROOT/'tools'/'check_pass1400_1404_worker.py').exists()

--- a/tools/check_pass1400_1404_worker.py
+++ b/tools/check_pass1400_1404_worker.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+worker = sys.argv[1]
+observed_path = Path(sys.argv[2])
+assert worker in {'1400','1401','1402','1403','1404'}
+cert = json.loads((ROOT/'data'/'w33_pass1400_1404_five_frontiers.json').read_text())
+observed = json.loads(observed_path.read_text())
+assert observed['canonical_pass'] == worker
+assert observed['sha256'] == cert['workers'][worker]
+
+if worker == '1400':
+    frozen = cert['pass1400']
+    assert observed['projector_denominator_lcms'] == frozen['denominators']
+    assert observed['localization'] == frozen['localization']
+    assert {p: observed['full_orbital_modular_profiles'][p]['radical_power_dimensions'] for p in ('2','3','5')} == frozen['radicals']
+    assert observed['characteristic5_regular_factor_census'] == frozen['p5_factors']
+elif worker == '1401':
+    frozen = cert['pass1401']
+    assert observed['invariant_dual_axis'] == frozen['axis']
+    assert observed['invariant_dual_plane_basis'] == frozen['plane_basis']
+    assert observed['plane_quadratic_form'] == frozen['quadratic_form']
+    assert [x['size'] for x in observed['orbit_classification']] == frozen['sizes']
+    assert [x['signature'] for x in observed['orbit_classification']] == frozen['signatures']
+elif worker == '1402':
+    frozen = cert['pass1402']
+    assert observed['block_dimensions'] == frozen['blocks']
+    assert observed['forward_basis_U']['sha256'] == frozen['U']['sha']
+    assert observed['inverse_transform_Uinv']['sha256'] == frozen['Uinv']['sha']
+    assert {k: observed['operators'][k]['sha256'] for k in ('A','D','S')} == frozen['operators']
+elif worker == '1403':
+    frozen = cert['pass1403']
+    assert [observed['apartment_rows'], observed['levi_flag_columns'], observed['sheet_rank'], observed['sheet_boundaryless']] == frozen['sheet']
+    assert {k: [v['rank'], v['boundaryless'], v['sha256']] for k,v in observed['bridge_scan'].items()} == frozen['bridges']
+    assert [x['bridge_rank'] for x in observed['mackey_sector_bridge_ranks']] == frozen['mackey_ranks']
+elif worker == '1404':
+    frozen = cert['pass1404']
+    assert [observed['O_contained_in_selected_M'], observed['selected_M_contained_in_O']] == frozen['containment']
+    assert [observed['index_M_over_intersection'], observed['index_O_over_intersection']] == frozen['intersection_indices']
+    assert [observed['level_O_to_M'], observed['level_M_to_O']] == frozen['levels']
+    assert observed['orbital_reduced_trace_discriminant'] == frozen['disc']
+    assert observed['discriminant_factorization'] == frozen['disc_factors']
+    assert observed['smith_rational_factor_census'] == frozen['smith']
+
+print(f'PASS worker {worker} matches frozen compact certificate')


### PR DESCRIPTION
## Fix

Correct the reviewer report to cite the merged compact certificate SHA-256 `6a6f5e3fb2eb441214057186c974573e99e983e9b665994842538b2647587b2b` instead of the superseded pre-compaction hash.

## Fail-closed verification

- add `tools/check_pass1400_1404_worker.py`;
- compare every regenerated exact worker SHA and load-bearing invariant with the frozen compact certificate;
- apply the checker in both matrix and serial workflows;
- add a regression preventing future report/certificate drift.

The five canonical worker hashes were independently recomputed from the completed local exact runs and match the merged certificate exactly.