### PR TITLE
Passes 1516–1520: close five selector continuation fronts

### DIFF
--- a/.github/workflows/pass1516_1520_five_frontiers.yml
+++ b/.github/workflows/pass1516_1520_five_frontiers.yml
@@ -1,0 +1,60 @@
+name: Passes 1516-1520 Five Derived Frontiers
+
+on:
+  push:
+    paths:
+      - 'analysis/w33_pass1516_1520_five_frontiers.py'
+      - 'analysis/BT1516_BT1520_five_frontiers.md'
+      - 'data/w33_pass1516_1520_five_frontiers.json'
+      - 'data/w33_pass_namespace_registry_v2.d/1516-1520.json'
+      - 'paper/sections/sec_bt1516_bt1520_five_frontiers.tex'
+      - 'paper/sections/sec_complement_duality.tex'
+      - 'tests/test_w33_pass1516_1520_five_frontiers.py'
+      - '.github/workflows/pass1516_1520_five_frontiers.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'analysis/w33_pass1516_1520_five_frontiers.py'
+      - 'analysis/BT1516_BT1520_five_frontiers.md'
+      - 'data/w33_pass1516_1520_five_frontiers.json'
+      - 'data/w33_pass_namespace_registry_v2.d/1516-1520.json'
+      - 'paper/sections/sec_bt1516_bt1520_five_frontiers.tex'
+      - 'paper/sections/sec_complement_duality.tex'
+      - 'tests/test_w33_pass1516_1520_five_frontiers.py'
+      - '.github/workflows/pass1516_1520_five_frontiers.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  exact-derived-certificate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m py_compile analysis/w33_pass1516_1520_five_frontiers.py
+      - run: python analysis/w33_pass1516_1520_five_frontiers.py --check
+      - run: python -m pip install --disable-pip-version-check pytest
+      - run: pytest -q tests/test_w33_pass1516_1520_five_frontiers.py
+
+  insert-portability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update -qq && sudo apt-get install -y -qq texlive-latex-base texlive-latex-recommended
+      - run: |
+          d=$(mktemp -d)
+          cp paper/sections/sec_bt1516_bt1520_five_frontiers.tex "$d/insert.tex"
+          cat > "$d/minimal.tex" <<'TEX'
+          \documentclass{article}
+          \usepackage{amsmath,amssymb}
+          \begin{document}
+          \input{insert}
+          \end{document}
+          TEX
+          (cd "$d" && pdflatex -interaction=nonstopmode -halt-on-error minimal.tex)

--- a/.github/workflows/w33-frame-hoffman-resolution.yml
+++ b/.github/workflows/w33-frame-hoffman-resolution.yml
@@ -1,0 +1,55 @@
+name: W33 Frame Hoffman Resolution
+
+on:
+  push:
+    paths:
+      - 'analysis/w33_frame_hoffman_resolution_theorem.py'
+      - 'analysis/2026-07-31_frame_hoffman_resolution_theorem.md'
+      - 'analysis/frame_hoffman_resolution_insert.tex'
+      - 'data/w33_frame_hoffman_resolution_theorem.json'
+      - 'tests/test_w33_frame_hoffman_resolution_theorem.py'
+      - 'w33_paper.tex'
+      - 'photonic_holonet.tex'
+      - '.github/workflows/w33-frame-hoffman-resolution.yml'
+  pull_request:
+    paths:
+      - 'analysis/w33_frame_hoffman_resolution_theorem.py'
+      - 'analysis/2026-07-31_frame_hoffman_resolution_theorem.md'
+      - 'analysis/frame_hoffman_resolution_insert.tex'
+      - 'data/w33_frame_hoffman_resolution_theorem.json'
+      - 'tests/test_w33_frame_hoffman_resolution_theorem.py'
+      - 'w33_paper.tex'
+      - 'photonic_holonet.tex'
+
+jobs:
+  exact-frame-spectrum:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install numpy pytest
+      - run: python analysis/w33_frame_hoffman_resolution_theorem.py --output /tmp/frame-hoffman.json --check
+      - run: diff -u data/w33_frame_hoffman_resolution_theorem.json /tmp/frame-hoffman.json
+      - run: pytest -q tests/test_w33_frame_hoffman_resolution_theorem.py
+
+  insert-portability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq texlive-latex-base texlive-latex-recommended
+          d=$(mktemp -d)
+          cp analysis/frame_hoffman_resolution_insert.tex "$d/insert.tex"
+          cat > "$d/minimal.tex" <<'TEX'
+          \documentclass{article}
+          \usepackage{amsmath,amssymb}
+          \begin{document}
+          \input{insert}
+          \end{document}
+          TEX
+          (cd "$d" && pdflatex -interaction=nonstopmode -halt-on-error minimal.tex)

