### PR TITLE
Pass 2303: verify and synthesize exact W33 RTL

### DIFF
--- a/.github/workflows/pass2303_hardware_toolchain.yml
+++ b/.github/workflows/pass2303_hardware_toolchain.yml
@@ -1,0 +1,61 @@
+name: Pass 2303 hardware toolchain
+on:
+  pull_request:
+    paths:
+      - 'rtl/w33_pass2303_packed_toolchain.sv'
+      - 'formal/w33_pass2303_formal.sv'
+      - 'tests/rtl/w33_pass2303_tb.sv'
+      - '.github/workflows/pass2303_hardware_toolchain.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  open-source-hdl:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Icarus and Yosys
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iverilog yosys
+          mkdir -p hardware_logs
+          iverilog -V 2>&1 | tee hardware_logs/iverilog_version.txt
+          yosys -V 2>&1 | tee hardware_logs/yosys_version.txt
+      - name: Compile and simulate
+        run: |
+          set -o pipefail
+          iverilog -g2012 -Wall -s w33_pass2303_tb -o /tmp/w33_tb \
+            rtl/w33_pass2303_packed_toolchain.sv tests/rtl/w33_pass2303_tb.sv \
+            2>&1 | tee hardware_logs/iverilog_compile.log
+          vvp /tmp/w33_tb 2>&1 | tee hardware_logs/iverilog_simulation.log
+      - name: Lint and generic synthesis
+        run: |
+          set -o pipefail
+          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; hierarchy -check -top w33_spread_mixer36_packed; proc; opt; check; stat' \
+            2>&1 | tee hardware_logs/yosys_generic.log
+      - name: Prove mixer identity
+        run: |
+          set -o pipefail
+          yosys -p 'read_verilog -formal -sv rtl/w33_pass2303_packed_toolchain.sv formal/w33_pass2303_formal.sv; prep -top w33_mixer_formal; flatten; opt; sat -verify -prove-asserts -timeout 300' \
+            2>&1 | tee hardware_logs/yosys_formal_mixer.log
+      - name: Prove D24 associativity and kernel
+        run: |
+          set -o pipefail
+          yosys -p 'read_verilog -formal -sv rtl/w33_pass2303_packed_toolchain.sv formal/w33_pass2303_formal.sv; prep -top w33_phase_formal; flatten; opt; sat -verify -prove-asserts -set-assumes -timeout 120' \
+            2>&1 | tee hardware_logs/yosys_formal_phase.log
+      - name: iCE40 synthesis
+        run: |
+          set -o pipefail
+          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; synth_ice40 -top w33_spread_mixer36_packed -json hardware_logs/mixer_ice40.json; stat' \
+            2>&1 | tee hardware_logs/yosys_ice40.log
+      - name: ECP5 synthesis
+        run: |
+          set -o pipefail
+          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; synth_ecp5 -top w33_spread_mixer36_packed -json hardware_logs/mixer_ecp5.json; stat' \
+            2>&1 | tee hardware_logs/yosys_ecp5.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pass2303-hardware-logs
+          path: hardware_logs

--- a/.github/workflows/pass2303_hardware_toolchain.yml
+++ b/.github/workflows/pass2303_hardware_toolchain.yml
@@ -5,6 +5,9 @@ on:
       - 'rtl/w33_pass2303_packed_toolchain.sv'
       - 'formal/w33_pass2303_formal.sv'
       - 'tests/rtl/w33_pass2303_tb.sv'
+      - 'tests/test_w33_pass2300_2305.py'
+      - 'analysis/w33_pass230*.py'
+      - 'data/w33_pass230*.json'
       - '.github/workflows/pass2303_hardware_toolchain.yml'
   workflow_dispatch:
 permissions:
@@ -15,13 +18,21 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Install Icarus and Yosys
+      - name: Install mathematical and HDL toolchains
         run: |
           sudo apt-get update
           sudo apt-get install -y iverilog yosys
+          python -m pip install --disable-pip-version-check numpy pytest
           mkdir -p hardware_logs
           iverilog -V 2>&1 | tee hardware_logs/iverilog_version.txt
           yosys -V 2>&1 | tee hardware_logs/yosys_version.txt
+      - name: Verify mathematical certificates
+        run: |
+          python analysis/w33_pass2300_ree_tits_divisible_code.py --verify-frozen
+          python analysis/w33_pass2301_complete_quadratic_hom_bases.py --verify-frozen
+          python analysis/w33_pass2302_q7_q11_weil_outer_inversion.py --verify-frozen
+          python analysis/w33_pass2304_known_q27_spread_spectra.py --verify-frozen
+          pytest -q tests/test_w33_pass2300_2305.py
       - name: Compile and simulate
         run: |
           set -o pipefail

--- a/.github/workflows/pass2303_hardware_toolchain.yml
+++ b/.github/workflows/pass2303_hardware_toolchain.yml
@@ -40,10 +40,10 @@ jobs:
             rtl/w33_pass2303_packed_toolchain.sv tests/rtl/w33_pass2303_tb.sv \
             2>&1 | tee hardware_logs/iverilog_compile.log
           vvp /tmp/w33_tb 2>&1 | tee hardware_logs/iverilog_simulation.log
-      - name: Lint and generic synthesis
+      - name: Lint and generic synthesis W4
         run: |
           set -o pipefail
-          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; hierarchy -check -top w33_spread_mixer36_packed; proc; opt; check; stat' \
+          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; hierarchy -check -top w33_spread_mixer36_packed; chparam -set W 4 -set OW 8 w33_spread_mixer36_packed; proc; opt; check; stat' \
             2>&1 | tee hardware_logs/yosys_generic.log
       - name: Prove mixer identity
         run: |
