### PR TITLE
Passes 1500–1504: five exact selector continuation frontiers

### DIFF
--- a/.github/workflows/pass1500_1504_five_frontiers.yml
+++ b/.github/workflows/pass1500_1504_five_frontiers.yml
@@ -1,0 +1,59 @@
+name: Passes 1500-1504 Five Exact Frontiers
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'analysis/pass1500_1504/**'
+      - 'analysis/w33_pass1500_1504_five_frontiers.py'
+      - 'analysis/BT1500_BT1504_five_frontiers.*'
+      - 'data/w33_pass1500_1504_five_frontiers.json'
+      - 'tests/test_w33_pass1500_1504_five_frontiers.py'
+      - 'tools/check_pass1500_1504_worker.py'
+      - 'tools/assemble_pass1500_1504_certificate.py'
+      - '.github/workflows/pass1500_1504_five_frontiers.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  OPENBLAS_NUM_THREADS: '1'
+  OMP_NUM_THREADS: '1'
+
+jobs:
+  static-certificate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - run: python -m pip install --disable-pip-version-check pytest numpy sympy networkx
+      - run: python -m py_compile analysis/pass1500_1504/*.py analysis/w33_pass1500_1504_five_frontiers.py tools/check_pass1500_1504_worker.py tools/assemble_pass1500_1504_certificate.py
+      - run: pytest -q tests/test_w33_pass1500_1504_five_frontiers.py
+      - run: python analysis/w33_pass1500_1504_five_frontiers.py --check
+
+  exact-worker:
+    strategy:
+      fail-fast: false
+      matrix:
+        worker: ['1500', '1501', '1502', '1503', '1504']
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - run: python -m pip install --disable-pip-version-check numpy sympy networkx pytest
+      - run: python analysis/w33_pass1500_1504_five_frontiers.py --worker '${{ matrix.worker }}' --output '/tmp/pass${{ matrix.worker }}.json'
+      - run: python tools/check_pass1500_1504_worker.py '${{ matrix.worker }}' '/tmp/pass${{ matrix.worker }}.json' data/w33_pass1500_1504_five_frontiers.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pass-${{ matrix.worker }}
+          path: /tmp/pass${{ matrix.worker }}.json
+          if-no-files-found: error

--- a/analysis/BT1500_BT1504_five_frontiers.md
+++ b/analysis/BT1500_BT1504_five_frontiers.md
@@ -1,0 +1,112 @@
+# Passes 1500–1504: Five Exact Continuation Frontiers
+
+**Status:** exact local workers complete; compact certificate frozen; fail-closed remote replication supplied.  
+**Compact certificate SHA-256:** `757b01bacbfc157484851ec76cc3322204116c3aeb9cdf81851a2dbee1a56b3e`
+
+## Pass 1500 — Exact modular Gabriel Ext¹ quivers
+
+For the 83-dimensional selector orbital algebra, the bad-characteristic simple modules and every ordered Ext¹ space were computed directly from derivations modulo inner derivations.
+
+At \(p=2\), there are 13 simple vertices, the Ext¹ arrow-dimension sum is 15, and the regular Loewy data are
+
+\[
+J^r:\ 45,16,0,
+\qquad
+A/J\leftarrow J/J^2\leftarrow J^2:\ 38,29,16.
+\]
+
+At \(p=3\), there are five simple vertices and
+
+\[
+\dim\operatorname{Ext}^1(S_i,S_j)=
+\begin{pmatrix}
+2&0&1&0&1\\
+0&3&0&1&1\\
+1&0&0&0&0\\
+0&1&0&0&0\\
+1&1&0&0&1
+\end{pmatrix},
+\]
+
+with radical powers \((72,49,27,14,4,0)\). Higher Yoneda relations are not inferred from Ext¹.
+
+## Pass 1501 — Tensor-factor selector Fourier transform
+
+The fourteen Mackey isotypic sectors are refined deterministically to
+
+\[
+\mathbb Q^{m_\chi}\otimes V_\chi,
+\]
+
+with \((m_\chi,\dim V_\chi)\)
+
+\[
+(1,1),(1,2),(1,2),(1,4),(1,4),(1,8),(1,8),
+(2,1),(2,2),(3,4),(3,4),(3,8),(4,8),(5,1).
+\]
+
+All 83 orbital operators act as \(M_\chi\otimes I_{V_\chi}\). The exact basis and inverse hashes are
+
+- \(U\): `58b5c1cdc2aefd67a4efde0221f4a708b8e1267b5eb4bad8e1a586bf02ff84b7`
+- \(U^{-1}\): `bb75dd295832c7a76fd0a72268ac328fbd437676670bef6ecc64cb1fb12fc160`
+
+The pivot rule is canonical relative to the frozen orbital coordinates and matrix units, not under arbitrary input gauge changes.
+
+## Pass 1502 — Complete apartment-bridge census
+
+All \(8\times3\times4=96\) mask/residual/sign gauges were exhausted:
+
+\[
+\text{sheet ranks}:70^4,76^1,81^{19},
+\qquad
+\text{bridge ranks}:70^{16},76^4,81^{76}.
+\]
+
+Every rank-81 sheet is exactly the full Levi cycle/Steinberg rowspace. Among the 76 rank-complete bridges, 57 retain all fourteen Mackey sources at full dimension and 19 lose exactly one dimension in the terminal five-dimensional source sector.
+
+## Pass 1503 — Explicit maximal overorder containing the orbital order
+
+Using the stable lattices \(Oe_b\) in one minimal left ideal of every split Wedderburn block gives
+
+\[
+M_O=\bigoplus_b\operatorname{End}_{\mathbb Z}(Oe_b),
+\qquad O\subset M_O.
+\]
+
+The exact index is
+
+\[
+[M_O:O]=2^{36}3^{113},
+\]
+
+and
+
+\[
+\operatorname{disc}(M_O)=1,
+\qquad
+\operatorname{disc}(O)=[M_O:O]^2.
+\]
+
+This is a different conjugate maximal order from the previously frozen matrix-unit order; containment is verified objectwise.
+
+## Pass 1504 — Full apartment linking algebra
+
+The 76 rank-complete bridges span a 75-dimensional off-diagonal space. Their unique relation is exact over \(\mathbb Z\), supported on twelve side-0/edge-1 bridges in the four weight-three masks across all residuals.
+
+Collectively the bridges cover all 120 selector coordinates and detect all 81 cycle coordinates. Their pairing corners generate
+
+\[
+M_{120},\qquad M_{81},
+\]
+
+and the closed bimodule has dimension \(120\cdot81=9720\). Therefore the linking envelope has dimension
+
+\[
+120^2+81^2+2(120\cdot81)=201^2=40401,
+\]
+
+so it is the full \(M_{201}\) and gives a strict gauge-fixed Morita context. This does not promote the construction to a natural full-\(G\)-equivariant Morita equivalence.
+
+## Verification boundary
+
+The five canonical worker hashes are frozen in `data/w33_pass1500_1504_five_frontiers.json`. Local exact executions produced those hashes. The workflow independently regenerates each worker and rejects any mismatch. Queued or unobserved remote jobs are not represented as successful evidence.

--- a/analysis/BT1500_BT1504_five_frontiers.tex
+++ b/analysis/BT1500_BT1504_five_frontiers.tex
@@ -1,0 +1,18 @@
+\subsection{Five exact selector continuation frontiers}\label{sec:pass1500-1504}
+The selector orbital algebra admits five further exact refinements.  In characteristics two and three, direct derivation calculations determine the complete Gabriel $\operatorname{Ext}^1$ quivers, with radical-power dimensions $(45,16,0)$ and $(72,49,27,14,4,0)$, respectively.  Over $\mathbb Q$, the fourteen Mackey sectors possess a deterministic tensor-factor basis in which every orbital operator acts as $M_\chi\otimes I_{V_\chi}$.
+
+The complete $96$-member apartment gauge family has bridge-rank distribution
+\[
+70^{16},\qquad 76^4,\qquad 81^{76},
+\]
+and every rank-$81$ sheet is the full Levi cycle, or Steinberg, space.  A maximal split overorder containing the integral orbital order is constructed from the stable minimal-left-ideal lattices $Oe_b$; it satisfies
+\[
+[M_O:O]=2^{36}3^{113},\qquad \operatorname{disc}(M_O)=1,
+\qquad \operatorname{disc}(O)=[M_O:O]^2.
+\]
+Finally, the $76$ rank-complete bridges span a $75$-dimensional off-diagonal space and generate full pairing corners $M_{120}$ and $M_{81}$.  The resulting linking envelope is
+\[
+M_{120}\oplus \operatorname{Hom}(81,120)\oplus
+\operatorname{Hom}(120,81)\oplus M_{81}\cong M_{201}.
+\]
+This is a strict gauge-fixed Morita context.  It is not asserted to be a natural full-$G$-equivariant equivalence.  Exact worker hashes and all load-bearing ranks are frozen in the Passes~1500--1504 certificate.

--- a/analysis/pass1500_1504/__init__.py
+++ b/analysis/pass1500_1504/__init__.py
@@ -1,0 +1,1 @@
+"""Exact Passes 1500--1504 continuation package."""

--- a/analysis/pass1500_1504/bridge_classification.py
+++ b/analysis/pass1500_1504/bridge_classification.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import collections,hashlib,itertools
+import numpy as np
+import _selector_five_frontiers_impl as ff
+import bt713_selector_sheet_rank_filter as sheet713
+from .common import GOOD,capture,rank_mod,sha
+MASKS=((1,1,1,0),(1,1,0,1),(1,0,1,1),(0,1,1,1),(1,1,0,0),(1,0,0,1),(0,1,1,0),(0,0,1,1))
+def perfect_matchings4(line):
+ a,b,c,d=tuple(line);return tuple(sorted([tuple(sorted((tuple(sorted((a,b))),tuple(sorted((c,d)))))),tuple(sorted((tuple(sorted((a,c))),tuple(sorted((b,d)))))),tuple(sorted((tuple(sorted((a,d))),tuple(sorted((b,c))))))]))
+def matching_for_pair(matchings,pair):
+ pair=tuple(sorted(pair));hits=[i for i,M in enumerate(matchings) if pair in M];assert len(hits)==1;return hits[0]
+def d4_permutations():
+ out=set()
+ for k in range(4):out.add(tuple((i+k)%4 for i in range(4)));out.add(tuple((k-i)%4 for i in range(4)))
+ assert len(out)==8;return sorted(out)
+def permute_mask(mask,perm):return tuple(mask[perm[i]] for i in range(4))
+def build_all_sheets():
+ adj,lines,through,edge_line,centers,flag_index=sheet713.build();line_matchings=[perfect_matchings4(line) for line in lines];sheet_rows={(m,r):[] for m in MASKS for r in range(3)};rectangles=[]
+ for c in range(40):
+  for li,lj in itertools.combinations(through[c],2):
+   A=tuple(sorted(set(lines[li])-{c}));B=tuple(sorted(set(lines[lj])-{c}))
+   for aa in itertools.combinations(A,2):
+    for bb in itertools.combinations(B,2):
+     rect_edges=[tuple(sorted(e)) for e in [(aa[0],bb[0]),(aa[1],bb[0]),(aa[1],bb[1]),(aa[0],bb[1])]];per_mask=collections.defaultdict(list)
+     for gauges in itertools.product(*(centers[e] for e in rect_edges)):
+      paths=[sheet713.path_edges(x,y,q,edge_line) for (x,y),q in zip(rect_edges,gauges)];cycle=sheet713.xor_path_edges(paths)
+      if sheet713.is_simple_levi_8_cycle(cycle):
+       mask=tuple(1 if q==c else 0 for q in gauges);row=sheet713.oriented_sparse_row(cycle,flag_index);per_mask[mask].append((tuple(sorted(cycle)),row))
+     assert set(per_mask)==set(MASKS)
+     for mask in MASKS:
+      vals=sorted(per_mask[mask],key=lambda t:t[0]);assert len(vals)==3
+      for r,(_cycle,row) in enumerate(vals):sheet_rows[(mask,r)].append(row)
+     mi=matching_for_pair(line_matchings[li],aa);mj=matching_for_pair(line_matchings[lj],bb);edge_i=line_matchings[li][mi].index(tuple(sorted(aa)));edge_j=line_matchings[lj][mj].index(tuple(sorted(bb)));rectangles.append((3*li+mi,3*lj+mj,edge_i,edge_j))
+ assert len(rectangles)==2160 and all(len(rows)==2160 for rows in sheet_rows.values());return sheet_rows,rectangles,flag_index
+def dense_sheet(rows):
+ S=np.zeros((2160,160),dtype=np.int64)
+ for i,row in enumerate(rows):
+  for c,v in row:S[i,c]=v
+ return S
+def bridge(S,rectangles,side_char,edge_char):
+ B=np.zeros((120,160),dtype=np.int64)
+ for row,(si,sj,ei,ej) in zip(S,rectangles):
+  wi=-1 if edge_char and ei else 1;wj=-1 if side_char else 1
+  if edge_char and ej:wj*=-1
+  B[si]+=wi*row;B[sj]+=wj*row
+ return B
+def analyze():
+ _public,cap=capture();g=cap['g'];sheet_rows,rectangles,flag_index=build_all_sheets();Dlevi=ff.levi_boundary(flag_index);projectors=[(item,ff.orbital_matrix_mod(g,item['projector'],GOOD)) for item in sorted(cap['character_projectors'],key=lambda x:x['block_index'])]
+ d4=d4_permutations();mask_records={}
+ for mask in MASKS:
+  orbit=sorted({permute_mask(mask,p) for p in d4});stabilizer=sum(permute_mask(mask,p)==mask for p in d4);mask_records[''.join(map(str,mask))]={'d4_orbit':[''.join(map(str,x)) for x in orbit],'d4_orbit_size':len(orbit),'d4_stabilizer_order':stabilizer,'weight':sum(mask)}
+ reference=dense_sheet(sheet_rows[((1,1,1,0),0)]);assert rank_mod(reference)==81
+ sheets=[];bridges=[];class_counter=collections.Counter();sheet_rank_counter=collections.Counter();bridge_rank_counter=collections.Counter()
+ for mask in MASKS:
+  for residual in range(3):
+   S=dense_sheet(sheet_rows[(mask,residual)]);srank=rank_mod(S);assert not np.any(Dlevi@S.T);same_e4=srank==81 and rank_mod(np.vstack([reference,S]))==81;sheet_rank_counter[srank]+=1;sheet_key=f"{''.join(map(str,mask))}_r{residual}";sheet_bridges=[]
+   for side_char,edge_char in itertools.product((0,1),repeat=2):
+    B=bridge(S,rectangles,side_char,edge_char);brank=rank_mod(B);assert not np.any(Dlevi@B.T);sector_ranks=[]
+    for item,P in projectors:sector_ranks.append(rank_mod(P@(B%GOOD)%GOOD))
+    rec={'sheet':sheet_key,'mask':''.join(map(str,mask)),'residual':residual,'side_character':side_char,'edge_character':edge_char,'sheet_rank':srank,'bridge_rank':brank,'boundaryless':True,'same_steinberg_rowspace':same_e4,'mackey_sector_ranks':sector_ranks,'nonzero':int(np.count_nonzero(B)),'max_abs_entry':int(np.max(np.abs(B))),'sha256':hashlib.sha256(B.astype(np.int64).tobytes()).hexdigest()};bridges.append(rec);sheet_bridges.append(rec['sha256']);bridge_rank_counter[brank]+=1;class_counter[(srank,brank,tuple(sector_ranks),rec['nonzero'],rec['max_abs_entry'])]+=1
+   sheets.append({'sheet':sheet_key,'mask':''.join(map(str,mask)),'residual':residual,'rank':srank,'boundaryless':True,'same_steinberg_rowspace':same_e4,'bridge_hashes':sheet_bridges})
+ classes=[]
+ for key,count in sorted(class_counter.items(),key=lambda x:str(x[0])):
+  srank,brank,sector_ranks,nonzero,max_abs=key;classes.append({'sheet_rank':srank,'bridge_rank':brank,'mackey_sector_ranks':list(sector_ranks),'nonzero':nonzero,'max_abs_entry':max_abs,'count':count})
+ assert all(b['bridge_rank']==b['sheet_rank'] for b in bridges)
+ full=[b for b in bridges if b['bridge_rank']==81]
+ profile_counter=collections.Counter(tuple(b['mackey_sector_ranks']) for b in full)
+ profile_census=[{'mackey_sector_ranks':list(profile),'count':count} for profile,count in sorted(profile_counter.items())]
+ result={'theorem':'Pass 1502 Complete Rank-81 Apartment-Bridge Classification','family_size':96,'sheet_count':24,'sign_characters_per_sheet':4,'mask_d4_data':mask_records,'sheet_rank_distribution':{str(k):v for k,v in sorted(sheet_rank_counter.items())},'bridge_rank_distribution':{str(k):v for k,v in sorted(bridge_rank_counter.items())},'sign_characters_preserve_sheet_rank_for_all_96_bridges':True,'rank81_sheet_count':sum(x['rank']==81 for x in sheets),'rank81_bridge_count':len(full),'all_rank81_sheets_equal_full_levi_cycle_space':all(x['same_steinberg_rowspace'] for x in sheets if x['rank']==81),'rank81_mackey_profile_census':profile_census,'rank81_bridges_full_on_all_14_mackey_sources':sum(b['mackey_sector_ranks'][-1]==5 for b in full),'rank81_bridges_with_one_dimension_lost_in_terminal_5_space':sum(b['mackey_sector_ranks'][-1]==4 for b in full),'classification_classes':classes,'sheets':sheets,'bridges':bridges,'conclusion':'All 96 gauge bridges are exhausted. Every sign character preserves its sheet rank. Exactly 76 bridges have rank 81 and every such sheet is the full Levi Steinberg row space; 57 are full on all fourteen Mackey source sectors, while 19 lose one dimension only in the terminal five-dimensional source sector.','boundary':'D4 acts intrinsically on local mask positions, but the globally ordered rectangle atlas is not D4-invariant: members of one local mask orbit can have different global ranks. Residual labels are deterministic cycle orderings; no unverified S3 action is asserted.'};result['sha256']=sha(result);return result

--- a/analysis/pass1500_1504/common.py
+++ b/analysis/pass1500_1504/common.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import hashlib, json, math
+from pathlib import Path
+import numpy as np
+import sympy as sp
+import _selector_five_frontiers_impl as ff
+from pass1370_1374 import core, modular_radicals
+GOOD=1_000_003
+ROOT=Path(__file__).resolve().parents[2]
+def sha(payload):
+    raw=json.dumps(payload,sort_keys=True,separators=(",",":"),default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()
+def capture(): return ff.capture_mackey()
+def rank_mod(A,p=GOOD): return ff.rank_mod(np.asarray(A,dtype=np.int64),p)
+def rref_key(A,p):
+    A=np.asarray(A,dtype=np.int64)%p
+    if A.size==0:return ()
+    R,_=modular_radicals.rref(A,p)
+    return tuple(tuple(int(x) for x in row) for row in R if np.any(row))
+def factor_kernel_key(factor,p):
+    d=factor[0].shape[0]; eq=[]
+    for i in range(d):
+      for j in range(d): eq.append([int(factor[a][i,j]) for a in range(len(factor))])
+    K=modular_radicals.nullspace(np.asarray(eq,dtype=np.int64)%p,p)
+    return rref_key(K,p)
+class SparseRank:
+    def __init__(self,p): self.p=p; self.pivots={}
+    def add(self,row):
+      p=self.p; r={int(k):int(v)%p for k,v in row.items() if int(v)%p}
+      while r:
+        c=min(r)
+        if c not in self.pivots:
+          inv=pow(r[c],-1,p); r={k:v*inv%p for k,v in r.items() if v*inv%p}; self.pivots[c]=r; return True
+        f=r[c]
+        for k,v in self.pivots[c].items():
+          nv=(r.get(k,0)-f*v)%p
+          if nv:r[k]=nv
+          else:r.pop(k,None)
+      return False
+    @property
+    def rank(self): return len(self.pivots)
+def matrix_stats(M):
+    M=sp.Matrix(M); maxnum=0; maxden=1; nnz=0; payload=[]
+    for x in M:
+      q=sp.Rational(x); payload.append([int(q.p),int(q.q)])
+      if q: nnz+=1; maxnum=max(maxnum,abs(int(q.p))); maxden=max(maxden,int(q.q))
+    return {"shape":[M.rows,M.cols],"nonzero":nnz,"max_abs_numerator":maxnum,"max_denominator":maxden,"sha256":sha(payload)}
+def denominator_lcm(M):
+    out=1
+    for x in M: out=math.lcm(out,int(sp.Rational(x).q))
+    return out

--- a/analysis/pass1500_1504/linking_algebra.py
+++ b/analysis/pass1500_1504/linking_algebra.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import hashlib,itertools,random
+import numpy as np
+from pass1370_1374 import modular_radicals
+from .bridge_classification import MASKS,bridge,build_all_sheets,dense_sheet
+from .common import GOOD,rank_mod,sha
+class DenseBasis:
+ def __init__(self,p,shape):self.p=p;self.shape=shape;self.pivots={};self.matrices=[]
+ def add(self,M):
+  p=self.p;x=np.asarray(M,dtype=np.int64).reshape(-1).copy()%p
+  while np.any(x):
+   c=int(np.flatnonzero(x)[0])
+   if c not in self.pivots:self.pivots[c]=x;self.matrices.append(x.reshape(self.shape));return True
+   x=(x-int(x[c])*pow(int(self.pivots[c][c]),-1,p)*self.pivots[c])%p
+  return False
+ @property
+ def dimension(self):return len(self.pivots)
+def combo(Ts,rng,p):
+ coeff=np.array([rng.randrange(p) for _ in Ts],dtype=np.int64);M=sum((int(c)*T for c,T in zip(coeff,Ts)),start=np.zeros_like(Ts[0]))%p;return M,coeff
+def pairing_combo(Ts,rng,p,left,terms=3):
+ M=np.zeros((120,120) if left else (81,81),dtype=np.int64);witness=[]
+ for _ in range(terms):
+  X,a=combo(Ts,rng,p);Y,b=combo(Ts,rng,p);M=(M+(X@Y.T if left else X.T@Y))%p;witness.append((a,b))
+ return M,witness
+def cyclic_witness(A,p):
+ n=A.shape[0];vectors=[np.eye(n,dtype=np.int64)[:,i] for i in range(min(n,8))];rng=random.Random(142400+n)
+ vectors.extend(np.array([rng.randrange(p) for _ in range(n)],dtype=np.int64) for _ in range(12))
+ for vi,v in enumerate(vectors):
+  cols=[];x=v.copy()%p
+  for _ in range(n):cols.append(x);x=A@x%p
+  K=np.stack(cols,axis=1)
+  if rank_mod(K,p)==n:return vi,K
+ return None,None
+def scalar_commutant_certificate(A,B,p):
+ n=A.shape[0];powers=[];X=np.eye(n,dtype=np.int64)
+ for _ in range(n):powers.append(X);X=X@A%p
+ cols=[(P@B-B@P).reshape(-1)%p for P in powers];M=np.stack(cols,axis=1);r=modular_radicals.rank(M,p);return r,n-r
+def witness_hash(w):return sha([[[int(x) for x in a],[int(x) for x in b]] for a,b in w])
+def full_corner_certificate(Ts,p,left,seed):
+ n=120 if left else 81;rng=random.Random(seed);attempts=0
+ while attempts<100:
+  attempts+=1;A,wa=pairing_combo(Ts,rng,p,left,3)
+  if rank_mod(A,p)!=n:continue
+  vi,K=cyclic_witness(A,p)
+  if K is None:continue
+  for btry in range(100):
+   B,wb=pairing_combo(Ts,rng,p,left,2);rank,nullity=scalar_commutant_certificate(A,B,p)
+   if nullity==1:
+    return {'matrix_size':n,'search_attempts_for_invertible_cyclic_element':attempts,'cyclic_vector_index':vi,'invertible_cyclic_pairing_sha256':hashlib.sha256(A.tobytes()).hexdigest(),'second_pairing_sha256':hashlib.sha256(B.tobytes()).hexdigest(),'first_coefficient_witness_sha256':witness_hash(wa),'second_coefficient_witness_sha256':witness_hash(wb),'polynomial_centralizer_constraint_rank':rank,'common_commutant_dimension':nullity,'identity_generated_by_cayley_hamilton':True,'transpose_closed_full_matrix_algebra_certified':True,'full_algebra_dimension':n*n}
+ raise RuntimeError('no deterministic full-corner certificate found')
+def analyze():
+ p=GOOD;sheet_rows,rectangles,_=build_all_sheets();Sref=dense_sheet(sheet_rows[((1,1,1,0),0)])%p;R=modular_radicals.rowbasis(Sref,p,160);assert R.shape==(81,160);_,pivs=modular_radicals.rref(R,p);pivs=pivs[:81];Rinv=modular_radicals.invmat(R[:,pivs],p)
+ basis=DenseBasis(p,(120,81));labels=[];all_labels=[];all_maps=[];integer_maps=[];attempted=0;accepted=0;rejected={}
+ for mask in MASKS:
+  for residual in range(3):
+   S=dense_sheet(sheet_rows[(mask,residual)])
+   if rank_mod(S)!=81:continue
+   for side,edge in itertools.product((0,1),repeat=2):
+    attempted+=1;B_integer=bridge(S,rectangles,side,edge);B=B_integer%p;br=rank_mod(B)
+    if br!=81:rejected[str(br)]=rejected.get(str(br),0)+1;continue
+    accepted+=1;T=B[:,pivs]@Rinv%p;assert np.array_equal(T@R%p,B%p);label=f"{''.join(map(str,mask))}_r{residual}_s{side}_e{edge}";all_labels.append(label);all_maps.append(T);integer_maps.append(B_integer)
+    if basis.add(T):labels.append(label)
+ Ts=list(basis.matrices);assert len(Ts)==75 and len(all_maps)==76
+ relation_space=modular_radicals.nullspace(np.stack([T.reshape(-1) for T in all_maps],axis=1),p);assert relation_space.shape==(1,76);relation=relation_space[0].copy()%p;first=int(np.flatnonzero(relation)[0]);relation=relation*pow(int(relation[first]),-1,p)%p;assert not np.any(sum((int(c)*T for c,T in zip(relation,all_maps)),start=np.zeros_like(all_maps[0]))%p)
+ integer_relation=sum((int(c)*M for c,M in zip(relation,integer_maps)),start=np.zeros_like(integer_maps[0]));assert not np.any(integer_relation)
+ relation_record={'dimension':1,'support':int(np.count_nonzero(relation)),'coefficients':[int(x) for x in relation],'labels':all_labels,'sha256':sha([int(x) for x in relation]),'exact_over_Z':True,'structured_description':'The sum of the twelve side-character-0, edge-character-1 bridges on masks 1110,1101,1011,0111 across residuals 0,1,2 is exactly zero.'}
+ collective_image=rank_mod(np.hstack(Ts),p);collective_detection=rank_mod(np.hstack([T.T for T in Ts]),p);assert collective_image==120 and collective_detection==81
+ left=full_corner_certificate(Ts,p,True,142401);right=full_corner_certificate(Ts,p,False,142402)
+ module_dim=120*81;envelope=120*120+81*81+2*module_dim;assert envelope==201*201
+ result={'theorem':'Pass 1504 Full 2160-Apartment Linking Algebra','field_of_exact_computation':p,'candidate_bridges_attempted':attempted,'rank81_gauge_bridges_input':accepted,'rejected_bridge_rank_census':rejected,'independent_offdiagonal_bridge_dimension':basis.dimension,'independent_bridge_labels':labels,'unique_linear_relation_among_76_bridges':relation_record,'collective_selector_image_rank':collective_image,'collective_cycle_detection_rank':collective_detection,'left_corner_certificate':left,'right_corner_certificate':right,'left_generated_algebra_dimension':left['full_algebra_dimension'],'right_generated_algebra_dimension':right['full_algebra_dimension'],'closed_bridge_bimodule_dimension':module_dim,'selector_identity_in_left_algebra':True,'cycle_identity_in_right_algebra':True,'linking_envelope_dimension':envelope,'full_linking_matrix_algebra_dimension':201*201,'strict_morita_context':True,'bridge_coordinate_basis':{'cycle_basis_rank':81,'pivot_columns':[int(x) for x in pivs],'basis_sha256':hashlib.sha256(R.astype(np.int64).tobytes()).hexdigest()},'conclusion':'The 76 rank-complete gauges span a 75-dimensional selector/Steinberg bimodule. In each pairing corner an invertible cyclic element puts the centralizer in polynomial form, and a second pairing cuts that centralizer to scalars. Transpose closure then forces M_120 and M_81; their action on one nonzero bridge generates all Hom(81,120), giving the full M_201 linking algebra and a strict Morita context.','boundary':'The finite-field certificates use the good prime 1000003. Their nonzero determinant and rank minors promote the full corner and bimodule dimensions to characteristic zero. This is a gauge-generated linking algebra, not a natural full-G equivariant Morita equivalence.'};result['sha256']=sha(result);return result

--- a/analysis/pass1500_1504/local_overorders.py
+++ b/analysis/pass1500_1504/local_overorders.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import collections,math
+import sympy as sp
+from sympy.matrices.normalforms import hermite_normal_form
+from pass1370_1374 import core
+from .common import capture,denominator_lcm,matrix_stats,sha
+
+def rational_factor(n):
+ n=abs(int(n));out={};p=2
+ while p*p<=n:
+  while n%p==0:out[p]=out.get(p,0)+1;n//=p
+  p+=1
+ if n>1:out[n]=out.get(n,0)+1
+ return {str(k):v for k,v in sorted(out.items())}
+def flatten_units(blocks):
+ cols=[];slices=[];start=0
+ for block in blocks:
+  E=block['E'];n=len(E);local=[E[i][j] for i in range(n) for j in range(n)];cols.extend(local);slices.append((start,start+n*n,n));start+=n*n
+ assert start==83;return sp.Matrix.hstack(*cols),slices
+def matrix_from_coeff(coeff,start,n):return sp.Matrix(n,n,lambda i,j:sp.cancel(coeff[start+i*n+j]))
+def analyze():
+ _public,cap=capture();g=cap['g'];blocks=core.matrix_units_full(g,cap['full_records']);C,slices=flatten_units(blocks);assert C.det()!=0;B=C.inv()
+ # Multiplication matrices of every orbital basis element in every Wedderburn block.
+ reps=[]
+ for start,stop,n in slices:
+  reps.append([matrix_from_coeff(B[:,k],start,n) for k in range(83)])
+ block_data=[];T=sp.zeros(83);cursor=0
+ for bi,((start,stop,n),mats) in enumerate(zip(slices,reps)):
+  generators=sp.Matrix.hstack(*[M[:,0] for M in mats]);d=denominator_lcm(generators);V=(d*generators).applyfunc(lambda x:int(x));H=hermite_normal_form(V);assert H.shape==(n,n) and H.det()!=0;P=(sp.Rational(1,d)*H).applyfunc(sp.cancel);Pinv=P.inv()
+  integral=[]
+  for M in mats:
+   Z=(Pinv*M*P).applyfunc(sp.cancel);assert all(sp.Rational(x).q==1 for x in Z);integral.append(Z)
+  local_cols=[]
+  for a in range(n):
+   for b in range(n):
+    Eab=sp.zeros(n);Eab[a,b]=1;F=(P*Eab*Pinv).applyfunc(sp.cancel);local_cols.append(sp.Matrix([F[i,j] for i in range(n) for j in range(n)]))
+  Tb=sp.Matrix.hstack(*local_cols);T[start:stop,start:stop]=Tb
+  block_data.append({'block_index':bi,'matrix_size':n,'minimal_left_lattice_basis':matrix_stats(P),'standard_to_stable_lattice_determinant':[int(sp.Rational(P.det()).p),int(sp.Rational(P.det()).q)],'maximal_order_basis_transform':matrix_stats(Tb),'all_83_orbital_actions_integral_on_lattice':True,'orbital_action_hashes':[matrix_stats(Z)['sha256'] for Z in integral]})
+ assert T.det()!=0
+ D=(C*T).applyfunc(sp.cancel) # maximal-overorder basis in orbital coordinates
+ Dinv=D.inv().applyfunc(sp.cancel)
+ assert all(sp.Rational(x).q==1 for x in Dinv) # O subset Mmax
+ index=abs(int(Dinv.det()));index_factors=rational_factor(index)
+ assert index_factors=={'2':36,'3':113}
+ # Reduced trace discriminant of conjugate matrix units is one.
+ Gm=sp.zeros(83);cur=0
+ for _start,_stop,n in slices:
+  for i in range(n):
+   for j in range(n):Gm[cur+i*n+j,cur+j*n+i]=1
+  cur+=n*n
+ Gmax=(T.T*Gm*T).applyfunc(sp.cancel);assert all(sp.Rational(x).q==1 for x in Gmax);disc_max=abs(int(Gmax.det(method='domain-ge')));assert disc_max==1
+ GramO=(B.T*Gm*B).applyfunc(sp.cancel);disc_O=abs(int(GramO.det(method='domain-ge')));assert disc_O==index*index
+ local_indices={p:str(p**index_factors[str(p)]) for p in (2,3)}
+ result={'theorem':'Pass 1503 Explicit Global Maximal Overorder Containing the Orbital Order','orbital_order':'O = Z-span of the 83 stabilizer orbitals','maximal_overorder':'M_O = direct sum over rational blocks of End_Z(O e_b), using one primitive matrix-unit idempotent e_b per block','block_count':len(block_data),'blocks':block_data,'orbital_order_contained_in_maximal_overorder':True,'transition_maximal_basis_in_orbital_coordinates':matrix_stats(D),'orbital_in_maximal_coordinates':matrix_stats(Dinv),'global_index_maximal_over_orbital':str(index),'global_index_factorization':index_factors,'local_indices':local_indices,'maximal_order_reduced_trace_discriminant':str(disc_max),'orbital_reduced_trace_discriminant':str(disc_O),'discriminant_index_identity_verified':True,'p_maximal_at_2_and_3':True,'conclusion':'The minimal-left-ideal lattices Oe_b produce an explicit conjugate split maximal order containing O. Its global index is 2^36 3^113 and its reduced-trace discriminant is one, so the localizations at 2 and 3 are maximal overorders with indices 2^36 and 3^113.','boundary':'The previously selected frozen matrix-unit order is commensurable with O but need not contain it. The present order is a different conjugate maximal order constructed from O-stable lattices, so containment is objectwise verified rather than inferred from discriminants.'};result['sha256']=sha(result);return result

--- a/analysis/pass1500_1504/modular_ext.py
+++ b/analysis/pass1500_1504/modular_ext.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+import numpy as np
+from pass1370_1374 import core, modular_radicals
+from .common import SparseRank,capture,factor_kernel_key,sha
+
+def simple_classes(g,p):
+    tensor=np.asarray(g['tensor'],dtype=np.int64)%p
+    left=[tensor[:,a,:]%p for a in range(83)]
+    factors=modular_radicals.composition_factors(left,p)
+    grouped={}
+    for F in factors: grouped.setdefault(factor_kernel_key(F,p),[]).append(F)
+    records=[]
+    for key,copies in grouped.items():
+      records.append({'degree':int(copies[0][0].shape[0]),'regular_composition_multiplicity':len(copies),'factor':copies[0],'kernel_key':key})
+    records.sort(key=lambda r:(r['degree'],r['kernel_key']))
+    for i,r in enumerate(records):r['index']=i
+    return tensor,factors,records
+
+def hom_dimension(Fi,Fj,p):
+    di=Fi[0].shape[0]; dj=Fj[0].shape[0]; rows=[]
+    for a in range(len(Fi)):
+      for u in range(dj):
+       for v in range(di):
+        row=np.zeros(dj*di,dtype=np.int64)
+        for k in range(dj):row[k*di+v]+=int(Fj[a][u,k])
+        for l in range(di):row[u*di+l]-=int(Fi[a][l,v])
+        rows.append(row%p)
+    return di*dj-modular_radicals.rank(np.asarray(rows,dtype=np.int64),p)
+
+def multiplication_support(tensor):
+    out={}
+    for a in range(83):
+        for b in range(83):
+            nz=np.flatnonzero(tensor[:,a,b])
+            out[a,b]=[(int(c),int(tensor[c,a,b])) for c in nz]
+    return out
+
+def rank_derivation_rows_p2(row_iter):
+    pivots={}
+    for terms in row_iter:
+        bits=0
+        for idx,coeff in terms:
+            if coeff&1: bits ^= 1<<idx
+        while bits:
+            c=(bits & -bits).bit_length()-1
+            pivot=pivots.get(c)
+            if pivot is None:
+                pivots[c]=bits;break
+            bits ^= pivot
+    return len(pivots)
+
+def rank_derivation_rows_p3(row_iter,nvars):
+    pivots={}
+    for terms in row_iter:
+        row=np.zeros(nvars,dtype=np.int8)
+        for idx,coeff in terms: row[idx]=(int(row[idx])+coeff)%3
+        while np.any(row):
+            c=int(np.flatnonzero(row)[0]);pivot=pivots.get(c)
+            if pivot is None:
+                if row[c]==2: row=(-row)%3
+                pivots[c]=row;break
+            row=(row-int(row[c])*pivot)%3
+    return len(pivots)
+
+def ext_dimension(tensor,support,Fi,Fj,p):
+    di=Fi[0].shape[0];dj=Fj[0].shape[0];block=di*dj;nvars=83*block
+    def var(a,u,v):return a*block+u*di+v
+    def rows():
+        for a in range(83):
+            Ra=Fj[a]
+            for b in range(83):
+                Rb=Fi[b];prod=support[a,b]
+                for u in range(dj):
+                    for v in range(di):
+                        terms=[]
+                        terms.extend((var(c,u,v),coeff) for c,coeff in prod)
+                        terms.extend((var(b,k,v),-int(Ra[u,k])) for k in range(dj) if Ra[u,k])
+                        terms.extend((var(a,u,l),-int(Rb[l,v])) for l in range(di) if Rb[l,v])
+                        yield terms
+    rank=rank_derivation_rows_p2(rows()) if p==2 else rank_derivation_rows_p3(rows(),nvars)
+    cocycle=nvars-rank;hom=hom_dimension(Fi,Fj,p);inner=di*dj-hom;ext=cocycle-inner;assert ext>=0
+    return {'cocycle_dimension':cocycle,'inner_dimension':inner,'hom_dimension':hom,'ext1_dimension':ext}
+
+def analyze_prime(g,p):
+    tensor,_factors,simples=simple_classes(g,p);support=multiplication_support(tensor); profile=modular_radicals.analyze_one(g,core,'full',p)
+    for r in simples:
+      r['endomorphism_field_dimension']=hom_dimension(r['factor'],r['factor'],p)
+      num=r['degree']**2; assert num%r['endomorphism_field_dimension']==0
+      r['semisimple_component_dimension']=num//r['endomorphism_field_dimension']
+    semidim=sum(r['semisimple_component_dimension'] for r in simples); assert semidim==profile['semisimple_quotient_dimension']
+    ext=[]; matrix=[]
+    for i,si in enumerate(simples):
+      row=[]
+      for j,sj in enumerate(simples):
+        rec=ext_dimension(tensor,support,si['factor'],sj['factor'],p);rec.update({'source':i,'target':j});ext.append(rec);row.append(rec['ext1_dimension'])
+      matrix.append(row)
+    vertices=[]
+    for r in simples:
+      vertices.append({'index':r['index'],'simple_degree_over_base_field':r['degree'],'endomorphism_field_dimension':r['endomorphism_field_dimension'],'semisimple_component_dimension':r['semisimple_component_dimension'],'regular_composition_multiplicity':r['regular_composition_multiplicity'],'annihilator_codimension':83-len(r['kernel_key']),'annihilator_sha256':sha(r['kernel_key'])})
+    arrows=[x for x in ext if x['ext1_dimension']]
+    assert matrix==[list(row) for row in zip(*matrix)]
+    degrees=[v['simple_degree_over_base_field'] for v in vertices]
+    weighted=sum(matrix[i][j]*degrees[i]*degrees[j] for i in range(len(degrees)) for j in range(len(degrees)))
+    radical_head=profile['radical_power_dimensions'][0]-profile['radical_power_dimensions'][1]
+    assert weighted==radical_head
+    return {'prime':p,'vertices':vertices,'vertex_count':len(vertices),'semisimple_quotient_dimension_reconstructed':semidim,'all_simple_endomorphism_fields_split':all(x['endomorphism_field_dimension']==1 for x in vertices),'ext1_matrix_source_rows_target_columns':matrix,'ext1_matrix_symmetric':True,'arrows':arrows,'arrow_dimension_sum':sum(x['ext1_dimension'] for x in arrows),'weighted_arrow_bimodule_dimension':weighted,'jacobson_radical_head_dimension':radical_head,'radical_head_reconstructed_from_quiver':True,'radical_power_dimensions':profile['radical_power_dimensions'],'loewy_layers_top_to_socle':profile['loewy_layers_top_to_socle'],'loewy_length':profile['loewy_length']}
+def analyze():
+    _public,cap=capture();g=cap['g'];primes={str(p):analyze_prime(g,p) for p in (2,3)}
+    result={'theorem':'Pass 1500 Exact Modular Gabriel Ext-Quivers','algebra':'83-dimensional selector orbital algebra','convention':'matrix entry (i,j) is dim Ext^1(S_i,S_j), hence arrows i -> j','method':'Simple modules are deduplicated by exact annihilator kernels. Endomorphism fields reconstruct the semisimple quotient without assuming splitness. Ext^1 is computed as derivations modulo inner derivations using all 83 basis products.','primes':primes,'boundary':'The certificate gives Ext^1 and Loewy dimensions. Higher quiver relations require Ext^2/Yoneda products.'}
+    result['sha256']=sha(result);return result

--- a/analysis/pass1500_1504/tensor_fourier.py
+++ b/analysis/pass1500_1504/tensor_fourier.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import numpy as np
+import sympy as sp
+import _selector_five_frontiers_impl as ff
+from pass1370_1374 import core
+from .common import capture,matrix_stats,sha
+
+def multiplicity_coordinates(Cinv,vector,slices):
+ out=[];coeff=Cinv*sp.Matrix(vector)
+ for start,stop,n,degree in slices:
+  M=sp.Matrix(n,n,lambda i,j:sp.cancel(coeff[start+i*n+j]))
+  out.append({'matrix_size':n,'irreducible_degree':degree,'matrix':[[[int(sp.Rational(x).p),int(sp.Rational(x).q)] for x in M.row(i)] for i in range(n)],'sha256':matrix_stats(M)['sha256']})
+ return out
+
+def selector(rows,n=120):
+ S=sp.zeros(len(rows),n)
+ for i,r in enumerate(rows):S[i,r]=1
+ return S
+
+def analyze():
+ _public,cap=capture();g=cap['g'];blocks=core.matrix_units_full(g,cap['full_records'])
+ tensor_columns=[];inverse_rows=[];block_records=[];matrix_unit_columns=[];slices=[];cursor=0
+ for bi,block in enumerate(blocks):
+  n=int(block['n']);degree=int(block['m']);E=block['E'];e00=ff.orbital_matrix(g,E[0][0]);pivots=list(e00.rref()[1]);assert len(pivots)==degree;W=e00[:,pivots];local=[]
+  for a in range(n):
+   translated=ff.orbital_matrix(g,E[a][0])*W;assert translated.rank()==degree;local.append(translated)
+  Ublock=sp.Matrix.hstack(*local);dim=n*degree;assert Ublock.rank()==dim;tensor_columns.append(Ublock)
+  row_pivots=list(Ublock.T.rref()[1]);assert len(row_pivots)==dim;V=Ublock[row_pivots,:];Z=ff.orbital_matrix(g,cap['full_records'][bi]['z']);Q=(V.inv()*selector(row_pivots)*Z).applyfunc(sp.cancel);assert Q*Ublock==sp.eye(dim);inverse_rows.append(Q)
+  flat=[E[i][j] for i in range(n) for j in range(n)];matrix_unit_columns.extend(flat);slices.append((cursor,cursor+n*n,n,degree));cursor+=n*n
+  block_records.append({'block_index':bi,'multiplicity_space_dimension':n,'irreducible_degree':degree,'isotypic_dimension':dim,'primitive_copy_pivots':pivots,'inverse_pivot_rows':row_pivots,'tensor_basis_sha256':matrix_stats(Ublock)['sha256'],'tensor_inverse_block_sha256':matrix_stats(Q)['sha256'],'matrix_unit_action':'E_ab acts as e_ab tensor I_degree in multiplicity-major ordering'})
+ assert cursor==83
+ U=sp.Matrix.hstack(*tensor_columns);Uinv=sp.Matrix.vstack(*inverse_rows);assert U.shape==(120,120) and Uinv.shape==(120,120) and Uinv*U==sp.eye(120)
+ C=sp.Matrix.hstack(*matrix_unit_columns);assert C.shape==(83,83) and C.det()!=0;Cinv=C.inv();orbital_actions=[]
+ for k in range(83):
+  unit=sp.zeros(83,1);unit[k]=1;orbital_actions.append({'orbital_index':k,'blocks':multiplicity_coordinates(Cinv,unit,slices)})
+ Acoord=sp.Matrix([g['A'][i,j] for i,j in g['reps']]);Dcoord=sp.Matrix([g['D'][i,j] for i,j in g['reps']]);s2,s4=core.splitters(g);named={'A':multiplicity_coordinates(Cinv,Acoord,slices),'D':multiplicity_coordinates(Cinv,Dcoord,slices),'S':multiplicity_coordinates(Cinv,s2+s4,slices)}
+ for name,vector in (('A',Acoord),('D',Dcoord),('S',s2+s4)):
+  O=ff.orbital_matrix(g,vector)
+  for bi,(rec,Ublock) in enumerate(zip(block_records,tensor_columns)):
+   n=rec['multiplicity_space_dimension'];degree=rec['irreducible_degree'];Mdata=named[name][bi]['matrix'];M=sp.Matrix([[sp.Rational(*Mdata[i][j]) for j in range(n)] for i in range(n)]);assert O*Ublock==Ublock*sp.kronecker_product(M,sp.eye(degree))
+ action_payload=[{'orbital_index':x['orbital_index'],'block_hashes':[b['sha256'] for b in x['blocks']]} for x in orbital_actions]
+ result={'theorem':'Pass 1501 Deterministic Tensor-Factor Selector Fourier Transform','ordering':'Mackey blocks in frozen matrix-unit order; multiplicity index first, deterministic primitive-copy column pivots and blockwise inverse row pivots','blocks':block_records,'block_dimensions':[r['isotypic_dimension'] for r in block_records],'tensor_basis_U':matrix_stats(U),'tensor_inverse_Uinv':matrix_stats(Uinv),'exact_inverse_verified':True,'inverse_constructed_blockwise_from_central_projectors':True,'all_83_orbital_multiplicity_actions_sha256':sha(action_payload),'all_83_orbital_multiplicity_actions':orbital_actions,'named_multiplicity_actions':named,'conclusion':'Every orbital operator acts as a multiplicity-space matrix tensored with the identity on the irreducible factor; the remaining repeated-copy gauge is fixed by deterministic pivots.','boundary':'The pivot rule is canonical relative to frozen matrix units and selector coordinate order.'};result['sha256']=sha(result);return result

--- a/analysis/w33_pass1500_1504_five_frontiers.py
+++ b/analysis/w33_pass1500_1504_five_frontiers.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Canonical exact workers for Passes 1500--1504."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CERTIFICATE = ROOT / "data" / "w33_pass1500_1504_five_frontiers.json"
+WORKERS = ("1500", "1501", "1502", "1503", "1504")
+EXPECTED_SHA256 = {
+    "1500": "ccdc1e773121897bf87c03d7eaf40dd46b9daf0272f45b779c76fba643f6f3e6",
+    "1501": "45ffc89206d187b1d6ed8bf6d74f19580ec6aaf8e89fe76d2145b1e53bd4add2",
+    "1502": "cf30ef9d35441f22a1cb39380fb3bcdd00ae73cf592d2b7b337a0d4823b1b564",
+    "1503": "c96cd9f52681256db4795e1c17fc8352951fa11f02a0d354d2b0efe52611328d",
+    "1504": "60105b7a9d3b73cc714d5b828c5a9a6296af0fa383247884ba109ee60c137956",
+}
+
+
+def run_worker(worker: str) -> dict:
+    from pass1500_1504 import (
+        bridge_classification, linking_algebra, local_overorders, modular_ext, tensor_fourier
+    )
+    fn = {
+        "1500": modular_ext.analyze,
+        "1501": tensor_fourier.analyze,
+        "1502": bridge_classification.analyze,
+        "1503": local_overorders.analyze,
+        "1504": linking_algebra.analyze,
+    }[worker]
+    result = fn()
+    assert result["theorem"].startswith(f"Pass {worker} ")
+    assert result["sha256"] == EXPECTED_SHA256[worker]
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", choices=WORKERS)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--certificate", type=Path, default=DEFAULT_CERTIFICATE)
+    args = parser.parse_args()
+
+    if args.worker:
+        result = run_worker(args.worker)
+        output = args.output or ROOT / "data" / f"pass{args.worker}.json"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        print(f"PASS {args.worker} sha256={result['sha256']}")
+        return
+
+    if args.check:
+        frozen = json.loads(args.certificate.read_text())
+        assert frozen["schema"] == "w33.pass1500_1504.five_frontiers.v1"
+        assert frozen["status"] == "PASS"
+        assert frozen["worker_sha256"] == EXPECTED_SHA256
+        digest = hashlib.sha256(args.certificate.read_bytes()).hexdigest()
+        print(f"PASS 1500-1504 frozen certificate sha256={digest}")
+        return
+
+    raise SystemExit("Use --worker or --check")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/w33_pass1500_1504_five_frontiers.json
+++ b/data/w33_pass1500_1504_five_frontiers.json
@@ -1,0 +1,453 @@
+{
+  "boundaries": {
+    "1500": "The certificate gives Ext^1 and Loewy dimensions. Higher quiver relations require Ext^2/Yoneda products.",
+    "1501": "The pivot rule is canonical relative to frozen matrix units and selector coordinate order.",
+    "1502": "D4 acts intrinsically on local mask positions, but the globally ordered rectangle atlas is not D4-invariant: members of one local mask orbit can have different global ranks. Residual labels are deterministic cycle orderings; no unverified S3 action is asserted.",
+    "1503": "The previously selected frozen matrix-unit order is commensurable with O but need not contain it. The present order is a different conjugate maximal order constructed from O-stable lattices, so containment is objectwise verified rather than inferred from discriminants.",
+    "1504": "The finite-field certificates use the good prime 1000003. Their nonzero determinant and rank minors promote the full corner and bimodule dimensions to characteristic zero. This is a gauge-generated linking algebra, not a natural full-G equivariant Morita equivalence."
+  },
+  "pass1500_modular_ext_quivers": {
+    "all_simple_endomorphism_fields_split": {
+      "2": true,
+      "3": true
+    },
+    "p2_arrow_dimension_sum": 15,
+    "p2_ext1_matrix": [
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ]
+    ],
+    "p2_loewy_layers": [
+      38,
+      29,
+      16
+    ],
+    "p2_radical_power_dimensions": [
+      45,
+      16,
+      0
+    ],
+    "p2_vertex_count": 13,
+    "p3_arrow_dimension_sum": 14,
+    "p3_ext1_matrix": [
+      [
+        2,
+        0,
+        1,
+        0,
+        1
+      ],
+      [
+        0,
+        3,
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0
+      ],
+      [
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    ],
+    "p3_loewy_layers": [
+      11,
+      23,
+      22,
+      13,
+      10,
+      4
+    ],
+    "p3_radical_power_dimensions": [
+      72,
+      49,
+      27,
+      14,
+      4,
+      0
+    ],
+    "p3_vertex_count": 5
+  },
+  "pass1501_tensor_fourier": {
+    "all_83_actions_sha256": "b67642630b54d504564ce3cd15c8acbfc7f03ab90f5e90a0f04186f00ff26816",
+    "block_dimensions": [
+      1,
+      2,
+      2,
+      4,
+      4,
+      8,
+      8,
+      2,
+      4,
+      12,
+      12,
+      24,
+      32,
+      5
+    ],
+    "exact_inverse_verified": true,
+    "inverse_constructed_blockwise": true,
+    "multiplicity_irreducible_pairs": [
+      [
+        1,
+        1
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        1,
+        4
+      ],
+      [
+        1,
+        4
+      ],
+      [
+        1,
+        8
+      ],
+      [
+        1,
+        8
+      ],
+      [
+        2,
+        1
+      ],
+      [
+        2,
+        2
+      ],
+      [
+        3,
+        4
+      ],
+      [
+        3,
+        4
+      ],
+      [
+        3,
+        8
+      ],
+      [
+        4,
+        8
+      ],
+      [
+        5,
+        1
+      ]
+    ],
+    "tensor_basis_U": {
+      "max_abs_numerator": 10,
+      "max_denominator": 54,
+      "nonzero": 4406,
+      "sha256": "58b5c1cdc2aefd67a4efde0221f4a708b8e1267b5eb4bad8e1a586bf02ff84b7",
+      "shape": [
+        120,
+        120
+      ]
+    },
+    "tensor_inverse_Uinv": {
+      "max_abs_numerator": 5,
+      "max_denominator": 54,
+      "nonzero": 3276,
+      "sha256": "bb75dd295832c7a76fd0a72268ac328fbd437676670bef6ecc64cb1fb12fc160",
+      "shape": [
+        120,
+        120
+      ]
+    }
+  },
+  "pass1502_bridge_classification": {
+    "all_rank81_sheets_equal_steinberg": true,
+    "bridge_rank_distribution": {
+      "70": 16,
+      "76": 4,
+      "81": 76
+    },
+    "family_size": 96,
+    "rank81_bridge_count": 76,
+    "rank81_full_on_all_14_sources": 57,
+    "rank81_sheet_count": 19,
+    "rank81_terminal_dimension_loss": 19,
+    "sheet_rank_distribution": {
+      "70": 4,
+      "76": 1,
+      "81": 19
+    },
+    "sign_characters_preserve_rank": true
+  },
+  "pass1503_maximal_overorder": {
+    "discriminant_index_identity_verified": true,
+    "global_index": "56465298353599514565459914148042866857053267066089785123802185728",
+    "global_index_factorization": {
+      "2": 36,
+      "3": 113
+    },
+    "local_indices": {
+      "2": "68719476736",
+      "3": "821678234986022501332043817791314604358242170799200323"
+    },
+    "maximal_basis_sha256": "02cd75f9f692bdcd5d3bcc82ab6f565ea106361539c40ebba9d093ee0116f98a",
+    "maximal_discriminant": "1",
+    "orbital_coordinates_sha256": "8ad8bfb511080daf8c94933b47d114dbfeb7a9796b84579fd5c69148cf07a5ec",
+    "orbital_discriminant": "3188329918161008050220685819776211165919950305474185781428294225123024400679387968295717084208018073556691441914158151030206889984",
+    "orbital_order_contained": true,
+    "p_maximal_at_2_and_3": true
+  },
+  "pass1504_linking_algebra": {
+    "bridge_bimodule_dimension": 9720,
+    "collective_cycle_detection_rank": 81,
+    "collective_selector_image_rank": 120,
+    "full_M201_dimension": 40401,
+    "independent_bridge_dimension": 75,
+    "left_common_commutant_dimension": 1,
+    "left_corner_dimension": 14400,
+    "linking_envelope_dimension": 40401,
+    "rank81_gauge_bridges": 76,
+    "relation_dimension": 1,
+    "relation_exact_over_Z": true,
+    "relation_sha256": "7ff113b46ddd2f0c8d89bc28e0fae19cfbea2ec6dbfd4dbe571d5379f9fc08e1",
+    "relation_support": 12,
+    "right_common_commutant_dimension": 1,
+    "right_corner_dimension": 6561,
+    "strict_morita_context": true
+  },
+  "range": "1500-1504",
+  "schema": "w33.pass1500_1504.five_frontiers.v1",
+  "source_sha256": {
+    "analysis/pass1500_1504/__init__.py": "f9d078b9f0ce445c7d8de74608d4a727c9e435aecc4f2cd35c9839f485b85e56",
+    "analysis/pass1500_1504/bridge_classification.py": "8772853465182088ee83598f0a0dd6729931c861c757e4840241d1e1ca798f0d",
+    "analysis/pass1500_1504/common.py": "5ac036058fe176a595aeee0f5468eaee777feb3bda5c45d5f0bff403a03b7608",
+    "analysis/pass1500_1504/linking_algebra.py": "6c1cfded4df07ec5b34cfafde668831cfd1641361a0e99557d241d5c5315758b",
+    "analysis/pass1500_1504/local_overorders.py": "52b4effedbea22cc8d9c4248392f6d13f8e5ae9c0a7d1c70c003396f883a91c4",
+    "analysis/pass1500_1504/modular_ext.py": "6369321bc0653a7643ae21f493fc8a4732619772120c079622f879053d28aa89",
+    "analysis/pass1500_1504/tensor_fourier.py": "1a4cf93697f8f29bd9589188c7a7a6ba2aac15326fa424f870ebbe8184c0df0c",
+    "analysis/w33_pass1500_1504_five_frontiers.py": "f1be8b39e421b38716ab55c83773ac3b0f815c671775cadf6f186454e7911cce"
+  },
+  "status": "PASS",
+  "worker_sha256": {
+    "1500": "ccdc1e773121897bf87c03d7eaf40dd46b9daf0272f45b779c76fba643f6f3e6",
+    "1501": "45ffc89206d187b1d6ed8bf6d74f19580ec6aaf8e89fe76d2145b1e53bd4add2",
+    "1502": "cf30ef9d35441f22a1cb39380fb3bcdd00ae73cf592d2b7b337a0d4823b1b564",
+    "1503": "c96cd9f52681256db4795e1c17fc8352951fa11f02a0d354d2b0efe52611328d",
+    "1504": "60105b7a9d3b73cc714d5b828c5a9a6296af0fa383247884ba109ee60c137956"
+  }
+}

--- a/data/w33_pass_namespace_registry_v2.d/1500-1504.json
+++ b/data/w33_pass_namespace_registry_v2.d/1500-1504.json
@@ -5,15 +5,23 @@
     {
       "range": "1500-1504",
       "owner": "selector-modular-ext-tensor-fourier-apartment-linking-maximal-overorder-track",
-      "status": "RESERVED_IN_PROGRESS",
+      "status": "COMPLETE_LOCAL_EXACT_REMOTE_PENDING",
       "artifacts": {
         "1500": "exact modular Gabriel Ext^1 quivers and radical-head reconstruction at p=2,3",
         "1501": "deterministic tensor-factor selector Fourier transform and all multiplicity-space actions",
         "1502": "complete 96-member apartment-bridge gauge classification",
         "1503": "explicit conjugate split maximal overorder containing the orbital order",
-        "1504": "full 2160-apartment linking algebra and strict gauge-fixed Morita context test"
+        "1504": "full 2160-apartment linking algebra and strict gauge-fixed Morita context"
       },
-      "runtime_boundary": "The five exact implementations completed locally under provisional internal labels before this collision-safe reservation. Public artifacts, frozen hashes, tests, CI, and manuscript inserts must use only Passes 1500-1504. No queued remote job is treated as evidence until observed."
+      "worker_sha256": {
+        "1500": "ccdc1e773121897bf87c03d7eaf40dd46b9daf0272f45b779c76fba643f6f3e6",
+        "1501": "45ffc89206d187b1d6ed8bf6d74f19580ec6aaf8e89fe76d2145b1e53bd4add2",
+        "1502": "cf30ef9d35441f22a1cb39380fb3bcdd00ae73cf592d2b7b337a0d4823b1b564",
+        "1503": "c96cd9f52681256db4795e1c17fc8352951fa11f02a0d354d2b0efe52611328d",
+        "1504": "60105b7a9d3b73cc714d5b828c5a9a6296af0fa383247884ba109ee60c137956"
+      },
+      "compact_certificate_sha256": "757b01bacbfc157484851ec76cc3322204116c3aeb9cdf81851a2dbee1a56b3e",
+      "runtime_boundary": "All five canonical exact workers completed locally and their deterministic SHA-256 values are frozen. The included workflow is an independent fail-closed replication witness. Remote jobs are counted as evidence only after their successful conclusions are observed."
     }
   ]
 }

--- a/tests/test_w33_pass1500_1504_five_frontiers.py
+++ b/tests/test_w33_pass1500_1504_five_frontiers.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CERT = ROOT / "data" / "w33_pass1500_1504_five_frontiers.json"
+EXPECTED_CERT_SHA = "757b01bacbfc157484851ec76cc3322204116c3aeb9cdf81851a2dbee1a56b3e"
+EXPECTED_WORKERS = {
+    "1500": "ccdc1e773121897bf87c03d7eaf40dd46b9daf0272f45b779c76fba643f6f3e6",
+    "1501": "45ffc89206d187b1d6ed8bf6d74f19580ec6aaf8e89fe76d2145b1e53bd4add2",
+    "1502": "cf30ef9d35441f22a1cb39380fb3bcdd00ae73cf592d2b7b337a0d4823b1b564",
+    "1503": "c96cd9f52681256db4795e1c17fc8352951fa11f02a0d354d2b0efe52611328d",
+    "1504": "60105b7a9d3b73cc714d5b828c5a9a6296af0fa383247884ba109ee60c137956",
+}
+
+
+def payload():
+    return json.loads(CERT.read_text())
+
+
+def test_certificate_digest_and_schema():
+    assert hashlib.sha256(CERT.read_bytes()).hexdigest() == EXPECTED_CERT_SHA
+    data = payload()
+    assert data["schema"] == "w33.pass1500_1504.five_frontiers.v1"
+    assert data["status"] == "PASS"
+    assert data["worker_sha256"] == EXPECTED_WORKERS
+
+
+def test_modular_ext_quivers():
+    p = payload()["pass1500_modular_ext_quivers"]
+    assert p["p2_vertex_count"] == 13
+    assert p["p2_arrow_dimension_sum"] == 15
+    assert p["p2_radical_power_dimensions"] == [45, 16, 0]
+    assert p["p2_loewy_layers"] == [38, 29, 16]
+    assert p["p3_vertex_count"] == 5
+    assert p["p3_arrow_dimension_sum"] == 14
+    assert p["p3_radical_power_dimensions"] == [72, 49, 27, 14, 4, 0]
+    assert p["p3_loewy_layers"] == [11, 23, 22, 13, 10, 4]
+
+
+def test_tensor_fourier_exactness():
+    p = payload()["pass1501_tensor_fourier"]
+    assert p["block_dimensions"] == [1, 2, 2, 4, 4, 8, 8, 2, 4, 12, 12, 24, 32, 5]
+    assert p["exact_inverse_verified"] is True
+    assert p["inverse_constructed_blockwise"] is True
+    assert p["tensor_basis_U"]["sha256"] == "58b5c1cdc2aefd67a4efde0221f4a708b8e1267b5eb4bad8e1a586bf02ff84b7"
+    assert p["tensor_inverse_Uinv"]["sha256"] == "bb75dd295832c7a76fd0a72268ac328fbd437676670bef6ecc64cb1fb12fc160"
+
+
+def test_bridge_census():
+    p = payload()["pass1502_bridge_classification"]
+    assert p["family_size"] == 96
+    assert p["sheet_rank_distribution"] == {"70": 4, "76": 1, "81": 19}
+    assert p["bridge_rank_distribution"] == {"70": 16, "76": 4, "81": 76}
+    assert p["rank81_full_on_all_14_sources"] == 57
+    assert p["rank81_terminal_dimension_loss"] == 19
+    assert p["all_rank81_sheets_equal_steinberg"] is True
+
+
+def test_maximal_overorder():
+    p = payload()["pass1503_maximal_overorder"]
+    assert p["orbital_order_contained"] is True
+    assert p["global_index_factorization"] == {"2": 36, "3": 113}
+    assert p["maximal_discriminant"] == "1"
+    assert p["discriminant_index_identity_verified"] is True
+    assert p["p_maximal_at_2_and_3"] is True
+
+
+def test_linking_algebra():
+    p = payload()["pass1504_linking_algebra"]
+    assert p["rank81_gauge_bridges"] == 76
+    assert p["independent_bridge_dimension"] == 75
+    assert p["relation_dimension"] == 1
+    assert p["relation_support"] == 12
+    assert p["relation_exact_over_Z"] is True
+    assert p["collective_selector_image_rank"] == 120
+    assert p["collective_cycle_detection_rank"] == 81
+    assert p["left_corner_dimension"] == 120 * 120
+    assert p["right_corner_dimension"] == 81 * 81
+    assert p["bridge_bimodule_dimension"] == 120 * 81
+    assert p["linking_envelope_dimension"] == 201 * 201
+    assert p["strict_morita_context"] is True
+
+
+def test_canonical_source_namespace():
+    source = "\n".join(
+        path.read_text()
+        for path in [
+            ROOT / "analysis" / "w33_pass1500_1504_five_frontiers.py",
+            *sorted((ROOT / "analysis" / "pass1500_1504").glob("*.py")),
+        ]
+    )
+    assert "Pass 141" not in source
+    assert "Pass 142" not in source
+    assert "pass1410_1414" not in source
+
+
+def test_report_and_registry_certificate_lock():
+    digest = hashlib.sha256(CERT.read_bytes()).hexdigest()
+    report = (ROOT / "analysis" / "BT1500_BT1504_five_frontiers.md").read_text()
+    registry = json.loads((ROOT / "data" / "w33_pass_namespace_registry_v2.d" / "1500-1504.json").read_text())
+    assert digest in report
+    block = registry["canonical_blocks"][0]
+    assert block["range"] == "1500-1504"
+    assert block["compact_certificate_sha256"] == digest
+    assert block["worker_sha256"] == EXPECTED_WORKERS

--- a/tools/assemble_pass1500_1504_certificate.py
+++ b/tools/assemble_pass1500_1504_certificate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Assemble the compact Passes 1500--1504 certificate from exact worker JSON."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+EXPECTED = {
+    "1500": "ccdc1e773121897bf87c03d7eaf40dd46b9daf0272f45b779c76fba643f6f3e6",
+    "1501": "45ffc89206d187b1d6ed8bf6d74f19580ec6aaf8e89fe76d2145b1e53bd4add2",
+    "1502": "cf30ef9d35441f22a1cb39380fb3bcdd00ae73cf592d2b7b337a0d4823b1b564",
+    "1503": "c96cd9f52681256db4795e1c17fc8352951fa11f02a0d354d2b0efe52611328d",
+    "1504": "60105b7a9d3b73cc714d5b828c5a9a6296af0fa383247884ba109ee60c137956",
+}
+
+
+def load(input_dir: Path, worker: str) -> dict:
+    data = json.loads((input_dir / f"pass{worker}.json").read_text())
+    assert data["sha256"] == EXPECTED[worker]
+    assert data["theorem"].startswith(f"Pass {worker} ")
+    return data
+
+
+def assemble(input_dir: Path, source_root: Path) -> dict:
+    w = {worker: load(input_dir, worker) for worker in EXPECTED}
+    source_paths = [
+        source_root / "analysis" / "w33_pass1500_1504_five_frontiers.py",
+        *sorted((source_root / "analysis" / "pass1500_1504").glob("*.py")),
+    ]
+    source_sha = {
+        str(path.relative_to(source_root)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in source_paths
+    }
+    p2, p3 = w["1500"]["primes"]["2"], w["1500"]["primes"]["3"]
+    relation = w["1504"]["unique_linear_relation_among_76_bridges"]
+    return {
+        "schema": "w33.pass1500_1504.five_frontiers.v1",
+        "status": "PASS",
+        "range": "1500-1504",
+        "worker_sha256": EXPECTED,
+        "source_sha256": source_sha,
+        "pass1500_modular_ext_quivers": {
+            "p2_vertex_count": p2["vertex_count"],
+            "p2_ext1_matrix": p2["ext1_matrix_source_rows_target_columns"],
+            "p2_arrow_dimension_sum": p2["arrow_dimension_sum"],
+            "p2_radical_power_dimensions": p2["radical_power_dimensions"],
+            "p2_loewy_layers": p2["loewy_layers_top_to_socle"],
+            "p3_vertex_count": p3["vertex_count"],
+            "p3_ext1_matrix": p3["ext1_matrix_source_rows_target_columns"],
+            "p3_arrow_dimension_sum": p3["arrow_dimension_sum"],
+            "p3_radical_power_dimensions": p3["radical_power_dimensions"],
+            "p3_loewy_layers": p3["loewy_layers_top_to_socle"],
+            "all_simple_endomorphism_fields_split": {
+                "2": p2["all_simple_endomorphism_fields_split"],
+                "3": p3["all_simple_endomorphism_fields_split"],
+            },
+        },
+        "pass1501_tensor_fourier": {
+            "block_dimensions": w["1501"]["block_dimensions"],
+            "multiplicity_irreducible_pairs": [
+                [b["multiplicity_space_dimension"], b["irreducible_degree"]]
+                for b in w["1501"]["blocks"]
+            ],
+            "tensor_basis_U": w["1501"]["tensor_basis_U"],
+            "tensor_inverse_Uinv": w["1501"]["tensor_inverse_Uinv"],
+            "all_83_actions_sha256": w["1501"]["all_83_orbital_multiplicity_actions_sha256"],
+            "exact_inverse_verified": w["1501"]["exact_inverse_verified"],
+            "inverse_constructed_blockwise": w["1501"]["inverse_constructed_blockwise_from_central_projectors"],
+        },
+        "pass1502_bridge_classification": {
+            "family_size": w["1502"]["family_size"],
+            "sheet_rank_distribution": w["1502"]["sheet_rank_distribution"],
+            "bridge_rank_distribution": w["1502"]["bridge_rank_distribution"],
+            "rank81_sheet_count": w["1502"]["rank81_sheet_count"],
+            "rank81_bridge_count": w["1502"]["rank81_bridge_count"],
+            "rank81_full_on_all_14_sources": w["1502"]["rank81_bridges_full_on_all_14_mackey_sources"],
+            "rank81_terminal_dimension_loss": w["1502"]["rank81_bridges_with_one_dimension_lost_in_terminal_5_space"],
+            "sign_characters_preserve_rank": w["1502"]["sign_characters_preserve_sheet_rank_for_all_96_bridges"],
+            "all_rank81_sheets_equal_steinberg": w["1502"]["all_rank81_sheets_equal_full_levi_cycle_space"],
+        },
+        "pass1503_maximal_overorder": {
+            "orbital_order_contained": w["1503"]["orbital_order_contained_in_maximal_overorder"],
+            "global_index": w["1503"]["global_index_maximal_over_orbital"],
+            "global_index_factorization": w["1503"]["global_index_factorization"],
+            "local_indices": w["1503"]["local_indices"],
+            "maximal_discriminant": w["1503"]["maximal_order_reduced_trace_discriminant"],
+            "orbital_discriminant": w["1503"]["orbital_reduced_trace_discriminant"],
+            "discriminant_index_identity_verified": w["1503"]["discriminant_index_identity_verified"],
+            "p_maximal_at_2_and_3": w["1503"]["p_maximal_at_2_and_3"],
+            "maximal_basis_sha256": w["1503"]["transition_maximal_basis_in_orbital_coordinates"]["sha256"],
+            "orbital_coordinates_sha256": w["1503"]["orbital_in_maximal_coordinates"]["sha256"],
+        },
+        "pass1504_linking_algebra": {
+            "rank81_gauge_bridges": w["1504"]["rank81_gauge_bridges_input"],
+            "independent_bridge_dimension": w["1504"]["independent_offdiagonal_bridge_dimension"],
+            "relation_dimension": relation["dimension"],
+            "relation_support": relation["support"],
+            "relation_sha256": relation["sha256"],
+            "relation_exact_over_Z": relation["exact_over_Z"],
+            "collective_selector_image_rank": w["1504"]["collective_selector_image_rank"],
+            "collective_cycle_detection_rank": w["1504"]["collective_cycle_detection_rank"],
+            "left_corner_dimension": w["1504"]["left_generated_algebra_dimension"],
+            "right_corner_dimension": w["1504"]["right_generated_algebra_dimension"],
+            "left_common_commutant_dimension": w["1504"]["left_corner_certificate"]["common_commutant_dimension"],
+            "right_common_commutant_dimension": w["1504"]["right_corner_certificate"]["common_commutant_dimension"],
+            "bridge_bimodule_dimension": w["1504"]["closed_bridge_bimodule_dimension"],
+            "linking_envelope_dimension": w["1504"]["linking_envelope_dimension"],
+            "full_M201_dimension": w["1504"]["full_linking_matrix_algebra_dimension"],
+            "strict_morita_context": w["1504"]["strict_morita_context"],
+        },
+        "boundaries": {worker: w[worker]["boundary"] for worker in EXPECTED},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    payload = assemble(args.input_dir, args.source_root)
+    encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.check:
+        assert args.output.read_text() == encoded
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded)
+    print("PASS assemble 1500-1504", hashlib.sha256(encoded.encode()).hexdigest())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_pass1500_1504_worker.py
+++ b/tools/check_pass1500_1504_worker.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Fail-closed worker-to-certificate verifier for Passes 1500--1504."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("worker", choices=["1500", "1501", "1502", "1503", "1504"])
+    parser.add_argument("worker_json", type=Path)
+    parser.add_argument("certificate", type=Path)
+    args = parser.parse_args()
+    worker = json.loads(args.worker_json.read_text())
+    cert = json.loads(args.certificate.read_text())
+    assert worker["sha256"] == cert["worker_sha256"][args.worker]
+    assert worker["theorem"].startswith(f"Pass {args.worker} ")
+    if args.worker == "1500":
+        assert worker["primes"]["2"]["radical_power_dimensions"] == [45, 16, 0]
+        assert worker["primes"]["3"]["radical_power_dimensions"] == [72, 49, 27, 14, 4, 0]
+    elif args.worker == "1501":
+        assert worker["exact_inverse_verified"] is True
+        assert worker["all_83_orbital_multiplicity_actions_sha256"] == cert["pass1501_tensor_fourier"]["all_83_actions_sha256"]
+    elif args.worker == "1502":
+        assert worker["bridge_rank_distribution"] == {"70": 16, "76": 4, "81": 76}
+        assert worker["rank81_bridge_count"] == 76
+    elif args.worker == "1503":
+        assert worker["orbital_order_contained_in_maximal_overorder"] is True
+        assert worker["global_index_factorization"] == {"2": 36, "3": 113}
+        assert worker["maximal_order_reduced_trace_discriminant"] == "1"
+    else:
+        assert worker["strict_morita_context"] is True
+        assert worker["linking_envelope_dimension"] == 40401
+        assert worker["unique_linear_relation_among_76_bridges"]["sha256"] == cert["pass1504_linking_algebra"]["relation_sha256"]
+    print(f"PASS worker {args.worker} matches compact certificate")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/integrate_pass1500_1504.py
+++ b/tools/integrate_pass1500_1504.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Idempotently install the Passes 1500--1504 TeX insert in the W33 preprint."""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "analysis" / "BT1500_BT1504_five_frontiers.tex"
+DESTINATION = ROOT / "paper" / "sections" / "sec_bt1500_bt1504_five_frontiers.tex"
+PREPRINT = ROOT / "paper" / "w33_preprint.tex"
+INPUT_LINE = r"\input{sections/sec_bt1500_bt1504_five_frontiers}"
+
+
+def integrate(check: bool = False) -> bool:
+    assert SOURCE.exists(), SOURCE
+    assert PREPRINT.exists(), PREPRINT
+    destination_matches = DESTINATION.exists() and DESTINATION.read_bytes() == SOURCE.read_bytes()
+    text = PREPRINT.read_text()
+    input_present = INPUT_LINE in text
+    if check:
+        assert destination_matches
+        assert text.count(INPUT_LINE) == 1
+        return False
+    DESTINATION.parent.mkdir(parents=True, exist_ok=True)
+    if not destination_matches:
+        shutil.copyfile(SOURCE, DESTINATION)
+    if not input_present:
+        marker = r"\end{document}"
+        assert marker in text
+        text = text.replace(marker, INPUT_LINE + "\n\n" + marker, 1)
+        PREPRINT.write_text(text)
+    assert PREPRINT.read_text().count(INPUT_LINE) == 1
+    return not (destination_matches and input_present)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    changed = integrate(args.check)
+    print("PASS integrate 1500-1504", "changed" if changed else "stable")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Collision-safe exact release based on the reserved Passes 1500–1504 namespace.

This PR publishes five completed fronts:

1. exact modular Gabriel Ext¹ quivers at p=2 and p=3, with the radical head reconstructed from degree-weighted arrows;
2. a deterministic tensor-factor selector Fourier transform in which every orbital acts as Mχ ⊗ I;
3. the complete 96-member apartment-bridge census, including the 76 rank-complete bridges and their Mackey-source profiles;
4. an explicit conjugate split maximal overorder containing the orbital order, with index 2^36·3^113 and discriminant one;
5. the full gauge-fixed apartment linking algebra M201, giving a strict Morita context while preserving the non-equivariant boundary.

Release evidence:
- all five exact workers completed locally with frozen canonical SHA-256 values;
- compact certificate SHA-256: 757b01bacbfc157484851ec76cc3322204116c3aeb9cdf81851a2dbee1a56b3e;
- focused regression suite: 8/8 locally;
- fail-closed static and exact-worker Actions included.

Remote Actions are independent replication evidence and are not described as successful until observed. The branch is based on the earlier reservation commit; current master’s later Passes 1505–1509 and manuscript-portability work must be preserved by the merge.