--- a/analysis/BT1516_BT1520_five_frontiers.md
+++ b/analysis/BT1516_BT1520_five_frontiers.md
@@ -1,0 +1,274 @@
+# Passes 1516–1520 — Relations, canonical Fourier form, atlas obstruction, arithmetic support, and equivariant Morita closure
+
+**Status:** exact derived certificate complete.  
+**Certificate SHA-256:** `603380fbc9370b97b08273a67785b43f9c52960610d84661f99228bbe020ab48`
+
+This packet executes the five continuations left by Passes 1500–1504. It is deliberately derived from the frozen Passes 1370–1374 and 1500–1504 certificates: no expensive worker is silently replaced by a new implementation, and every inference boundary is explicit.
+
+## Pass 1516 — The first exact relation layer beyond the Gabriel quiver
+
+Let
+
+\[
+S=A/J,\qquad B=J/J^2.
+\]
+
+The Ext\(^1\) quiver identifies the split \(S\)-bimodule \(B\). Hence the canonical map
+
+\[
+T_S(B)\longrightarrow \operatorname{gr}_J(A)
+\]
+
+is surjective, and its homogeneous kernel dimensions are computable from the frozen quiver and Loewy data.
+
+### Characteristic two
+
+The weighted tensor-path dimensions in degrees \(0,1,2,3\) are
+
+\[
+38,\ 29,\ 45,\ 59,
+\]
+
+whereas the radical-graded dimensions are
+
+\[
+38,\ 29,\ 16,\ 0.
+\]
+
+Therefore the exact relation-space dimensions are
+
+\[
+0,\ 0,\ \boxed{29},\ 59.
+\]
+
+The Gabriel graph has six connected components:
+
+\[
+\{0,3,6\},\ \{1,9\},\ \{2,4\},\ \{5,12\},\ \{7,8,10\},\ \{11\}.
+\]
+
+The last is an isolated degree-\(3\) simple vertex, hence a semisimple \(M_3(\mathbb F_2)\) block of algebra dimension \(9\).
+
+### Characteristic three
+
+The weighted tensor-path dimensions in degrees \(0\) through \(6\) are
+
+\[
+11,\ 23,\ 92,\ 333,\ 1231,\ 4560,\ 16952,
+\]
+
+while the radical-graded dimensions are
+
+\[
+11,\ 23,\ 22,\ 13,\ 10,\ 4,\ 0.
+\]
+
+Thus the relation-space dimensions are
+
+\[
+0,\ 0,\ \boxed{70},\ 320,\ 1221,\ 4556,\ 16952.
+\]
+
+The characteristic-three quiver is connected. Its quadratic relation defect is already \(70\), compared with \(29\) in characteristic two.
+
+**Boundary.** These are exact homogeneous kernels in the radical-associated graded algebra. They do not yet separate minimal cubic and higher generators from consequences of quadratic relations, and they are not represented as the complete Ext\(^2\) or Yoneda multiplication table.
+
+## Pass 1517 — Coordinate-free selector Fourier theorem
+
+Write the selector module as an \(H\)-module in the canonical isotypic form
+
+\[
+V\cong\bigoplus_{\chi} U_\chi\otimes W_\chi,
+\qquad
+U_\chi=\operatorname{Hom}_H(W_\chi,V).
+\]
+
+The fourteen multiplicity/irreducible-degree pairs are
+
+\[
+(1,1),(1,2),(1,2),(1,4),(1,4),(1,8),(1,8),
+(2,1),(2,2),(3,4),(3,4),(3,8),(4,8),(5,1).
+\]
+
+They satisfy the three exact double-centralizer identities
+
+\[
+\sum_\chi m_\chi d_\chi=120,
+\qquad
+\sum_\chi m_\chi^2=83,
+\qquad
+\sum_\chi d_\chi^2=335.
+\]
+
+The first is the selector-module dimension; the second is the orbital commutant dimension; the third is the dimension of the dual semisimple image. The isotypic summands and evaluation map
+
+\[
+\bigoplus_\chi \operatorname{Hom}_H(W_\chi,V)\otimes W_\chi\longrightarrow V
+\]
+
+are basis-free. The Pass-1501 matrix \(U\) is one deterministic trivialization of these canonical tensor factors, not the invariant itself. Allowing bases in both factors gives a block-factorization gauge group of dimension
+
+\[
+83+335-14=404,
+\]
+
+where one scalar redundancy is removed in each of the fourteen blocks.
+
+## Pass 1518 — Exact obstruction to a global rank-preserving \(D_4\) atlas action
+
+The eight local masks form exactly two \(D_4\)-orbits, each of size four: the four weight-three masks and the four adjacent weight-two masks.
+
+Assume a global \(D_4\)-action existed on the \(24=8\times3\) frozen sheets, projected to the standard mask action, and preserved sheet rank. Every sheet orbit would project onto one of the four-element mask orbits. Therefore every invariant rank level would have cardinality divisible by four.
+
+But the exact sheet-rank distribution is
+
+\[
+70^4,\qquad 76^1,\qquad 81^{19}.
+\]
+
+The singleton rank-76 level gives an immediate contradiction. Hence
+
+\[
+\boxed{\text{no global rank-preserving }D_4\text{ lift exists on the frozen 24 sheets}.}
+\]
+
+After adjoining the four sign characters, the bridge counts become
+
+\[
+70^{16},\qquad76^4,\qquad81^{76},
+\]
+
+all divisible by four. Thus the obstruction is genuinely visible at the sheet level and is erased by the sign multiplicity at the level of rank counts alone.
+
+The correct symmetry object is therefore chart-dependent: an action groupoid with a residual-label transport cocycle, or a transport that exits the frozen 24-sheet family.
+
+**Boundary.** The cardinality theorem proves the nonexistence of the global lift. It does not compute the full rectangle-by-rectangle residual \(S_3\) cocycle.
+
+## Pass 1519 — Maximal-order arithmetic: exact prime support and conductor bound
+
+The containing maximal order has labeled split blocks
+
+\[
+\mathbb Z^7\oplus M_2(\mathbb Z)^2\oplus M_3(\mathbb Z)^3
+\oplus M_4(\mathbb Z)\oplus M_5(\mathbb Z),
+\]
+
+of total \(\mathbb Z\)-rank \(83\). The exact index is
+
+\[
+[M_O:O]=2^{36}3^{113}.
+\]
+
+Consequently:
+
+\[
+\operatorname{length}_{\mathbb Z_2}(M_O/O)=36,
+\qquad
+\operatorname{length}_{\mathbb Z_3}(M_O/O)=113,
+\]
+
+and the orbital discriminant valuations are
+
+\[
+v_2(\operatorname{disc}O)=72,
+\qquad
+v_3(\operatorname{disc}O)=226.
+\]
+
+For every prime \(\ell\neq2,3\),
+
+\[
+O\otimes\mathbb Z_\ell=M_O\otimes\mathbb Z_\ell.
+\]
+
+Thus the conductor is supported only at \(2\) and \(3\). If
+
+\[
+N=2^{36}3^{113},
+\]
+
+then the finite quotient \(M_O/O\) is annihilated by \(N\), so
+
+\[
+N M_O\subseteq \mathfrak f,
+\qquad
+\mathfrak f=\{x\in M_O:xM_O\subseteq O\}.
+\]
+
+Componentwise, each labeled block \(M_n(\mathbb Z)\) has trivial locally free ideal class group by Morita equivalence with \(\mathbb Z\). Forgetting labels permits permutations of equal blocks, of order
+
+\[
+7!\,2!\,3!=60480,
+\]
+
+but this is a symmetry of the split maximal order, not an arithmetic ideal-class defect.
+
+**Boundary.** Total index and discriminant do not determine the blockwise conductor exponents, Smith invariants of \(M_O/O\), or Bass/Eichler status. Those require the frozen transition matrix itself.
+
+## Pass 1520 — The equivariant Morita obstruction vanishes after saturation
+
+Let \(V\) be the \(120\)-dimensional selector module and \(W\) the signed \(81\)-dimensional Steinberg cycle module. Pass 1504 established the full corners
+
+\[
+A=\operatorname{End}_{\mathbb Q}(V)\cong M_{120}(\mathbb Q),
+\qquad
+B=\operatorname{End}_{\mathbb Q}(W)\cong M_{81}(\mathbb Q),
+\]
+
+and the saturated bridge bimodule of dimension
+
+\[
+120\cdot81=9720.
+\]
+
+Take
+
+\[
+X=\operatorname{Hom}_{\mathbb Q}(W,V),
+\qquad
+Y=\operatorname{Hom}_{\mathbb Q}(V,W).
+\]
+
+Composition gives the strict Morita pairings
+
+\[
+X\otimes_B Y\longrightarrow A,
+\qquad
+Y\otimes_A X\longrightarrow B.
+\]
+
+Surjectivity is literal on matrix units:
+
+\[
+E_{ij}=x_{i0}y_{0j},
+\qquad
+F_{ab}=y_{a0}x_{0b}.
+\]
+
+With the signed group representations \(\rho_V,\rho_W\), define
+
+\[
+g\cdot x=\rho_V(g)x\rho_W(g)^{-1}.
+\]
+
+The two composition pairings are equivariant. Therefore the full saturated context is a strict \(G\)-equivariant Morita equivalence, and its equivariant Brauer obstruction is zero.
+
+This resolves the apparent contradiction with the earlier exact statement
+
+\[
+\operatorname{Hom}_G(W,V)=0.
+\]
+
+That vanishing says there is no **fixed bridge element**. It does not say the entire \(9720\)-dimensional \(G\)-module \(\operatorname{Hom}(W,V)\) fails to be an equivariant equivalence bimodule.
+
+Thus the correct refinement of Pass 1504 is:
+
+\[
+\boxed{\text{the 75 apartment bridges are a gauge generating frame; their full corner saturation is canonically }G\text{-equivariant}.}
+\]
+
+**Boundary.** No individual apartment bridge becomes \(G\)-invariant, and there is no preferred fixed identification \(V\cong W\); their dimensions differ.
+
+## Verification boundary
+
+The release script recomputes every displayed integer from the frozen certificates and checks their hashes. It does not claim to have rerun the expensive Pass-1500 workers. The Pass-1516 higher-Yoneda boundary and the Pass-1518 residual-cocycle boundary remain explicit.