@@ -55,15 +55,15 @@ jobs:
           set -o pipefail
           yosys -p 'read_verilog -formal -sv rtl/w33_pass2303_packed_toolchain.sv formal/w33_pass2303_formal.sv; prep -top w33_phase_formal; flatten; opt; sat -verify -prove-asserts -set-assumes -timeout 120' \
             2>&1 | tee hardware_logs/yosys_formal_phase.log
-      - name: iCE40 synthesis
+      - name: iCE40 synthesis W4
         run: |
           set -o pipefail
-          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; synth_ice40 -top w33_spread_mixer36_packed -json hardware_logs/mixer_ice40.json; stat' \
+          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; hierarchy -top w33_spread_mixer36_packed; chparam -set W 4 -set OW 8 w33_spread_mixer36_packed; synth_ice40 -top w33_spread_mixer36_packed -json hardware_logs/mixer_ice40.json; stat' \
             2>&1 | tee hardware_logs/yosys_ice40.log
-      - name: ECP5 synthesis
+      - name: ECP5 synthesis W4
         run: |
           set -o pipefail
-          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; synth_ecp5 -top w33_spread_mixer36_packed -json hardware_logs/mixer_ecp5.json; stat' \
+          yosys -p 'read_verilog -sv rtl/w33_pass2303_packed_toolchain.sv; hierarchy -top w33_spread_mixer36_packed; chparam -set W 4 -set OW 8 w33_spread_mixer36_packed; synth_ecp5 -top w33_spread_mixer36_packed -json hardware_logs/mixer_ecp5.json; stat' \
             2>&1 | tee hardware_logs/yosys_ecp5.log
       - uses: actions/upload-artifact@v4
         if: always()

--- a/analysis/BT2300_BT2305_five_frontiers.md
+++ b/analysis/BT2300_BT2305_five_frontiers.md
@@ -28,7 +28,7 @@ The universal theorem for arbitrary ovoids of `Q(4,p^h)` supplies only the weake
 
 ## Pass 2301 — the full quadratic algebra has dimension 50
 
-The literal signed 240-edge representation and its target-identified projectors were reconstructed over `GF(101)`. Signed orbits of edge triples give compressed integral tensors. Exact output-span and independence tests produce complete bases
+The literal signed 240-edge representation and its target-identified projectors were reconstructed modulo 101, a semisimple test characteristic not dividing the group order. The tensors themselves are integral signed-orbit tensors; exact modular full-rank tests certify their characteristic-zero independence and surjectivity, while the Hom dimensions are independently fixed by the character calculation. Exact output-span and independence tests produce complete bases
 
 | target | `Sym^2(90)` | `Lambda^2(90)` |
 |---:|---:|---:|
@@ -97,11 +97,11 @@ The tool-friendly RTL consists of
 - a packed 36-lane signed spread mixer;
 - the faithful `D24=C12:C2` phase action;
 - a wrapper implementing the shared C4/C6 command map;
-- exhaustive Icarus simulation;
-- Yosys SAT properties for `A^2=9I+6J`, D24 associativity, and the `(step4,step6)=(2,3)` kernel;
-- generic, iCE40 and ECP5 synthesis commands.
+- deterministic Icarus simulation of the mixer and exhaustive simulation of all phase-state/command combinations;
+- Yosys SAT properties proving `A^2=9I+6J` for every 4-bit 36-lane input, D24 associativity, and the `(step4,step6)=(2,3)` kernel;
+- generic, iCE40 and ECP5 synthesis of an explicit `W=4, OW=8` mixer instance.
 
-The observable pull-request workflow is `Pass 2303 hardware toolchain`. Tool versions, proof logs, synthesis logs and JSON netlists are retained as a workflow artifact. Exact cell counts and conclusions are frozen only after the workflow completes; no fabricated-device timing, power or area is inferred from generic synthesis.
+The observable pull-request workflow is `Pass 2303 hardware toolchain`. Tool versions, proof logs, synthesis logs and JSON netlists are retained as workflow artifacts. Exact cell counts and conclusions are frozen only after the workflow completes; no fabricated-device timing, power or area is inferred from generic synthesis.
 
 ## Pass 2304 — four q=27 spread families have distinct spectra
 

--- a/analysis/BT2300_BT2305_five_frontiers.md
+++ b/analysis/BT2300_BT2305_five_frontiers.md
@@ -1,0 +1,134 @@
+# Passes 2300–2305 — divisible ovoid codes, complete quadratic Hom bases, Weil inversion, verified RTL, and nonregular spectra
+
+## Pass 2300 — the Ree–Tits `1 mod 9` law is a divisible-code theorem
+
+The q=27 Ree–Tits ovoid was reconstructed in `PG(4,27)` from
+
+`g(x,y)=-x^21-y^9`
+
+over `GF(27)=F_3[t]/(t^3+2t+1)`. Every one of the 551,881 projective hyperplanes was evaluated. The complete intersection spectrum is
+
+| section size | number of hyperplanes |
+|---:|---:|
+| 1 | 730 |
+| 10 | 4,563 |
+| 19 | 96,174 |
+| 28 | 408,294 |
+| 37 | 36,504 |
+| 46 | 4,914 |
+| 55 | 702 |
+
+All seven values are `1 mod 9`. Equivalently, the five homogeneous coordinate rows generate a projective `[730,5]_27` code with nonzero weights
+
+`675,684,693,702,711,720,729`.
+
+The gcd is exactly 9, so the code is 9-divisible but not 27-divisible. The first three Pless factorial moments and the total `27^5` codeword count were checked exactly. This is the structural explanation of the observed congruence: a hyperplane section has size `730-w`, where `w` is a codeword weight.
+
+The universal theorem for arbitrary ovoids of `Q(4,p^h)` supplies only the weaker congruence `1 mod p`. The stronger `1 mod 9` statement is therefore recorded as an exhaustive theorem for this q=27 coordinate object, not as an unproved universal law.
+
+## Pass 2301 — the full quadratic algebra has dimension 50
+
+The literal signed 240-edge representation and its target-identified projectors were reconstructed over `GF(101)`. Signed orbits of edge triples give compressed integral tensors. Exact output-span and independence tests produce complete bases
+
+| target | `Sym^2(90)` | `Lambda^2(90)` |
+|---:|---:|---:|
+| 15 | 3 | 3 |
+| 24 | 6 | 4 |
+| 30 | 5 | 5 |
+| 81 | 12 | 12 |
+
+Thus
+
+`dim Hom_PSp(Sym^2(90),15+24+30+81)=26`
+
+and
+
+`dim Hom_PSp(Lambda^2(90),15+24+30+81)=24`.
+
+The complete PSp-equivariant quadratic algebra has dimension 50.
+
+The outer similitude splits every multiplicity space. Its even half is
+
+| target | symmetric even | alternating even |
+|---:|---:|---:|
+| 15 | 3 | 0 |
+| 24 | 5 | 0 |
+| 30 | 3 | 2 |
+| 81 | 7 | 5 |
+
+which is exactly the target-identified Pass-2200 table. The previously unrecorded outer-odd half is
+
+| target | symmetric odd | alternating odd |
+|---:|---:|---:|
+| 15 | 0 | 3 |
+| 24 | 1 | 4 |
+| 30 | 2 | 3 |
+| 81 | 5 | 7 |
+
+so the outer-even and outer-odd sectors both have dimension 25. The earlier table was not wrong as a PGSp table; it was incomplete as a PSp table.
+
+The simultaneous `mu6` input action factors to order three on bilinear maps. Its fixed dimensions and rotation-pair counts were computed exactly, and the outer involution conjugates the phase action to its inverse. Every listed basis tensor is surjective onto its irreducible target. These are allowed intertwiners, not physical coupling constants.
+
+## Pass 2302 — q=7 and q=11 close on the canonical Weil family
+
+For each q in `{7,11}`, use the Schrödinger Weil representation on functions on `F_q^2`. Parity gives the canonical even and odd constituents
+
+| q | even complex dimension | odd complex dimension |
+|---:|---:|---:|
+| 7 | 25 | 24 |
+| 11 | 61 | 60 |
+
+The similitude `h=diag(I_2,-I_2)` has nonsquare multiplier `-1`. Entrywise complex conjugation implements its action on the standard generators:
+
+- chirp `B` is sent to chirp `-B`;
+- the determinant-one Levi permutation is fixed;
+- the normalized Fourier operator is sent to its inverse.
+
+The maximum numerical generator-identity residual is below `1.1e-13`. On realification, complex multiplication `J` and conjugation `K` satisfy
+
+`J^2=-I`, `K^2=I`, `KJK=-J`,
+
+so they generate `D4` of order eight on each parity constituent. This closes the two-i inversion theorem objectwise for a canonical q=7/q=11 representation family. It does not identify those constituents with the q=3 signed-edge 90.
+
+## Pass 2303 — real open-source HDL verification
+
+The tool-friendly RTL consists of
+
+- a packed 36-lane signed spread mixer;
+- the faithful `D24=C12:C2` phase action;
+- a wrapper implementing the shared C4/C6 command map;
+- exhaustive Icarus simulation;
+- Yosys SAT properties for `A^2=9I+6J`, D24 associativity, and the `(step4,step6)=(2,3)` kernel;
+- generic, iCE40 and ECP5 synthesis commands.
+
+The observable pull-request workflow is `Pass 2303 hardware toolchain`. Tool versions, proof logs, synthesis logs and JSON netlists are retained as a workflow artifact. Exact cell counts and conclusions are frozen only after the workflow completes; no fabricated-device timing, power or area is inferred from generic synthesis.
+
+## Pass 2304 — four q=27 spread families have distinct spectra
+
+The complete hyperplane and regular-section spectra were computed for four standard coordinate families:
+
+1. regular: `g=-nx`;
+2. Kantor: `g=-nx^3`;
+3. Thas–Payne: `g=-nx-(n^{-1}x)^3-y^9`;
+4. Ree–Tits: `g=-x^21-y^9`.
+
+All four have section sizes congruent to one modulo nine, but the spectra are pairwise different.
+
+The regular elliptic section lies in a hyperplane, giving a 27-divisible `[730,4]_27` two-weight code. The three nonregular ovoids span `PG(4,27)` and give pairwise distinct, exactly 9-divisible `[730,5]_27` codes.
+
+The numbers of possible intersections with regular spreads, including the self-intersection where applicable, are
+
+| family | number of values |
+|---|---:|
+| regular | 3 |
+| Kantor | 5 |
+| Thas–Payne | 7 |
+| Ree–Tits | 6 |
+
+This replaces a single counterexample by an exact four-family taxonomy. It is not a classification of all symplectic spreads.
+
+## Evidence boundary
+
+The finite-field coordinate families, ovoid/spread correspondence, Weil representations, extended similitude action and divisible-code language retain their literature ownership. The repository contribution is the unified exact census, the complete signed-orbit Hom bases, the objectwise q=7/q=11 verification, and the executable hardware proof path.
+
+No code weight, Hom-space multiplicity, Weil constituent, FPGA cell, phase state or intersection number is identified with a measured particle, coupling, charge, colour, generation, neutrino, or spacetime degree of freedom.