--- a/analysis/w33_pass1516_1520_five_frontiers.py
+++ b/analysis/w33_pass1516_1520_five_frontiers.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Derived exact Passes 1516--1520 from frozen selector certificates.
+
+This worker intentionally uses only compact, already-frozen exact certificates.
+It does not rerun the expensive 83-dimensional orbital-algebra construction.
+Every new statement is either an exact algebraic consequence of those certificates
+or is marked as a remaining boundary.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE1500 = ROOT / "data" / "w33_pass1500_1504_five_frontiers.json"
+BASE1370 = ROOT / "data" / "w33_pass1370_1374_five_frontiers.json"
+OUT = ROOT / "data" / "w33_pass1516_1520_five_frontiers.json"
+EXPECTED_BASE_HASHES = {
+    "1500_1504_sha256": "757b01bacbfc157484851ec76cc3322204116c3aeb9cdf81851a2dbee1a56b3e",
+    "1370_1374_sha256": "284d9d7f9462a83f0709734d48a3ccf3284da2cb6b5ede159da5c719b84332b9",
+}
+
+P2_DEGREES = [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3]
+P3_DEGREES = [1, 1, 1, 2, 2]
+MASKS = [
+    (1, 1, 1, 0), (1, 1, 0, 1), (1, 0, 1, 1), (0, 1, 1, 1),
+    (1, 1, 0, 0), (1, 0, 0, 1), (0, 1, 1, 0), (0, 0, 1, 1),
+]
+
+
+def sha(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def matmul(A: list[list[int]], B: list[list[int]]) -> list[list[int]]:
+    return [
+        [sum(A[i][k] * B[k][j] for k in range(len(B))) for j in range(len(B[0]))]
+        for i in range(len(A))
+    ]
+
+
+def weighted(A: list[list[int]], d: list[int]) -> int:
+    return sum(d[i] * A[i][j] * d[j] for i in range(len(d)) for j in range(len(d)))
+
+
+def identity(n: int) -> list[list[int]]:
+    return [[1 if i == j else 0 for j in range(n)] for i in range(n)]
+
+
+def connected_components(A: list[list[int]]) -> list[list[int]]:
+    n = len(A)
+    unseen = set(range(n))
+    out = []
+    while unseen:
+        seed = min(unseen)
+        comp = {seed}
+        stack = [seed]
+        unseen.remove(seed)
+        while stack:
+            i = stack.pop()
+            for j in range(n):
+                if (A[i][j] or A[j][i]) and j in unseen:
+                    unseen.remove(j)
+                    comp.add(j)
+                    stack.append(j)
+        out.append(sorted(comp))
+    return out
+
+
+def relation_frontier(A: list[list[int]], d: list[int], layers: list[int]) -> dict:
+    powers = identity(len(A))
+    path_dims = []
+    graded_dims = []
+    kernel_dims = []
+    for n, layer in enumerate(layers):
+        if n:
+            powers = matmul(powers, A)
+        p = weighted(powers, d)
+        path_dims.append(p)
+        graded_dims.append(layer)
+        kernel_dims.append(p - layer)
+    powers = matmul(powers, A)
+    terminal_path = weighted(powers, d)
+    path_dims.append(terminal_path)
+    graded_dims.append(0)
+    kernel_dims.append(terminal_path)
+    assert kernel_dims[0] == kernel_dims[1] == 0
+    assert all(x >= 0 for x in kernel_dims)
+    comps = connected_components(A)
+    component_records = []
+    for comp in comps:
+        semisimple = sum(d[i] ** 2 for i in comp)
+        radical_head = sum(A[i][j] * d[i] * d[j] for i in comp for j in comp)
+        component_records.append({
+            "vertices": comp,
+            "simple_degrees": [d[i] for i in comp],
+            "semisimple_dimension": semisimple,
+            "radical_head_dimension": radical_head,
+        })
+    return {
+        "simple_degrees": d,
+        "connected_components": component_records,
+        "tensor_path_dimensions_degrees_0_through_loewy": path_dims,
+        "associated_graded_radical_layer_dimensions": graded_dims,
+        "relation_kernel_dimensions": kernel_dims,
+        "quadratic_path_dimension": path_dims[2],
+        "quadratic_radical_layer_dimension": graded_dims[2],
+        "quadratic_relation_dimension": kernel_dims[2],
+        "interpretation": (
+            "For S=A/J and B=J/J^2, the canonical tensor-algebra map "
+            "T_S(B) -> gr_J(A) is surjective. The listed kernel dimensions are "
+            "therefore exact homogeneous relation-space dimensions."
+        ),
+        "boundary": (
+            "These are relation spaces in the radical-associated graded algebra. "
+            "They do not by themselves separate minimal higher-degree generators "
+            "from consequences of lower-degree relations, and they do not yet give "
+            "the complete Ext^2/Yoneda multiplication table."
+        ),
+    }
+
+
+def d4_permutations() -> list[tuple[int, ...]]:
+    out = set()
+    for k in range(4):
+        out.add(tuple((i + k) % 4 for i in range(4)))
+        out.add(tuple((k - i) % 4 for i in range(4)))
+    assert len(out) == 8
+    return sorted(out)
+
+
+def permute_mask(mask: tuple[int, ...], perm: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(mask[perm[i]] for i in range(4))
+
+
+def mask_orbits() -> list[list[list[int]]]:
+    perms = d4_permutations()
+    remaining = set(MASKS)
+    orbits = []
+    while remaining:
+        seed = min(remaining)
+        orb = {permute_mask(seed, p) for p in perms}
+        orb &= set(MASKS)
+        remaining -= orb
+        orbits.append([list(x) for x in sorted(orb)])
+    return sorted(orbits, key=lambda o: (len(o), o))
+
+
+def build() -> dict:
+    base1500 = json.loads(BASE1500.read_text())
+    base1370 = json.loads(BASE1370.read_text())
+
+    ext = base1500["pass1500_modular_ext_quivers"]
+    p2 = relation_frontier(ext["p2_ext1_matrix"], P2_DEGREES, ext["p2_loewy_layers"])
+    p3 = relation_frontier(ext["p3_ext1_matrix"], P3_DEGREES, ext["p3_loewy_layers"])
+    assert p2["quadratic_relation_dimension"] == 29
+    assert p3["quadratic_relation_dimension"] == 70
+    assert sum(x["semisimple_dimension"] for x in p2["connected_components"]) == 38
+    assert sum(x["radical_head_dimension"] for x in p2["connected_components"]) == 29
+    assert sum(x["semisimple_dimension"] for x in p3["connected_components"]) == 11
+    assert sum(x["radical_head_dimension"] for x in p3["connected_components"]) == 23
+
+    fourier = base1500["pass1501_tensor_fourier"]
+    pairs = fourier["multiplicity_irreducible_pairs"]
+    multiplicities = [x[0] for x in pairs]
+    degrees = [x[1] for x in pairs]
+    ranks = [m * d for m, d in pairs]
+    commutant_dim = sum(m * m for m in multiplicities)
+    image_dim = sum(d * d for d in degrees)
+    module_dim = sum(ranks)
+    factorization_gauge_dim = commutant_dim + image_dim - len(pairs)
+    assert module_dim == 120 and commutant_dim == 83
+    assert ranks == fourier["block_dimensions"]
+
+    bridge = base1500["pass1502_bridge_classification"]
+    orbits = mask_orbits()
+    assert [len(x) for x in orbits] == [4, 4]
+    sheet_counts = {int(k): v for k, v in bridge["sheet_rank_distribution"].items()}
+    bridge_counts = {int(k): v for k, v in bridge["bridge_rank_distribution"].items()}
+    sheet_obstruction = {str(k): v % 4 for k, v in sorted(sheet_counts.items())}
+    assert sheet_obstruction == {"70": 0, "76": 1, "81": 3}
+    assert all(v % 4 == 0 for v in bridge_counts.values())
+
+    over = base1500["pass1503_maximal_overorder"]
+    e2 = over["global_index_factorization"]["2"]
+    e3 = over["global_index_factorization"]["3"]
+    N = (2 ** e2) * (3 ** e3)
+    assert str(N) == over["global_index"]
+    rational_blocks = [1] * 7 + [2] * 2 + [3] * 3 + [4, 5]
+    assert sum(n * n for n in rational_blocks) == 83
+
+    linking = base1500["pass1504_linking_algebra"]
+    natural = base1370["pass1374_selector_levi_bimodule_boundary"]
+    n, m = 120, 81
+    assert linking["left_corner_dimension"] == n * n
+    assert linking["right_corner_dimension"] == m * m
+    assert linking["bridge_bimodule_dimension"] == n * m
+    assert natural["steinberg_81_channel_present"] is False
+
+    result = {
+        "schema": "w33.pass1516_1520.five_frontiers.v1",
+        "status": "PASS",
+        "base_certificates": dict(EXPECTED_BASE_HASHES),
+        "pass1516_radical_graded_relations": {
+            "theorem": "Exact tensor-algebra relation defects in characteristics 2 and 3",
+            "p2": p2,
+            "p3": p3,
+            "headline": (
+                "The quadratic multiplication kernels have dimensions 29 at p=2 "
+                "and 70 at p=3. Characteristic 3 has the substantially denser "
+                "relation ideal already in degree two."
+            ),
+        },
+        "pass1517_coordinate_free_fourier": {
+            "theorem": "Basis-free double-centralizer form of the selector Fourier decomposition",
+            "isotypic_count": len(pairs),
+            "multiplicity_irreducible_pairs": pairs,
+            "canonical_isotypic_ranks": ranks,
+            "module_dimension_sum_m_times_d": module_dim,
+            "selector_commutant_dimension_sum_m_squared": commutant_dim,
+            "dual_image_dimension_sum_d_squared": image_dim,
+            "tensor_factorization_gauge_group_dimension": factorization_gauge_dim,
+            "canonical_evaluation_map": "direct_sum Hom_H(W_chi,V) tensor W_chi -> V",
+            "coordinate_free_content": (
+                "The fourteen central isotypic summands and the evaluation isomorphism "
+                "are canonical. A Fourier matrix is only a choice of bases in the two "
+                "factors of each summand."
+            ),
+            "boundary": (
+                "The frozen U and U^{-1} hashes certify one deterministic trivialization, "
+                "not an invariant under arbitrary changes of models for the irreducibles."
+            ),
+        },
+        "pass1518_apartment_d4_obstruction": {
+            "theorem": "Cardinality obstruction to a global rank-preserving D4 lift",
+            "local_mask_orbits": orbits,
+            "local_mask_orbit_sizes": [len(x) for x in orbits],
+            "sheet_rank_distribution": {str(k): v for k, v in sorted(sheet_counts.items())},
+            "sheet_rank_count_mod_4": sheet_obstruction,
+            "global_rank_preserving_d4_lift_exists": False,
+            "proof": (
+                "Every orbit of any D4-action on the 24 sheets that projects to the "
+                "standard action on masks must project onto a four-element mask orbit, "
+                "so each invariant rank level must have cardinality divisible by four. "
+                "The unique rank-76 sheet violates this necessary condition."
+            ),
+            "sign_extended_bridge_distribution": {str(k): v for k, v in sorted(bridge_counts.items())},
+            "bridge_census_alone_has_cardinality_obstruction": False,
+            "correct_symmetry_object": (
+                "Local D4 transport must be chart-dependent (an action groupoid with a "
+                "residual-label cocycle), or it must leave the frozen 24-sheet family."
+            ),
+            "boundary": (
+                "The cardinality argument proves nonexistence of a global rank-preserving "
+                "lift. It does not compute the full rectangle-by-rectangle S3 residual cocycle."
+            ),
+        },
+        "pass1519_maximal_order_arithmetic": {
+            "theorem": "Prime support, conductor bound, and componentwise class triviality",
+            "maximal_order_block_sizes": rational_blocks,
+            "z_rank": sum(n * n for n in rational_blocks),
+            "index": str(N),
+            "local_defect_lengths": {"2": e2, "3": e3},
+            "orbital_discriminant_valuations": {"2": 2 * e2, "3": 2 * e3},
+            "good_local_primes": "all primes other than 2 and 3",
+            "local_equality_away_from_2_3": True,
+            "conductor_support_subset": [2, 3],
+            "annihilator_bound": f"({N}) M_O is contained in the conductor f=(O:M_O)",
+            "componentwise_labeled_locally_free_class_group": "trivial",
+            "componentwise_reason": "Each labeled block M_n(Z) is Morita equivalent to Z, whose ideal class group is trivial.",
+            "unlabeled_equal_block_permutation_group_order": 60480,
+            "boundary": (
+                "The index and discriminant determine prime support and total local lengths, "
+                "but not the blockwise conductor exponents, Bass/Eichler status, or the Smith "
+                "invariants of M_O/O. Those require the frozen transition matrix itself."
+            ),
+        },
+        "pass1520_equivariant_morita": {
+            "theorem": "The saturated full-matrix Morita context is G-equivariant; the fixed-bridge obstruction is not a Morita obstruction",
+            "selector_dimension": n,
+            "signed_steinberg_dimension": m,
+            "left_algebra": "End_Q(V) = M_120(Q)",
+            "right_algebra": "End_Q(W) = M_81(Q)",
+            "equivalence_bimodule": "X = Hom_Q(W,V)",
+            "inverse_bimodule": "Y = Hom_Q(V,W)",
+            "equivalence_bimodule_dimension": n * m,
+            "pairing_witnesses": {
+                "End_V_matrix_unit": "E_ij = x_i0 y_0j",
+                "End_W_matrix_unit": "F_ab = y_a0 x_0b",
+            },
+            "G_action": "g.x = rho_V(g) x rho_W(g)^(-1), and similarly on Y",
+            "pairings_G_equivariant": True,
+            "strict_G_equivariant_Morita_context": True,
+            "equivariant_Brauer_obstruction": "zero",
+            "G_fixed_cross_map_present": False,
+            "fixed_cross_map_interpretation": (
+                "Hom_G(W,V)=0 forbids a G-fixed bridge element. It does not forbid the "
+                "full Hom(W,V) space from being a G-equivariant equivalence bimodule."
+            ),
+            "apartment_generator_span_dimension": linking["independent_bridge_dimension"],
+            "saturated_bimodule_dimension": linking["bridge_bimodule_dimension"],
+            "upgrade": (
+                "Pass 1504's 75 gauge bridges are a generating frame, not an invariant "
+                "bimodule. Their corner saturation is the full Hom(W,V), which is canonically "
+                "G-stable and supplies the equivariant Morita equivalence."
+            ),
+            "boundary": (
+                "This does not make any individual apartment bridge G-invariant, nor does it "
+                "supply a preferred G-fixed identification between V and W (their dimensions differ)."
+            ),
+        },
+    }
+    result["sha256"] = sha(result)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+    got = build()
+    encoded = json.dumps(got, indent=2, sort_keys=True) + "\n"
+    if args.write:
+        OUT.write_text(encoded)
+    if args.check:
+        assert hashlib.sha256(BASE1500.read_bytes()).hexdigest() == EXPECTED_BASE_HASHES["1500_1504_sha256"]
+        assert hashlib.sha256(BASE1370.read_bytes()).hexdigest() == EXPECTED_BASE_HASHES["1370_1374_sha256"]
+        expected = json.loads(OUT.read_text())
+        assert got == expected
+        print("PASS Passes 1516-1520 derived certificate", got["sha256"])
+    elif not args.write:
+        print(encoded, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/w33_pass1516_1520_five_frontiers.json
+++ b/data/w33_pass1516_1520_five_frontiers.json
@@ -1,0 +1,420 @@
+{
+  "base_certificates": {
+    "1370_1374_sha256": "284d9d7f9462a83f0709734d48a3ccf3284da2cb6b5ede159da5c719b84332b9",
+    "1500_1504_sha256": "757b01bacbfc157484851ec76cc3322204116c3aeb9cdf81851a2dbee1a56b3e"
+  },
+  "pass1516_radical_graded_relations": {
+    "headline": "The quadratic multiplication kernels have dimensions 29 at p=2 and 70 at p=3. Characteristic 3 has the substantially denser relation ideal already in degree two.",
+    "p2": {
+      "associated_graded_radical_layer_dimensions": [
+        38,
+        29,
+        16,
+        0
+      ],
+      "boundary": "These are relation spaces in the radical-associated graded algebra. They do not by themselves separate minimal higher-degree generators from consequences of lower-degree relations, and they do not yet give the complete Ext^2/Yoneda multiplication table.",
+      "connected_components": [
+        {
+          "radical_head_dimension": 4,
+          "semisimple_dimension": 3,
+          "simple_degrees": [
+            1,
+            1,
+            1
+          ],
+          "vertices": [
+            0,
+            3,
+            6
+          ]
+        },
+        {
+          "radical_head_dimension": 4,
+          "semisimple_dimension": 5,
+          "simple_degrees": [
+            1,
+            2
+          ],
+          "vertices": [
+            1,
+            9
+          ]
+        },
+        {
+          "radical_head_dimension": 2,
+          "semisimple_dimension": 2,
+          "simple_degrees": [
+            1,
+            1
+          ],
+          "vertices": [
+            2,
+            4
+          ]
+        },
+        {
+          "radical_head_dimension": 6,
+          "semisimple_dimension": 10,
+          "simple_degrees": [
+            1,
+            3
+          ],
+          "vertices": [
+            5,
+            12
+          ]
+        },
+        {
+          "radical_head_dimension": 13,
+          "semisimple_dimension": 9,
+          "simple_degrees": [
+            1,
+            2,
+            2
+          ],
+          "vertices": [
+            7,
+            8,
+            10
+          ]
+        },
+        {
+          "radical_head_dimension": 0,
+          "semisimple_dimension": 9,
+          "simple_degrees": [
+            3
+          ],
+          "vertices": [
+            11
+          ]
+        }
+      ],
+      "interpretation": "For S=A/J and B=J/J^2, the canonical tensor-algebra map T_S(B) -> gr_J(A) is surjective. The listed kernel dimensions are therefore exact homogeneous relation-space dimensions.",
+      "quadratic_path_dimension": 45,
+      "quadratic_radical_layer_dimension": 16,
+      "quadratic_relation_dimension": 29,
+      "relation_kernel_dimensions": [
+        0,
+        0,
+        29,
+        59
+      ],
+      "simple_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3
+      ],
+      "tensor_path_dimensions_degrees_0_through_loewy": [
+        38,
+        29,
+        45,
+        59
+      ]
+    },
+    "p3": {
+      "associated_graded_radical_layer_dimensions": [
+        11,
+        23,
+        22,
+        13,
+        10,
+        4,
+        0
+      ],
+      "boundary": "These are relation spaces in the radical-associated graded algebra. They do not by themselves separate minimal higher-degree generators from consequences of lower-degree relations, and they do not yet give the complete Ext^2/Yoneda multiplication table.",
+      "connected_components": [
+        {
+          "radical_head_dimension": 23,
+          "semisimple_dimension": 11,
+          "simple_degrees": [
+            1,
+            1,
+            1,
+            2,
+            2
+          ],
+          "vertices": [
+            0,
+            1,
+            2,
+            3,
+            4
+          ]
+        }
+      ],
+      "interpretation": "For S=A/J and B=J/J^2, the canonical tensor-algebra map T_S(B) -> gr_J(A) is surjective. The listed kernel dimensions are therefore exact homogeneous relation-space dimensions.",
+      "quadratic_path_dimension": 92,
+      "quadratic_radical_layer_dimension": 22,
+      "quadratic_relation_dimension": 70,
+      "relation_kernel_dimensions": [
+        0,
+        0,
+        70,
+        320,
+        1221,
+        4556,
+        16952
+      ],
+      "simple_degrees": [
+        1,
+        1,
+        1,
+        2,
+        2
+      ],
+      "tensor_path_dimensions_degrees_0_through_loewy": [
+        11,
+        23,
+        92,
+        333,
+        1231,
+        4560,
+        16952
+      ]
+    },
+    "theorem": "Exact tensor-algebra relation defects in characteristics 2 and 3"
+  },
+  "pass1517_coordinate_free_fourier": {
+    "boundary": "The frozen U and U^{-1} hashes certify one deterministic trivialization, not an invariant under arbitrary changes of models for the irreducibles.",
+    "canonical_evaluation_map": "direct_sum Hom_H(W_chi,V) tensor W_chi -> V",
+    "canonical_isotypic_ranks": [
+      1,
+      2,
+      2,
+      4,
+      4,
+      8,
+      8,
+      2,
+      4,
+      12,
+      12,
+      24,
+      32,
+      5
+    ],
+    "coordinate_free_content": "The fourteen central isotypic summands and the evaluation isomorphism are canonical. A Fourier matrix is only a choice of bases in the two factors of each summand.",
+    "dual_image_dimension_sum_d_squared": 335,
+    "isotypic_count": 14,
+    "module_dimension_sum_m_times_d": 120,
+    "multiplicity_irreducible_pairs": [
+      [
+        1,
+        1
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        1,
+        4
+      ],
+      [
+        1,
+        4
+      ],
+      [
+        1,
+        8
+      ],
+      [
+        1,
+        8
+      ],
+      [
+        2,
+        1
+      ],
+      [
+        2,
+        2
+      ],
+      [
+        3,
+        4
+      ],
+      [
+        3,
+        4
+      ],
+      [
+        3,
+        8
+      ],
+      [
+        4,
+        8
+      ],
+      [
+        5,
+        1
+      ]
+    ],
+    "selector_commutant_dimension_sum_m_squared": 83,
+    "tensor_factorization_gauge_group_dimension": 404,
+    "theorem": "Basis-free double-centralizer form of the selector Fourier decomposition"
+  },
+  "pass1518_apartment_d4_obstruction": {
+    "boundary": "The cardinality argument proves nonexistence of a global rank-preserving lift. It does not compute the full rectangle-by-rectangle S3 residual cocycle.",
+    "bridge_census_alone_has_cardinality_obstruction": false,
+    "correct_symmetry_object": "Local D4 transport must be chart-dependent (an action groupoid with a residual-label cocycle), or it must leave the frozen 24-sheet family.",
+    "global_rank_preserving_d4_lift_exists": false,
+    "local_mask_orbit_sizes": [
+      4,
+      4
+    ],
+    "local_mask_orbits": [
+      [
+        [
+          0,
+          0,
+          1,
+          1
+        ],
+        [
+          0,
+          1,
+          1,
+          0
+        ],
+        [
+          1,
+          0,
+          0,
+          1
+        ],
+        [
+          1,
+          1,
+          0,
+          0
+        ]
+      ],
+      [
+        [
+          0,
+          1,
+          1,
+          1
+        ],
+        [
+          1,
+          0,
+          1,
+          1
+        ],
+        [
+          1,
+          1,
+          0,
+          1
+        ],
+        [
+          1,
+          1,
+          1,
+          0
+        ]
+      ]
+    ],
+    "proof": "Every orbit of any D4-action on the 24 sheets that projects to the standard action on masks must project onto a four-element mask orbit, so each invariant rank level must have cardinality divisible by four. The unique rank-76 sheet violates this necessary condition.",
+    "sheet_rank_count_mod_4": {
+      "70": 0,
+      "76": 1,
+      "81": 3
+    },
+    "sheet_rank_distribution": {
+      "70": 4,
+      "76": 1,
+      "81": 19
+    },
+    "sign_extended_bridge_distribution": {
+      "70": 16,
+      "76": 4,
+      "81": 76
+    },
+    "theorem": "Cardinality obstruction to a global rank-preserving D4 lift"
+  },
+  "pass1519_maximal_order_arithmetic": {
+    "annihilator_bound": "(56465298353599514565459914148042866857053267066089785123802185728) M_O is contained in the conductor f=(O:M_O)",
+    "boundary": "The index and discriminant determine prime support and total local lengths, but not the blockwise conductor exponents, Bass/Eichler status, or the Smith invariants of M_O/O. Those require the frozen transition matrix itself.",
+    "componentwise_labeled_locally_free_class_group": "trivial",
+    "componentwise_reason": "Each labeled block M_n(Z) is Morita equivalent to Z, whose ideal class group is trivial.",
+    "conductor_support_subset": [
+      2,
+      3
+    ],
+    "good_local_primes": "all primes other than 2 and 3",
+    "index": "56465298353599514565459914148042866857053267066089785123802185728",
+    "local_defect_lengths": {
+      "2": 36,
+      "3": 113
+    },
+    "local_equality_away_from_2_3": true,
+    "maximal_order_block_sizes": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+      3,
+      4,
+      5
+    ],
+    "orbital_discriminant_valuations": {
+      "2": 72,
+      "3": 226
+    },
+    "theorem": "Prime support, conductor bound, and componentwise class triviality",
+    "unlabeled_equal_block_permutation_group_order": 60480,
+    "z_rank": 83
+  },
+  "pass1520_equivariant_morita": {
+    "G_action": "g.x = rho_V(g) x rho_W(g)^(-1), and similarly on Y",
+    "G_fixed_cross_map_present": false,
+    "apartment_generator_span_dimension": 75,
+    "boundary": "This does not make any individual apartment bridge G-invariant, nor does it supply a preferred G-fixed identification between V and W (their dimensions differ).",
+    "equivalence_bimodule": "X = Hom_Q(W,V)",
+    "equivalence_bimodule_dimension": 9720,
+    "equivariant_Brauer_obstruction": "zero",
+    "fixed_cross_map_interpretation": "Hom_G(W,V)=0 forbids a G-fixed bridge element. It does not forbid the full Hom(W,V) space from being a G-equivariant equivalence bimodule.",
+    "inverse_bimodule": "Y = Hom_Q(V,W)",
+    "left_algebra": "End_Q(V) = M_120(Q)",
+    "pairing_witnesses": {
+      "End_V_matrix_unit": "E_ij = x_i0 y_0j",
+      "End_W_matrix_unit": "F_ab = y_a0 x_0b"
+    },
+    "pairings_G_equivariant": true,
+    "right_algebra": "End_Q(W) = M_81(Q)",
+    "saturated_bimodule_dimension": 9720,
+    "selector_dimension": 120,
+    "signed_steinberg_dimension": 81,
+    "strict_G_equivariant_Morita_context": true,
+    "theorem": "The saturated full-matrix Morita context is G-equivariant; the fixed-bridge obstruction is not a Morita obstruction",
+    "upgrade": "Pass 1504's 75 gauge bridges are a generating frame, not an invariant bimodule. Their corner saturation is the full Hom(W,V), which is canonically G-stable and supplies the equivariant Morita equivalence."
+  },
+  "schema": "w33.pass1516_1520.five_frontiers.v1",
+  "sha256": "c946554a7e2af52440636263f85e8f8f75e02c6f4fadc8211d4481ea67256f91",
+  "status": "PASS"
+}

--- a/data/w33_pass_namespace_registry_v2.d/1516-1520.json
+++ b/data/w33_pass_namespace_registry_v2.d/1516-1520.json
@@ -1,0 +1,16 @@
+{
+  "schema": "w33.pass_namespace_registry.v2.supplement",
+  "status": "ACTIVE",
+  "canonical_blocks": [
+    {
+      "range": "1516-1520",
+      "title": "Relations, coordinate-free Fourier form, apartment D4 obstruction, maximal-order arithmetic, and equivariant Morita closure",
+      "source": "analysis/w33_pass1516_1520_five_frontiers.py",
+      "certificate": "data/w33_pass1516_1520_five_frontiers.json",
+      "compact_certificate_sha256": "603380fbc9370b97b08273a67785b43f9c52960610d84661f99228bbe020ab48",
+      "report": "analysis/BT1516_BT1520_five_frontiers.md",
+      "manuscript_insert": "paper/sections/sec_bt1516_bt1520_five_frontiers.tex",
+      "evidence_boundary": "Exact derived consequences of the frozen Passes 1370-1374 and 1500-1504 certificates. The expensive base workers are hash-locked but not rerun by this packet. Higher Yoneda generators and the residual-label transport cocycle remain open."
+    }
+  ]
+}

--- a/paper/sections/sec_bt1516_bt1520_five_frontiers.tex
+++ b/paper/sections/sec_bt1516_bt1520_five_frontiers.tex
@@ -1,0 +1,37 @@
+\subsection{Five derived selector frontiers: relations, canonicality, symmetry, arithmetic, and equivariance}\label{sec:pass1516-1520}
+Let $A$ be the $83$-dimensional selector orbital algebra, $J$ its modular Jacobson radical, and $S=A/J$.  The frozen Gabriel quivers determine $B=J/J^2$ as an $S$-bimodule.  Comparing the tensor algebra $T_S(B)$ with $\operatorname{gr}_J(A)$ gives quadratic relation-space dimensions
+\[
+29\quad (p=2),\qquad 70\quad (p=3).
+\]
+These are exact associated-graded relation defects; the complete $\operatorname{Ext}^2$ and Yoneda multiplication table remains open.
+
+The selector Fourier decomposition has the coordinate-free form
+\[
+V\cong\bigoplus_\chi \operatorname{Hom}_H(W_\chi,V)\otimes W_\chi,
+\]
+with
+\[
+\sum m_\chi d_\chi=120,\qquad \sum m_\chi^2=83,\qquad \sum d_\chi^2=335.
+\]
+Thus the fourteen isotypic summands and the evaluation map are canonical; the frozen Fourier matrix is a deterministic choice of bases in those factors.
+
+The eight apartment masks form two $D_4$-orbits of size four.  Any rank-preserving lift to the $24$ frozen sheets would force every rank-level cardinality to be divisible by four, contradicting the exact distribution
+\[
+70^4,\qquad 76^1,\qquad 81^{19}.
+\]
+Hence the local $D_4$ symmetry globalizes only through chart-dependent transport, not as a rank-preserving action on the frozen sheet labels.
+
+For the containing split maximal order,
+\[
+[M_O:O]=2^{36}3^{113},
+\]
+so $O$ and $M_O$ agree locally away from $2$ and $3$, the conductor is supported at those two primes, and
+\[
+2^{36}3^{113}M_O\subseteq\mathfrak f=\{x\in M_O:xM_O\subseteq O\}.
+\]
+
+Finally, let $V$ be the selector $120$ and $W$ the signed Steinberg $81$.  Although $\operatorname{Hom}_G(W,V)=0$, the full bimodule
+\[
+X=\operatorname{Hom}_{\mathbb Q}(W,V)
+\]
+with $g\cdot x=\rho_V(g)x\rho_W(g)^{-1}$ gives a strict $G$-equivariant Morita equivalence between $M_{120}(\mathbb Q)$ and $M_{81}(\mathbb Q)$.  The vanishing invariant space forbids a fixed bridge element; it is not an equivariant Morita obstruction.  The $75$ apartment bridges are therefore a gauge generating frame whose full corner saturation is the canonical $9720$-dimensional equivariant bimodule.

--- a/paper/sections/sec_complement_duality.tex
+++ b/paper/sections/sec_complement_duality.tex
@@ -1,3 +1,4 @@
-% Reversible manuscript wrapper installed for Passes 1500--1504.
+% Reversible manuscript wrapper installed for Passes 1500--1504 and extended for Passes 1516--1520.
 \input{sections/sec_complement_duality_body}
 \input{sections/sec_bt1500_bt1504_five_frontiers}
+\input{sections/sec_bt1516_bt1520_five_frontiers}

--- a/photonic_holonet.tex
+++ b/photonic_holonet.tex
@@ -1,5 +1,6 @@
-% Pass 1420/1425/1408/1509/1510/1511-1515 wrapper: preserve the complete historical manuscript body verbatim
-% while injecting the certified theorem inserts immediately after the contents.
+% Pass 1420/1425/1408/1509/1510/1511-1515 plus frame-Hoffman wrapper:
+% preserve the complete historical manuscript body verbatim while injecting the
+% certified theorem inserts immediately after the contents.
 \AtBeginDocument{%
   \let\BTorigtableofcontents\tableofcontents
   \renewcommand{\tableofcontents}{%
@@ -10,6 +11,7 @@
     \input{analysis/BT1509_census_morita_m20_insert}%
     \input{analysis/BT1510_bidirectional_cover_saturation_insert}%
     \input{analysis/BT1515_cover_resolution_insert}%
+    \input{analysis/frame_hoffman_resolution_insert}%
   }%
 }
 \input{photonic_holonet_body.tex}

--- a/tests/test_w33_pass1516_1520_five_frontiers.py
+++ b/tests/test_w33_pass1516_1520_five_frontiers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CERT = ROOT / "data" / "w33_pass1516_1520_five_frontiers.json"
+SCRIPT = ROOT / "analysis" / "w33_pass1516_1520_five_frontiers.py"
+EXPECTED_CERT_SHA = "603380fbc9370b97b08273a67785b43f9c52960610d84661f99228bbe020ab48"
+
+
+def payload() -> dict:
+    return json.loads(CERT.read_text())
+
+
+def load_worker():
+    spec = importlib.util.spec_from_file_location("pass1516_1520", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_certificate_digest_schema_and_rebuild():
+    assert hashlib.sha256(CERT.read_bytes()).hexdigest() == EXPECTED_CERT_SHA
+    data = payload()
+    assert data["schema"] == "w33.pass1516_1520.five_frontiers.v1"
+    assert data["status"] == "PASS"
+    assert load_worker().build() == data
+
+
+def test_pass1516_relation_frontier():
+    p = payload()["pass1516_radical_graded_relations"]
+    assert p["p2"]["tensor_path_dimensions_degrees_0_through_loewy"] == [38, 29, 45, 59]
+    assert p["p2"]["associated_graded_radical_layer_dimensions"] == [38, 29, 16, 0]
+    assert p["p2"]["relation_kernel_dimensions"] == [0, 0, 29, 59]
+    assert p["p2"]["quadratic_relation_dimension"] == 29
+    assert len(p["p2"]["connected_components"]) == 6
+    assert p["p3"]["tensor_path_dimensions_degrees_0_through_loewy"] == [11, 23, 92, 333, 1231, 4560, 16952]
+    assert p["p3"]["associated_graded_radical_layer_dimensions"] == [11, 23, 22, 13, 10, 4, 0]
+    assert p["p3"]["relation_kernel_dimensions"] == [0, 0, 70, 320, 1221, 4556, 16952]
+    assert p["p3"]["quadratic_relation_dimension"] == 70
+    assert len(p["p3"]["connected_components"]) == 1
+
+
+def test_pass1517_coordinate_free_fourier():
+    p = payload()["pass1517_coordinate_free_fourier"]
+    assert p["canonical_isotypic_ranks"] == [1, 2, 2, 4, 4, 8, 8, 2, 4, 12, 12, 24, 32, 5]
+    assert p["module_dimension_sum_m_times_d"] == 120
+    assert p["selector_commutant_dimension_sum_m_squared"] == 83
+    assert p["dual_image_dimension_sum_d_squared"] == 335
+    assert p["tensor_factorization_gauge_group_dimension"] == 404
+
+
+def test_pass1518_d4_no_go():
+    p = payload()["pass1518_apartment_d4_obstruction"]
+    assert p["local_mask_orbit_sizes"] == [4, 4]
+    assert p["sheet_rank_distribution"] == {"70": 4, "76": 1, "81": 19}
+    assert p["sheet_rank_count_mod_4"] == {"70": 0, "76": 1, "81": 3}
+    assert p["global_rank_preserving_d4_lift_exists"] is False
+    assert p["bridge_census_alone_has_cardinality_obstruction"] is False
+
+
+def test_pass1519_arithmetic_support():
+    p = payload()["pass1519_maximal_order_arithmetic"]
+    assert p["z_rank"] == 83
+    assert p["local_defect_lengths"] == {"2": 36, "3": 113}
+    assert p["orbital_discriminant_valuations"] == {"2": 72, "3": 226}
+    assert p["local_equality_away_from_2_3"] is True
+    assert p["conductor_support_subset"] == [2, 3]
+    assert p["unlabeled_equal_block_permutation_group_order"] == 60480
+
+
+def test_pass1520_equivariant_morita_refinement():
+    p = payload()["pass1520_equivariant_morita"]
+    assert p["equivalence_bimodule_dimension"] == 120 * 81
+    assert p["pairings_G_equivariant"] is True
+    assert p["strict_G_equivariant_Morita_context"] is True
+    assert p["equivariant_Brauer_obstruction"] == "zero"
+    assert p["G_fixed_cross_map_present"] is False
+    assert p["apartment_generator_span_dimension"] == 75
+    assert p["saturated_bimodule_dimension"] == 9720
+
+
+def test_report_and_insert_preserve_boundaries():
+    report = (ROOT / "analysis" / "BT1516_BT1520_five_frontiers.md").read_text()
+    insert = (ROOT / "paper" / "sections" / "sec_bt1516_bt1520_five_frontiers.tex").read_text()
+    assert EXPECTED_CERT_SHA in report
+    assert r"complete Ext\(^2\) or Yoneda multiplication table" in report
+    assert "no global rank-preserving" in report
+    assert "Hom}_G(W,V)=0" in insert
+    assert "not an equivariant Morita obstruction" in insert


### PR DESCRIPTION
## Exact results

- **Pass 1516:** computes the homogeneous relation kernels of `T_S(J/J²) -> gr_J(A)`: quadratic dimensions **29** at `p=2` and **70** at `p=3`, with complete tensor-path/radical-layer dimension frontiers and explicit higher-Yoneda boundaries.
- **Pass 1517:** replaces the coordinate-dependent Fourier statement by the canonical isotypic evaluation map, with exact sums `Σmd=120`, `Σm²=83`, `Σd²=335`, and factorization-gauge dimension `404`.
- **Pass 1518:** proves no global rank-preserving `D4` lift can act on the frozen 24 sheets because the rank-76 level is a singleton while each projected orbit must have cardinality divisible by four.
- **Pass 1519:** derives local defect lengths `36` and `113`, discriminant valuations `72` and `226`, equality with the maximal order away from `2,3`, conductor support at `2,3`, and the exact annihilator/conductor bound.
- **Pass 1520:** corrects the equivariant interpretation: `Hom_G(W,V)=0` forbids a fixed bridge element, not equivariance of the full `Hom(W,V)` bimodule. The saturated `9720`-dimensional context is a strict `G`-equivariant Morita equivalence; the equivariant Brauer obstruction is zero.

## Release engineering

Adds the hash-locked compact certificate (`603380fbc9370b97b08273a67785b43f9c52960610d84661f99228bbe020ab48`), exact derived worker, focused tests, CI, theorem report, standalone LaTeX insert, reversible manuscript reachability, and namespace metadata.

## Evidence boundaries

This packet hash-locks but does not rerun the expensive Passes 1370–1374 and 1500–1504 workers. It does **not** claim the complete Ext²/Yoneda multiplication table, minimal higher relation generators, the residual `S3` atlas cocycle, or blockwise conductor/Smith invariants.