--- a/analysis/BT2305_five_frontiers_insert.tex
+++ b/analysis/BT2305_five_frontiers_insert.tex
@@ -17,7 +17,7 @@ The full $PSp(4,3)$-equivariant quadratic map dimensions from the canonical $90$
 \Lambda^{2}(90)&3&4&5&12 .
 \end{array}
 \]
-Thus the complete quadratic space has dimension $26+24=50$. The outer similitude splits it into two equal $25$-dimensional sectors. The outer-even half is exactly the earlier target-identified PGSp table; the outer-odd half supplies the missing PSp-equivariant maps. Explicit signed-orbit representatives form complete bases, and every nonzero basis map is surjective onto its irreducible target.
+Thus the complete quadratic space has dimension $26+24=50$. The outer similitude splits it into two equal $25$-dimensional sectors. The outer-even half is exactly the earlier target-identified PGSp table; the outer-odd half supplies the missing PSp-equivariant maps. Explicit integral signed-orbit representatives form complete bases; exact reduction modulo a characteristic not dividing the group order certifies independence and surjectivity, while the dimensions are fixed independently by characters.
 
 For $q=7$ and $q=11$, the canonical Schr\"odinger Weil representations on functions on $\mathbb F_q^2$ split into parity dimensions
 \[
@@ -29,4 +29,4 @@ J^2=-I,\qquad K^2=I,\qquad KJK=-J,
 \]
 and generate $D_4$. This is an objectwise theorem for the canonical Weil family and is not a dimension-based identification with the q=3 signed-edge $90$.
 
-A packed SystemVerilog implementation, exhaustive simulation, Yosys SAT properties for $A^2=9I+6J$ and the faithful $D_{24}$ action, and iCE40/ECP5 synthesis scripts are included. Tool results are engineering evidence for the specified RTL only; no fabricated-device timing, power, physical coupling or particle assignment is claimed.
+A packed SystemVerilog implementation, deterministic Icarus simulation, exhaustive Yosys SAT properties for $A^2=9I+6J$ and the faithful $D_{24}$ action, and explicit $W=4$ iCE40/ECP5 synthesis scripts are included. Tool results are engineering evidence for the specified RTL only; no fabricated-device timing, power, physical coupling or particle assignment is claimed.

--- a/analysis/BT2305_five_frontiers_insert.tex
+++ b/analysis/BT2305_five_frontiers_insert.tex
@@ -1,0 +1,32 @@
+% Passes 2300--2305: five-frontier exact continuation.
+\section*{Divisible ovoid codes, complete quadratic maps, and Weil inversion}
+\addcontentsline{toc}{section}{Divisible ovoid codes, complete quadratic maps, and Weil inversion}
+
+The complete q=27 Ree--Tits hyperplane spectrum is
+\[
+1^{730},\quad 10^{4563},\quad 19^{96174},\quad
+28^{408294},\quad 37^{36504},\quad 46^{4914},\quad 55^{702}.
+\]
+All section sizes are $1\bmod 9$. Equivalently, the homogeneous coordinates generate an exactly $9$-divisible projective $[730,5]_{27}$ code. Complete censuses for the regular, Kantor, Thas--Payne and Ree--Tits q=27 families give pairwise distinct weight enumerators. The regular elliptic section gives a $27$-divisible $[730,4]_{27}$ code, whereas the three nonregular examples give exactly $9$-divisible $[730,5]_{27}$ codes.
+
+The full $PSp(4,3)$-equivariant quadratic map dimensions from the canonical $90$ are
+\[
+\begin{array}{c|rrrr}
+ &15&24&30&81\\ \hline
+\operatorname{Sym}^{2}(90)&3&6&5&12\\
+\Lambda^{2}(90)&3&4&5&12 .
+\end{array}
+\]
+Thus the complete quadratic space has dimension $26+24=50$. The outer similitude splits it into two equal $25$-dimensional sectors. The outer-even half is exactly the earlier target-identified PGSp table; the outer-odd half supplies the missing PSp-equivariant maps. Explicit signed-orbit representatives form complete bases, and every nonzero basis map is surjective onto its irreducible target.
+
+For $q=7$ and $q=11$, the canonical Schr\"odinger Weil representations on functions on $\mathbb F_q^2$ split into parity dimensions
+\[
+(25,24)\quad\hbox{and}\quad(61,60).
+\]
+The nonsquare similitude $h=\operatorname{diag}(I_2,-I_2)$ is implemented by entrywise complex conjugation. On realification, complex multiplication $J$ and conjugation $K$ obey
+\[
+J^2=-I,\qquad K^2=I,\qquad KJK=-J,
+\]
+and generate $D_4$. This is an objectwise theorem for the canonical Weil family and is not a dimension-based identification with the q=3 signed-edge $90$.
+
+A packed SystemVerilog implementation, exhaustive simulation, Yosys SAT properties for $A^2=9I+6J$ and the faithful $D_{24}$ action, and iCE40/ECP5 synthesis scripts are included. Tool results are engineering evidence for the specified RTL only; no fabricated-device timing, power, physical coupling or particle assignment is claimed.

--- a/analysis/w33_pass2301_complete_quadratic_hom_bases.py
+++ b/analysis/w33_pass2301_complete_quadratic_hom_bases.py
@@ -33,6 +33,14 @@ def digest(d):
     x=dict(d);x.pop('sha256_without_hash_field',None)
     return hashlib.sha256(json.dumps(x,sort_keys=True,separators=(',',':')).encode()).hexdigest()
 
+def matpow_mod(A,n,p=P):
+    A=np.array(A,dtype=np.int64)%p
+    R=np.eye(A.shape[0],dtype=np.int64)
+    while n:
+        if n&1:R=(R@A)%p
+        A=(A@A)%p;n//=2
+    return R
+
 def rank_mod(A,p=P):
     A=np.array(A,dtype=np.int64)%p;m,n=A.shape;r=0
     for c in range(n):
@@ -146,7 +154,7 @@ def build_full():
     Q,D=projectors(w,edges,ei);perms,signs=all_actions(w,edges,ei)
     outer=matrix_perm(w,np.diag([1,2,1,2]));op,os=signed_action(outer,edges,ei)
     U=(pow(2,-1,P)*Q['90']+pow(16,-1,P)*D)%P
-    assert np.array_equal(np.linalg.matrix_power(U,6)%P,Q['90'])
+    assert np.array_equal(matpow_mod(U,6),Q['90'])
     rows={};outer_even={};outer_odd={};phase={};compressed={};surj=True
     for kind in ('Sym','Lambda'):
         rows[kind]={};outer_even[kind]={};outer_odd[kind]={};phase[kind]={};compressed[kind]={}
@@ -170,9 +178,9 @@ def build_full():
             for T in tensors:
                 v=fingerprint(T,Q['90'],Pt,kind,U).ravel()%P
                 cols.append(solve_square(S,v[piv])[:,0])
-            R=np.stack(cols,axis=1)%P;assert np.array_equal(np.linalg.matrix_power(R,3)%P,np.eye(m,dtype=np.int64)%P)
+            R=np.stack(cols,axis=1)%P;assert np.array_equal(matpow_mod(R,3),np.eye(m,dtype=np.int64)%P)
             fixed=nullity((R-np.eye(m,dtype=np.int64))%P);assert (m-fixed)%2==0
-            assert np.array_equal((Aout@R@Aout)%P,np.linalg.matrix_power(R,2)%P)
+            assert np.array_equal((Aout@R@Aout)%P,matpow_mod(R,2))
             rows[kind][target]=m;outer_even[kind][target]=ep;outer_odd[kind][target]=em
             phase[kind][target]={'fixed':fixed,'rotation_pairs':(m-fixed)//2};compressed[kind][target]=meta
     assert rows==EXPECTED_DIMS

--- a/formal/.pass2303_placeholder
+++ b/formal/.pass2303_placeholder
@@ -1,1 +1,0 @@
-Pass 2303 formal hardware branch placeholder.

--- a/formal/w33_pass2303_formal.sv
+++ b/formal/w33_pass2303_formal.sv
@@ -31,11 +31,15 @@ module w33_phase_formal;
     w33_d24_action a2(.phase_in(p1),.conjugated_in(e1),.step12(v),.reflect(fv),.phase_out(p2),.conjugated_out(e2));
     w33_d24_action ac(.phase_in(phase0),.conjugated_in(conj0),.step12(uv),.reflect(fu^fv),.phase_out(pc),.conjugated_out(ec));
     wire [3:0] pk;wire ek;
-    w33_single_j_action24 kernel(.phase_in(phase0),.conjugated_in(conj0),.step4(2),.step6(3),.reflect(0),.phase_out(pk),.conjugated_out(ek));
+    w33_single_j_action24 kernel(.phase_in(phase0),.conjugated_in(conj0),.step4(2'd2),.step6(3'd3),.reflect(1'b0),.phase_out(pk),.conjugated_out(ek));
     always @* begin
-        assume(phase0<12);assume(u<12);assume(v<12);
-        if(!fu) begin tmp=u+v;uv=(tmp>=12)?tmp-12:tmp[3:0];end
-        else uv=(u>=v)?u-v:u+12-v;
+        assume(phase0<4'd12);assume(u<4'd12);assume(v<4'd12);
+        if(!fu) begin
+            tmp={1'b0,u}+{1'b0,v};
+            uv=(tmp>=5'd12)?tmp-5'd12:tmp[3:0];
+        end else begin
+            uv=(u>=v)?u-v:u+4'd12-v;
+        end
         assert(p2==pc);assert(e2==ec);
         assert(pk==phase0);assert(ek==conj0);
     end

--- a/formal/w33_pass2303_formal.sv
+++ b/formal/w33_pass2303_formal.sv
@@ -1,0 +1,42 @@
+// Pass 2303 formal properties for the exact mixer and D24 controller.
+module w33_mixer_formal;
+    (* anyconst *) reg signed [36*4-1:0] x_flat;
+    wire signed [36*8-1:0] y1;
+    wire signed [36*12-1:0] y2;
+    w33_spread_mixer36_packed #(.W(4),.OW(8)) m1(.x_flat(x_flat),.y_flat(y1));
+    w33_spread_mixer36_packed #(.W(8),.OW(12)) m2(.x_flat(y1),.y_flat(y2));
+    integer i,j;
+    reg signed [9:0] total;
+    reg signed [11:0] rhs;
+    always @* begin
+        total=0;
+        for(j=0;j<36;j=j+1) total=total+$signed(x_flat[j*4 +: 4]);
+        for(i=0;i<36;i=i+1) begin
+            rhs=9*$signed(x_flat[i*4 +: 4])+6*$signed(total);
+            assert($signed(y2[i*12 +: 12])==rhs);
+        end
+    end
+endmodule
+
+module w33_phase_formal;
+    (* anyconst *) reg [3:0] phase0;
+    (* anyconst *) reg conj0;
+    (* anyconst *) reg [3:0] u;
+    (* anyconst *) reg fu;
+    (* anyconst *) reg [3:0] v;
+    (* anyconst *) reg fv;
+    wire [3:0] p1,p2,pc;wire e1,e2,ec;
+    reg [4:0] tmp;reg [3:0] uv;
+    w33_d24_action a1(.phase_in(phase0),.conjugated_in(conj0),.step12(u),.reflect(fu),.phase_out(p1),.conjugated_out(e1));
+    w33_d24_action a2(.phase_in(p1),.conjugated_in(e1),.step12(v),.reflect(fv),.phase_out(p2),.conjugated_out(e2));
+    w33_d24_action ac(.phase_in(phase0),.conjugated_in(conj0),.step12(uv),.reflect(fu^fv),.phase_out(pc),.conjugated_out(ec));
+    wire [3:0] pk;wire ek;
+    w33_single_j_action24 kernel(.phase_in(phase0),.conjugated_in(conj0),.step4(2),.step6(3),.reflect(0),.phase_out(pk),.conjugated_out(ek));
+    always @* begin
+        assume(phase0<12);assume(u<12);assume(v<12);
+        if(!fu) begin tmp=u+v;uv=(tmp>=12)?tmp-12:tmp[3:0];end
+        else uv=(u>=v)?u-v:u+12-v;
+        assert(p2==pc);assert(e2==ec);
+        assert(pk==phase0);assert(ek==conj0);
+    end
+endmodule

--- a/photonic_holonet.tex
+++ b/photonic_holonet.tex
@@ -1,4 +1,4 @@
-% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2206 plus frame-Hoffman wrapper:
+% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2305 plus frame-Hoffman wrapper:
 % preserve the complete historical manuscript body verbatim while injecting the
 % certified theorem inserts immediately after the contents.
 \AtBeginDocument{%
@@ -40,6 +40,7 @@
     \input{analysis/BT2064_full_group_intertwiners_graph_family_insert}%
     \input{analysis/BT2092_regular_spread_quadratic_structure_controller_insert}%
     \input{analysis/BT2206_all_q_spreads_nonregular_controller_rtl_insert}%
+    \input{analysis/BT2305_five_frontiers_insert}%
   }%
 }
 \input{photonic_holonet_body.tex}

--- a/rtl/w33_pass2303_packed_toolchain.sv
+++ b/rtl/w33_pass2303_packed_toolchain.sv
@@ -49,8 +49,12 @@ module w33_d24_action(
 );
     reg [4:0] tmp;
     always @* begin
-        if(!conjugated_in) begin tmp=phase_in+step12;phase_out=(tmp>=12)?tmp-12:tmp[3:0];end
-        else phase_out=(phase_in>=step12)?phase_in-step12:phase_in+12-step12;
+        if(!conjugated_in) begin
+            tmp={1'b0,phase_in}+{1'b0,step12};
+            phase_out=(tmp>=5'd12)?tmp-5'd12:tmp[3:0];
+        end else begin
+            phase_out=(phase_in>=step12)?phase_in-step12:phase_in+4'd12-step12;
+        end
     end
     assign conjugated_out=conjugated_in^reflect;
 endmodule
@@ -60,7 +64,7 @@ module w33_single_j_action24(
     input wire [1:0] step4,input wire [2:0] step6,input wire reflect,
     output wire [3:0] phase_out,output wire conjugated_out
 );
-    wire [5:0] raw=3*step4+2*step6;
-    wire [3:0] delta12=(raw>=12)?raw-12:raw[3:0];
+    wire [5:0] raw=6'd3*step4+6'd2*step6;
+    wire [3:0] delta12=(raw>=6'd12)?raw-6'd12:raw[3:0];
     w33_d24_action u(.phase_in(phase_in),.conjugated_in(conjugated_in),.step12(delta12),.reflect(reflect),.phase_out(phase_out),.conjugated_out(conjugated_out));
 endmodule

--- a/rtl/w33_pass2303_packed_toolchain.sv
+++ b/rtl/w33_pass2303_packed_toolchain.sv
@@ -26,13 +26,16 @@ module w33_spread_mixer36_packed #(
     integer i,j;
     reg signed [OW-1:0] acc;
     reg signed [W-1:0] xj;
+    reg [35:0] rowmask;
     always @* begin
         y_flat={36*OW{1'b0}};
+        rowmask=0;
         for(i=0;i<36;i=i+1) begin
             acc={OW{1'b0}};
+            rowmask=mask(i);
             for(j=0;j<36;j=j+1) begin
                 xj=x_flat[j*W +: W];
-                if(mask(i)[j]) acc=acc+{{(OW-W){xj[W-1]}},xj};
+                if(rowmask[j]) acc=acc+{{(OW-W){xj[W-1]}},xj};
             end
             y_flat[i*OW +: OW]=acc;
         end

--- a/rtl/w33_pass2303_packed_toolchain.sv
+++ b/rtl/w33_pass2303_packed_toolchain.sv
@@ -1,0 +1,63 @@
+// Pass 2303: packed, tool-friendly exact W(3,3) mixer and D24 action.
+module w33_spread_mixer36_packed #(
+    parameter integer W = 16,
+    parameter integer OW = W + 4
+) (
+    input  wire signed [36*W-1:0]  x_flat,
+    output reg  signed [36*OW-1:0] y_flat
+);
+    function [35:0] mask;
+      input integer idx;
+      begin
+        case (idx)
+          0: mask=36'h00a323cf6; 1: mask=36'h0094c5b6d; 2: mask=36'h00c81e79b; 3: mask=36'h6a0c4c0f6;
+          4: mask=36'hb20a3216d; 5: mask=36'hc6078119b; 6: mask=36'h39306099b; 7: mask=36'h4d610856d;
+          8: mask=36'h9550902f6; 9: mask=36'h950c4bd06; 10: mask=36'h4d0a35a85; 11: mask=36'h390786643;
+          12: mask=36'hc63066623; 13: mask=36'hb2610da15; 14: mask=36'h6a5093c0e; 15: mask=36'h27a55228c;
+          16: mask=36'h2792ac514; 17: mask=36'h8b9951451; 18: mask=36'h53a8a924a; 19: mask=36'h53c354922;
+          20: mask=36'h8bc4aa8a1; 21: mask=36'h74ac90c31; 22: mask=36'hac9b08a2a; 23: mask=36'hd8c66061c;
+          24: mask=36'hace435142; 25: mask=36'h74d24b0c1; 26: mask=36'hd8b986184; 27: mask=36'h007ff8007;
+          28: mask=36'he001f8fc0; 29: mask=36'h1c01ff038; 30: mask=36'h1a36197a0; 31: mask=36'h165d24cc8;
+          32: mask=36'h0e6ac2b50; 33: mask=36'hc1361e858; 34: mask=36'ha16ac54a8; 35: mask=36'h615d23330;
+          default: mask=36'b0;
+        endcase
+      end
+    endfunction
+    integer i,j;
+    reg signed [OW-1:0] acc;
+    reg signed [W-1:0] xj;
+    always @* begin
+        y_flat={36*OW{1'b0}};
+        for(i=0;i<36;i=i+1) begin
+            acc={OW{1'b0}};
+            for(j=0;j<36;j=j+1) begin
+                xj=x_flat[j*W +: W];
+                if(mask(i)[j]) acc=acc+{{(OW-W){xj[W-1]}},xj};
+            end
+            y_flat[i*OW +: OW]=acc;
+        end
+    end
+endmodule
+
+module w33_d24_action(
+    input wire [3:0] phase_in,input wire conjugated_in,
+    input wire [3:0] step12,input wire reflect,
+    output reg [3:0] phase_out,output wire conjugated_out
+);
+    reg [4:0] tmp;
+    always @* begin
+        if(!conjugated_in) begin tmp=phase_in+step12;phase_out=(tmp>=12)?tmp-12:tmp[3:0];end
+        else phase_out=(phase_in>=step12)?phase_in-step12:phase_in+12-step12;
+    end
+    assign conjugated_out=conjugated_in^reflect;
+endmodule
+
+module w33_single_j_action24(
+    input wire [3:0] phase_in,input wire conjugated_in,
+    input wire [1:0] step4,input wire [2:0] step6,input wire reflect,
+    output wire [3:0] phase_out,output wire conjugated_out
+);
+    wire [5:0] raw=3*step4+2*step6;
+    wire [3:0] delta12=(raw>=12)?raw-12:raw[3:0];
+    w33_d24_action u(.phase_in(phase_in),.conjugated_in(conjugated_in),.step12(delta12),.reflect(reflect),.phase_out(phase_out),.conjugated_out(conjugated_out));
+endmodule

--- a/tests/rtl/w33_pass2303_tb.sv
+++ b/tests/rtl/w33_pass2303_tb.sv
@@ -1,0 +1,35 @@
+`timescale 1ns/1ps
+module w33_pass2303_tb;
+    reg signed [36*4-1:0] x;
+    wire signed [36*8-1:0] y1;
+    wire signed [36*12-1:0] y2;
+    w33_spread_mixer36_packed #(.W(4),.OW(8)) m1(.x_flat(x),.y_flat(y1));
+    w33_spread_mixer36_packed #(.W(8),.OW(12)) m2(.x_flat(y1),.y_flat(y2));
+    reg [3:0] phase;reg conj;reg [1:0] a;reg [2:0] b;reg reflect;
+    wire [3:0] po;wire eo;
+    w33_single_j_action24 ctl(.phase_in(phase),.conjugated_in(conj),.step4(a),.step6(b),.reflect(reflect),.phase_out(po),.conjugated_out(eo));
+    integer i,j,aa,bb,total,rhs,delta,expect;
+    initial begin
+        x=0;
+        for(i=0;i<36;i=i+1) x[i*4 +: 4]=(i%16)-8;
+        #1;total=0;
+        for(i=0;i<36;i=i+1) total=total+$signed(x[i*4 +: 4]);
+        for(i=0;i<36;i=i+1) begin
+            rhs=9*$signed(x[i*4 +: 4])+6*total;
+            if($signed(y2[i*12 +: 12])!==rhs) $fatal(1,"mixer identity lane %0d",i);
+        end
+        for(i=0;i<12;i=i+1) for(j=0;j<2;j=j+1) begin
+          phase=i;conj=j;
+          for(aa=0;aa<4;aa=aa+1) for(bb=0;bb<6;bb=bb+1) begin
+            a=aa;b=bb;reflect=0;#1;delta=(3*aa+2*bb)%12;
+            expect=conj?(phase-delta+12)%12:(phase+delta)%12;
+            if(po!==expect||eo!==conj) $fatal(1,"phase rotation");
+            reflect=1;#1;
+            if(po!==expect||eo!==(conj^1)) $fatal(1,"phase reflection");
+          end
+          a=2;b=3;reflect=0;#1;
+          if(po!==phase||eo!==conj) $fatal(1,"kernel");
+        end
+        $display("PASS w33_pass2303_tb");$finish;
+    end
+endmodule

--- a/tests/rtl/w33_pass2303_tb.sv
+++ b/tests/rtl/w33_pass2303_tb.sv
@@ -8,7 +8,7 @@ module w33_pass2303_tb;
     reg [3:0] phase;reg conj;reg [1:0] a;reg [2:0] b;reg reflect;
     wire [3:0] po;wire eo;
     w33_single_j_action24 ctl(.phase_in(phase),.conjugated_in(conj),.step4(a),.step6(b),.reflect(reflect),.phase_out(po),.conjugated_out(eo));
-    integer i,j,aa,bb,total,rhs,delta,expect;
+    integer i,j,aa,bb,total,rhs,delta,expected_phase;
     initial begin
         x=0;
         for(i=0;i<36;i=i+1) x[i*4 +: 4]=(i%16)-8;
@@ -22,10 +22,10 @@ module w33_pass2303_tb;
           phase=i;conj=j;
           for(aa=0;aa<4;aa=aa+1) for(bb=0;bb<6;bb=bb+1) begin
             a=aa;b=bb;reflect=0;#1;delta=(3*aa+2*bb)%12;
-            expect=conj?(phase-delta+12)%12:(phase+delta)%12;
-            if(po!==expect||eo!==conj) $fatal(1,"phase rotation");
+            expected_phase=conj?(phase-delta+12)%12:(phase+delta)%12;
+            if(po!==expected_phase||eo!==conj) $fatal(1,"phase rotation");
             reflect=1;#1;
-            if(po!==expect||eo!==(conj^1)) $fatal(1,"phase reflection");
+            if(po!==expected_phase||eo!==(conj^1)) $fatal(1,"phase reflection");
           end
           a=2;b=3;reflect=0;#1;
           if(po!==phase||eo!==conj) $fatal(1,"kernel");

--- a/tests/test_w33_pass2300_2305.py
+++ b/tests/test_w33_pass2300_2305.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import hashlib,json,subprocess,sys
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+
+CERTS={
+ 'data/w33_pass2300_ree_tits_divisible_code.json':'dc6a1b4262e96210af832d098a4140f58e022bea979b7cdf3c030246dbf956e9',
+ 'data/w33_pass2301_complete_quadratic_hom_bases.json':'26eab93605eeb603e3a899c2ecda2a39e268c65e3286b86dce9449f0540b8c43',
+ 'data/w33_pass2302_q7_q11_extended_weil_outer_inversion.json':'d850de3ddaad56765d692fcdba838e2e05bd13340da0194f56c7996807b651a7',
+ 'data/w33_pass2304_known_q27_symplectic_spread_spectra.json':'559653e8cd1b32f70596a0b334cae02abc4426c694146beaac4ca96970239b72'}
+
+def digest(d):
+    x=dict(d);x.pop('sha256_without_hash_field',None)
+    return hashlib.sha256(json.dumps(x,sort_keys=True,separators=(',',':')).encode()).hexdigest()
+
+def test_frozen_semantic_hashes():
+    for path,h in CERTS.items():
+        d=json.loads((ROOT/path).read_text())
+        assert d['sha256_without_hash_field']==h==digest(d)
+        assert all(d['checks'].values())
+
+def test_ree_code_and_family_spectra():
+    r=json.loads((ROOT/'data/w33_pass2300_ree_tits_divisible_code.json').read_text())
+    assert sum(r['complete_hyperplane_intersection_spectrum'].values())==551881
+    assert r['projective_code']['weight_gcd']==9
+    f=json.loads((ROOT/'data/w33_pass2304_known_q27_symplectic_spread_spectra.json').read_text())
+    assert f['complete_results']['regular']['projective_code']['parameters']=='[730,4]_27'
+    assert f['complete_results']['regular']['projective_code']['weight_gcd']==27
+    for name in ('kantor','thas_payne','ree_tits'):
+        assert f['complete_results'][name]['projective_code']['parameters']=='[730,5]_27'
+        assert f['complete_results'][name]['projective_code']['weight_gcd']==9
+
+def test_complete_hom_outer_split():
+    d=json.loads((ROOT/'data/w33_pass2301_complete_quadratic_hom_bases.json').read_text())
+    assert d['total_dimensions']=={'Sym2':26,'Lambda2':24,'combined':50}
+    for kind in ('Sym','Lambda'):
+        for target,m in d['full_PSp_Hom_dimensions'][kind].items():
+            assert len(d['compressed_orbit_bases'][kind][target])==m
+            assert d['outer_involution_split']['even_PGSp_extendible'][kind][target]+d['outer_involution_split']['odd_outer_twisted'][kind][target]==m
+
+def test_weil_full_replay():
+    subprocess.run([sys.executable,str(ROOT/'analysis/w33_pass2302_q7_q11_weil_outer_inversion.py'),'--full'],check=True,capture_output=True,text=True)

--- a/w33_paper.tex
+++ b/w33_paper.tex
@@ -1,4 +1,4 @@
-% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2206 plus frame-Hoffman wrapper:
+% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2305 plus frame-Hoffman wrapper:
 % preserve the complete historical manuscript body verbatim while injecting the
 % certified theorem inserts immediately after the contents.
 \AtBeginDocument{%
@@ -40,6 +40,7 @@
     \input{analysis/BT2064_full_group_intertwiners_graph_family_insert}%
     \input{analysis/BT2092_regular_spread_quadratic_structure_controller_insert}%
     \input{analysis/BT2206_all_q_spreads_nonregular_controller_rtl_insert}%
+    \input{analysis/BT2305_five_frontiers_insert}%
   }%
 }
 \input{w33_paper_body.tex}


### PR DESCRIPTION
## Scope

- adds packed, open-source-tool-friendly RTL for the exact 36-lane spread mixer and faithful D24 phase action
- adds deterministic Icarus simulation for the mixer and exhaustive phase-state/command simulation
- proves the mixer identity for every 4-bit 36-lane input, plus D24 associativity and the shared-clock kernel, with Yosys SAT
- synthesizes an explicit W=4, OW=8 mixer instance for generic, iCE40, and ECP5 targets
- verifies the Pass 2300–2304 mathematical certificates and focused regression suite
- uploads complete tool logs and FPGA JSON netlists as workflow artifacts

The exhaustive mixer coverage comes from the formal SAT proof, not from a claim that finite simulation enumerates all 2^144 mixer inputs. The PR exists to obtain observable toolchain evidence before merge.