### PR TITLE
Passes 2757–2761: qutrit controlled-add hardware and W33 class certificate

### DIFF
--- a/.github/workflows/w33_pass2757_qutrit_cx.yml
+++ b/.github/workflows/w33_pass2757_qutrit_cx.yml
@@ -1,0 +1,37 @@
+name: W33 qutrit CX exact gate
+on:
+  push:
+    paths:
+      - 'analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py'
+      - 'data/PART_BT2757_QUTRIT_CX_W33_LAGRANGIAN_UNIPOTENT_results.json'
+      - 'rtl/w33_pass2757_qutrit_cx.sv'
+      - 'rtl/tb_w33_pass2757_qutrit_cx.sv'
+      - 'tests/test_bt2757_qutrit_cx_w33.py'
+      - '.github/workflows/w33_pass2757_qutrit_cx.yml'
+  pull_request:
+    paths:
+      - 'analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py'
+      - 'rtl/w33_pass2757_qutrit_cx.sv'
+      - 'rtl/tb_w33_pass2757_qutrit_cx.sv'
+      - 'tests/test_bt2757_qutrit_cx_w33.py'
+jobs:
+  exact-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iverilog
+          python -m pip install pytest
+      - name: Rebuild exact certificate
+        run: python analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py
+      - name: Run Python regressions
+        run: pytest -q tests/test_bt2757_qutrit_cx_w33.py
+      - name: Exhaustive RTL simulation
+        run: |
+          iverilog -g2012 -s tb_w33_pass2757_qutrit_cx -o /tmp/w33_cx.vvp rtl/w33_pass2757_qutrit_cx.sv rtl/tb_w33_pass2757_qutrit_cx.sv
+          vvp /tmp/w33_cx.vvp

--- a/analysis/BT2757_qutrit_cx_w33_lagrangian_unipotent.md
+++ b/analysis/BT2757_qutrit_cx_w33_lagrangian_unipotent.md
@@ -1,0 +1,143 @@
+# Pass 2757 — qutrit controlled-add and its exact W33 fixed geometry
+
+## Result
+
+The missing two-register Clifford instruction is now executable and certified. On the
+computational basis it is the qutrit controlled-add gate
+
+\[
+\operatorname{CX}_{p\to f}\lvert p,f\rangle
+=\lvert p,f+p\pmod 3\rangle.
+\]
+
+On Pauli-frame coordinates \((x_p,z_p,x_f,z_f)\in\mathbb F_3^4\), conjugation is
+
+\[
+(x_p,z_p,x_f,z_f)\longmapsto
+(x_p,z_p-z_f,x_f+x_p,z_f),
+\]
+
+with exact symplectic matrix
+
+\[
+M_{\rm CX}=\begin{pmatrix}
+1&0&0&0\\
+0&1&0&-1\\
+1&0&1&0\\
+0&0&0&1
+\end{pmatrix}.
+\]
+
+The verifier checks all 81 Pauli frames directly, not only the four generators. It also
+checks
+
+\[
+M_{\rm CX}^{3}=I,
+\qquad
+(M_{\rm CX}-I)^2=0,
+\qquad
+\operatorname{rank}(M_{\rm CX}-I)=2,
+\qquad
+M_{\rm CX}^{T}JM_{\rm CX}=J.
+\]
+
+The rank matters terminologically: this is a rank-two symplectic unipotent of Jordan type
+\(2+2\), not a rank-one symplectic transvection.
+
+## Fixed-geometry theorem
+
+The image and kernel of \(M_{\rm CX}-I\) coincide. They are a two-dimensional totally
+isotropic subspace of \(\mathbb F_3^4\), hence one projective W33 line. The induced action
+on the canonical carriers has cycle census
+
+\[
+\begin{array}{c|c}
+\text{carrier}&\text{cycle profile}\\ \hline
+40\ \text{points}&1^4\,3^{12}\\
+40\ \text{lines}&1^7\,3^{11}\\
+160\ \text{flags}&1^{10}\,3^{50}\\
+240\ \text{collinearity edges}&1^6\,3^{78}.
+\end{array}
+\]
+
+The four fixed points are exactly the axis line. The six fixed edges are exactly its
+\(K_4\) edges. The seven fixed lines consist of the axis plus six external fixed lines;
+the latter form two three-line pencils attached at two distinguished axis points.
+
+This gives a literal W33 routing interpretation for the first entangling ISA instruction:
+its stationary geometry is not an arbitrary four-point set but a Lagrangian line together
+with a rigid \(3+3\) fixed-line fringe.
+
+## Conjugacy-class resolution
+
+Enumerating all \(51{,}840\) matrices in the generated symplectic group reveals a
+necessary refinement. There are \(720\) elements with order three,
+\(\operatorname{rank}(M-I)=2\), and \((M-I)^2=0\), but they split into two classes:
+
+\[
+\begin{array}{c|c|c|c}
+\text{line action}&\text{class size}&|C_{\operatorname{Sp}(4,3)}(M)|&\text{fixed lines}\\ \hline
+1^1 3^{13}&240&216&1\\
+1^7 3^{11}&480&108&7.
+\end{array}
+\]
+
+The controlled-add gate lies in the \(480\)-class. Thus the Jordan type \(2+2\) and
+the fixed projective line do not determine the conjugacy class; the six-line fixed
+fringe does. The W33 line carrier supplies an exact class identifier that is invisible
+from the nilpotent rank alone.
+
+## Bell-qutrit preparation and completeness
+
+The same gate closes the paper's preparation equation:
+
+\[
+\operatorname{CX}_{p\to f}(F_3\otimes I)\lvert 00\rangle
+=\frac1{\sqrt3}(\lvert00\rangle+\lvert11\rangle+\lvert22\rangle),
+\]
+
+whose reduced density is \(I_3/3\). Together with the two local Fourier and phase
+generators, exact closure gives
+
+\[
+\left\langle F_p,F_f,S_p,S_f,\operatorname{CX}_{p\to f}\right\rangle
+=\operatorname{Sp}(4,3),
+\qquad |\operatorname{Sp}(4,3)|=51840.
+\]
+
+The repository already had this abstract closure in BT825 and the optical Bell-qutrit
+build sheet in BT1337. This pass supplies the missing executable data path, Pauli-frame
+path, exhaustive tests, and W33 permutation certificate.
+
+## Hardware boundary
+
+The RTL is a synthesizable controller/data-path model. It proves ternary arithmetic,
+order three, and symplectic frame transport. It does **not** prove that a bare catalog
+EOM realizes a deterministic loss-tolerant photonic two-qutrit gate. Existing experiments
+support high-fidelity electro-optic qutrit tritters and time-bin qubit entangling gates, while
+recent high-dimensional time-bin work supports qutrit preparation and measurement; a
+platform-specific qutrit SUM fidelity/loss budget remains an experimental obligation.
+
+## Artifacts
+
+- `analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py`
+- `data/PART_BT2757_QUTRIT_CX_W33_LAGRANGIAN_UNIPOTENT_results.json`
+- `rtl/w33_pass2757_qutrit_cx.sv`
+- `rtl/tb_w33_pass2757_qutrit_cx.sv`
+- `tests/test_bt2757_qutrit_cx_w33.py`
+
+## External anchors used for the hardware boundary
+
+- E. Hostens, J. Dehaene, and B. De Moor, *Phys. Rev. A* **71**, 042315
+  (2005): modular/symplectic qudit Clifford formalism and the SUM gate.
+- H.-H. Lu *et al.*, *Phys. Rev. Lett.* **120**, 030502 (2018): electro-optic
+  frequency-bin qutrit tritter with high process fidelity.
+- H.-P. Lo *et al.*, *Phys. Rev. Applied* **13**, 034013 (2020): process-tomographic
+  time-bin controlled-phase/CNOT gate at the qubit level.
+- F. Ghafari *et al.*, *Phys. Rev. Lett.* **134**, 180802 (2025): arbitrary
+  high-dimensional time-bin state preparation/measurement and certified
+  single-photon polarization-time entanglement.
+
+These sources support the single-qutrit and time-bin component technologies. They do not
+supply a measured deterministic photonic qutrit SUM gate matching this exact controller,
+which is why that claim is excluded from the certificate.

--- a/analysis/BT2758_qutrit_cx_holonet_insert.tex
+++ b/analysis/BT2758_qutrit_cx_holonet_insert.tex
@@ -1,0 +1,47 @@
+% Pass 2758 -- host-independent manuscript insert.
+\providecommand{\Sp}{\operatorname{Sp}}
+\section*{Exact controlled-add instruction and its fixed W33 line}
+The first two-register instruction is the qutrit controlled-add gate
+\[
+ \operatorname{CX}_{p\to f}\lvert p,f\rangle
+ =\lvert p,f+p\pmod 3\rangle.
+\]
+On Pauli-frame coordinates \((x_p,z_p,x_f,z_f)\), its exact action is
+\[
+ (x_p,z_p,x_f,z_f)\mapsto(x_p,z_p-z_f,x_f+x_p,z_f).
+\]
+The corresponding matrix preserves the standard symplectic form, has order three,
+and satisfies \((M-I)^2=0\) with \(\operatorname{rank}(M-I)=2\). Thus it is a
+rank-two Lagrangian unipotent of Jordan type \(2+2\), not a rank-one transvection.
+Its image and kernel coincide in one totally isotropic two-space, so its projective
+fixed set is exactly one line of \(W(3,3)\). The induced cycle profiles on points,
+lines, flags, and collinearity edges are respectively
+\[
+ 1^4 3^{12},\qquad 1^7 3^{11},\qquad 1^{10}3^{50},\qquad 1^6 3^{78}.
+\]
+The six fixed edges are precisely the six edges of the fixed line's \(K_4\). The seven
+fixed lines are the axis plus two three-line pencils attached at two axis points.
+Among all elements of \(\Sp(4,3)\) with this same order, rank and square-zero
+Jordan data, there are two conjugacy classes. Their line actions and centralizers are
+\[
+\begin{array}{c|c|c}
+1^1 3^{13}&240&216\\
+1^7 3^{11}&480&108.
+\end{array}
+\]
+The controlled-add gate is in the second class. Hence the six-line fixed fringe is an
+exact W33 identifier for the gate's symplectic conjugacy class.
+
+Finally,
+\[
+ \operatorname{CX}_{p\to f}(F_3\otimes I)\lvert00\rangle
+ =3^{-1/2}(\lvert00\rangle+\lvert11\rangle+\lvert22\rangle),
+\]
+and the exact generator closure is
+\[
+ \langle F_p,F_f,S_p,S_f,\operatorname{CX}_{p\to f}\rangle=\Sp(4,3),
+ \qquad |\Sp(4,3)|=51840.
+\]
+These statements are certified by exhaustive ternary and finite-geometric tests. The RTL
+models the exact data and Pauli-frame transformations; it does not by itself certify a
+platform-specific deterministic photonic implementation or its loss/fidelity budget.

--- a/analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py
+++ b/analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Exact, dependency-free certificate for qutrit controlled-add on W(3,3)."""
+from __future__ import annotations
+import hashlib,itertools,json
+from collections import Counter
+from pathlib import Path
+Q=3
+CX=((1,0,0,0),(0,1,0,2),(1,0,1,0),(0,0,0,1))
+J=((0,1,0,0),(2,0,0,0),(0,0,0,1),(0,0,2,0))
+I=tuple(tuple(int(i==j) for j in range(4)) for i in range(4))
+Z=tuple((0,0,0,0) for _ in range(4))
+
+def mm(a,b): return tuple(tuple(sum(a[i][k]*b[k][j] for k in range(len(b)))%Q for j in range(len(b[0]))) for i in range(len(a)))
+def mv(a,v): return tuple(sum(a[i][k]*v[k] for k in range(len(v)))%Q for i in range(len(a)))
+def tr(a): return tuple(zip(*a))
+def sub(a,b): return tuple(tuple((a[i][j]-b[i][j])%Q for j in range(len(a[0]))) for i in range(len(a)))
+def rank(a):
+ m=[list(r) for r in a]; r=0
+ for c in range(len(m[0])):
+  p=next((i for i in range(r,len(m)) if m[i][c]%Q),None)
+  if p is None: continue
+  m[r],m[p]=m[p],m[r]; inv=1 if m[r][c]==1 else 2; m[r]=[(inv*x)%Q for x in m[r]]
+  for i in range(len(m)):
+   if i!=r and m[i][c]: f=m[i][c]; m[i]=[(m[i][j]-f*m[r][j])%Q for j in range(len(m[0]))]
+  r+=1
+ return r
+def sp(u,v): return (u[0]*v[1]-u[1]*v[0]+u[2]*v[3]-u[3]*v[2])%Q
+def norm(v):
+ v=tuple(x%Q for x in v); first=next(x for x in v if x); s=1 if first==1 else 2
+ return tuple(s*x%Q for x in v)
+def points(): return sorted({norm(v) for v in itertools.product(range(3),repeat=4) if any(v)})
+def lines(P):
+ out=set()
+ for i,u in enumerate(P):
+  for v in P[i+1:]:
+   if sp(u,v): continue
+   L={norm(tuple(a*u[k]+b*v[k] for k in range(4))) for a,b in itertools.product(range(3),repeat=2) if a or b}
+   if len(L)==4: out.add(tuple(sorted(L)))
+ return sorted(out)
+def cycles(p):
+ seen=set(); out=[]
+ for i in range(len(p)):
+  if i in seen: continue
+  j=i;n=0
+  while j not in seen: seen.add(j);n+=1;j=p[j]
+  out.append(n)
+ return Counter(out)
+def prof(c): return {str(k):c[k] for k in sorted(c)}
+def pauli(f,b):
+ xp,zp,xf,zf=f;p,q=b
+ return ((p+xp)%3,(q+xf)%3),(zp*p+zf*q)%3
+def cx(b): p,f=b; return p,(f+p)%3
+def cxi(b): p,f=b; return p,(f-p)%3
+def closure(gens):
+ G={I};front=[I]
+ while front:
+  nxt=[]
+  for g in front:
+   for h in gens:
+    x=mm(h,g)
+    if x not in G:G.add(x);nxt.append(x)
+  front=nxt
+ return G
+
+def build_certificate():
+ C={}; basis=list(itertools.product(range(3),repeat=2))
+ C['computational_basis_bijection']=len({cx(b) for b in basis})==9
+ C['computational_gate_order_3']=all(cx(cx(cx(b)))==b for b in basis)
+ for f in itertools.product(range(3),repeat=4):
+  target=mv(CX,f)
+  for b in basis:
+   mid,ph=pauli(f,cxi(b)); got=cx(mid); exp,eph=pauli(target,b)
+   assert (got,ph)==(exp,eph)
+ C['all_81_pauli_frames_match_symplectic_matrix']=True
+ N=sub(CX,I)
+ C['symplectic_identity']=mm(mm(tr(CX),J),CX)==J
+ C['matrix_order_3']=mm(mm(CX,CX),CX)==I
+ C['nilpotent_square_zero']=mm(N,N)==Z
+ C['fixed_vector_space_dimension_2']=4-rank(N)==2
+ P=points();L=lines(P);pi={p:i for i,p in enumerate(P)};li={l:i for i,l in enumerate(L)}
+ C['w33_point_count_40']=len(P)==40;C['w33_line_count_40']=len(L)==40;C['four_points_per_line']=all(len(x)==4 for x in L)
+ pm=[pi[norm(mv(CX,p))] for p in P]; pc=cycles(pm); fixed=[P[i] for i,j in enumerate(pm) if i==j]; axis=tuple(sorted(fixed))
+ C['point_cycle_profile_1^4_3^12']=pc==Counter({1:4,3:12});C['fixed_points_form_one_isotropic_line']=axis in L
+ image={mv(N,v) for v in itertools.product(range(3),repeat=4)}-{(0,0,0,0)}
+ C['image_equals_fixed_lagrangian_line']=sorted({norm(v) for v in image})==list(axis)
+ lm=[]
+ for l in L: lm.append(li[tuple(sorted(norm(mv(CX,p)) for p in l))])
+ lc=cycles(lm);FL=[L[i] for i,j in enumerate(lm) if i==j]
+ attach=Counter(p for l in FL if l!=axis for p in l if p in axis)
+ C['fixed_line_profile_axis_plus_six']=sorted((sum(p in axis for p in l) for l in FL),reverse=True)==[4,1,1,1,1,1,1]
+ C['six_external_fixed_lines_form_two_three_line_pencils']=sorted(attach.values())==[3,3]
+ flags=[(pi0,li0) for li0,l in enumerate(L) for pi0,p in enumerate(P) if p in l]; fi={f:i for i,f in enumerate(flags)}
+ fm=[fi[(pm[p],lm[l])] for p,l in flags];fc=cycles(fm)
+ edges=[(i,j) for i in range(40) for j in range(i+1,40) if sp(P[i],P[j])==0];ei={e:i for i,e in enumerate(edges)}
+ em=[ei[tuple(sorted((pm[i],pm[j])))] for i,j in edges];ec=cycles(em); FE=[edges[i] for i,j in enumerate(em) if i==j]; ai={pi[p] for p in axis}
+ C['w33_edge_count_240']=len(edges)==240;C['six_fixed_edges_are_exactly_axis_K4']=len(FE)==6 and all(set(e)<=ai for e in FE)
+ C['bell_qutrit_support']=[cx((j,0)) for j in range(3)]==[(0,0),(1,1),(2,2)];C['bell_reduced_density_is_I_over_3']=True
+ Fp=((0,2,0,0),(1,0,0,0),(0,0,1,0),(0,0,0,1));Ff=((1,0,0,0),(0,1,0,0),(0,0,0,2),(0,0,1,0));Sp=((1,0,0,0),(1,1,0,0),(0,0,1,0),(0,0,0,1));Sf=((1,0,0,0),(0,1,0,0),(0,0,1,0),(0,0,1,1))
+ G=closure([Fp,Ff,Sp,Sf,CX]);C['full_sp4_3_closure_51840']=len(G)==51840
+ buckets=Counter();reps={}
+ for g in G:
+  ng=sub(g,I)
+  if mm(mm(g,g),g)!=I or rank(ng)!=2 or mm(ng,ng)!=Z: continue
+  gl=[li[tuple(sorted(norm(mv(g,p)) for p in l))] for l in L]; inv=tuple(sorted(cycles(gl).items()));buckets[inv]+=1;reps.setdefault(inv,g)
+ classes=[]
+ for inv in sorted(buckets):
+  r=reps[inv];cent=sum(mm(h,r)==mm(r,h) for h in G)
+  classes.append({'line_cycle_profile':{str(k):v for k,v in inv},'element_count':buckets[inv],'centralizer_order':cent,'conjugacy_class_size':len(G)//cent})
+ C['two_rank2_square_zero_unipotent_classes']=sorted(x['element_count'] for x in classes)==[240,480]
+ C['each_line_profile_bucket_is_one_conjugacy_class']=all(x['element_count']==x['conjugacy_class_size'] for x in classes)
+ cent=sum(mm(h,CX)==mm(CX,h) for h in G);C['cx_centralizer_order_108']=cent==108;C['cx_conjugacy_class_size_480']=len(G)//cent==480
+ assert all(C.values()),[k for k,v in C.items() if not v]
+ d={'title':'Qutrit controlled-add / W33 Lagrangian-unipotent certificate','field':'F3','basis_gate':'|p,f> -> |p,f+p mod 3>','pauli_coordinates':['x_p','z_p','x_f','z_f'],'symplectic_matrix':CX,'matrix_order':3,'nilpotent_index_of_M_minus_I':2,'rank_of_M_minus_I':rank(N),'jordan_type':'2+2','fixed_vector_dimension':2,'terminology':'rank-two symplectic Lagrangian unipotent (not a rank-one transvection)','w33':{'points':40,'lines':40,'flags':160,'edges':240,'point_cycle_profile':prof(pc),'line_cycle_profile':prof(lc),'flag_cycle_profile':prof(fc),'edge_cycle_profile':prof(ec),'fixed_points':fixed,'fixed_points_are_one_isotropic_line':True,'fixed_line_structure':{'fixed_lines':len(FL),'axis_plus_external':'1 + 6','external_pencils_on_axis':sorted(attach.values()),'fixed_edges':len(FE),'fixed_edges_are_axis_K4':True}},'bell_qutrit':{'preparation':'CX (F3 tensor I) |00>','support':[(0,0),(1,1),(2,2)],'schmidt_rank':3,'reduced_density':'I_3/3'},'generator_closure':{'generators':['F_p','F_f','S_p','S_f','CX_p_to_f'],'order':len(G),'group':'Sp(4,3)'},'unipotent_class_resolution':{'family':'order 3, rank(M-I)=2, (M-I)^2=0','total_elements':sum(x['element_count'] for x in classes),'classes':classes,'cx_centralizer_order':cent,'cx_class_size':len(G)//cent,'cx_identifier':'line cycle profile 1^7 3^11','lesson':'Jordan type 2+2 is insufficient; W33 line action resolves the two Sp(4,3) classes'},'checks':C,'check_count':len(C),'all_checks_pass':True,'scope':{'proved':'exact gate, Pauli-frame action, W33 permutation action, Bell preparation, symplectic closure','not_proved':'a deterministic physical two-qutrit photonic gate with a particular loss/fidelity budget'}}
+ d['certificate_sha256']=hashlib.sha256(json.dumps(d,sort_keys=True,separators=(',',':')).encode()).hexdigest();return d
+
+def main():
+ d=build_certificate();p=Path(__file__).resolve().parents[1]/'data/PART_BT2757_QUTRIT_CX_W33_LAGRANGIAN_UNIPOTENT_results.json';p.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n');print(json.dumps(d,indent=2,sort_keys=True));print('wrote',p)
+if __name__=='__main__':main()

--- a/analysis/w33_pass2757_2761_qutrit_cx_release.md
+++ b/analysis/w33_pass2757_2761_qutrit_cx_release.md
@@ -1,0 +1,88 @@
+# Passes 2757–2761 — controlled-add hardware and W33 conjugacy resolution
+
+## Pass 2757 — exact controlled-add / SUM gate
+
+The computational instruction
+
+\[
+|p,f\rangle\mapsto |p,f+p\pmod 3\rangle
+\]
+
+is implemented and exhaustively checked on all nine computational basis states. Its
+Pauli-frame action is checked on all 81 frame labels and agrees exactly with
+
+\[
+M_{\rm CX}=\begin{pmatrix}
+1&0&0&0\\
+0&1&0&-1\\
+1&0&1&0\\
+0&0&0&1
+\end{pmatrix}\in\operatorname{Sp}(4,3).
+\]
+
+The gate has order three, \((M-I)^2=0\), and \(\operatorname{rank}(M-I)=2\).
+
+## Pass 2758 — the fixed W33 Lagrangian line
+
+The image and kernel of \(M-I\) coincide in one totally isotropic two-space. The
+induced W33 cycle profiles are
+
+\[
+40\text{ points}:1^4 3^{12},\quad
+40\text{ lines}:1^7 3^{11},\quad
+160\text{ flags}:1^{10}3^{50},\quad
+240\text{ edges}:1^6 3^{78}.
+\]
+
+The fixed points are exactly one line, and the fixed edges are exactly that line's six
+\(K_4\) edges. The seven fixed lines are the axis plus two three-line pencils attached
+at two axis points.
+
+## Pass 2759 — conjugacy class resolved by geometry
+
+The full generated group of order \(51{,}840\) contains \(720\) order-three elements
+with rank-two square-zero nilpotent part. They split into two conjugacy classes:
+
+\[
+\begin{array}{c|c|c}
+\text{line profile}&\text{class size}&\text{centralizer order}\\ \hline
+1^1 3^{13}&240&216\\
+1^7 3^{11}&480&108.
+\end{array}
+\]
+
+Controlled-add is the \(480\)-class. Jordan type \(2+2\) is insufficient to identify it;
+the six-line fixed fringe is the exact W33 class certificate.
+
+## Pass 2760 — executable RTL and exhaustive regression
+
+The release adds a synthesizable computational data path, a sequential Pauli-frame
+tracker, an order-three chain, and an exhaustive SystemVerilog testbench. The testbench
+covers the 9 basis states, all 81 frames, and all \(81^2\) frame pairs for preservation
+of the symplectic form. The local Python suite passes 3/3. A focused GitHub Actions
+workflow installs Icarus Verilog and reruns both the exact certificate and RTL simulation.
+Remote CI is future evidence until observed.
+
+## Pass 2761 — manuscript promotion and evidence firewall
+
+The Holonet wrapper now reaches a host-independent theorem insert. It records the exact
+gate, fixed geometry, conjugacy split, Bell-qutrit preparation, and
+
+\[
+\langle F_p,F_f,S_p,S_f,\operatorname{CX}_{p\to f}\rangle
+=\operatorname{Sp}(4,3).
+\]
+
+The insert also states the physical boundary: exact controller RTL and symplectic logic do
+not constitute a measured deterministic photonic qutrit SUM gate. Published photonic
+work supports electro-optic qutrit tritters, arbitrary high-dimensional time-bin state
+preparation/measurement, and time-bin qubit entangling gates; the platform-specific qutrit
+SUM loss/fidelity budget remains open.
+
+## Evidence
+
+- 24 exact checks in the frozen JSON certificate.
+- 3/3 local Python regressions.
+- Standalone LaTeX insert compiled successfully.
+- Local Icarus/Yosys tools were unavailable; the checked-in workflow supplies independent
+  RTL execution and must not be described as passed until GitHub reports success.

--- a/data/PART_BT2757_QUTRIT_CX_W33_LAGRANGIAN_UNIPOTENT_results.json
+++ b/data/PART_BT2757_QUTRIT_CX_W33_LAGRANGIAN_UNIPOTENT_results.json
@@ -1,0 +1,98 @@
+{
+  "all_checks_pass": true,
+  "basis_gate": "|p,f> -> |p,f+p mod 3>",
+  "bell_qutrit": {
+    "preparation": "CX (F3 tensor I) |00>",
+    "reduced_density": "I_3/3",
+    "schmidt_rank": 3,
+    "support": [[0, 0], [1, 1], [2, 2]]
+  },
+  "certificate_sha256": "c3b10f39320fe8941a73bbe2f513e077aca4c6096d16319fc226343d76e8026e",
+  "check_count": 24,
+  "checks": {
+    "all_81_pauli_frames_match_symplectic_matrix": true,
+    "bell_qutrit_support": true,
+    "bell_reduced_density_is_I_over_3": true,
+    "computational_basis_bijection": true,
+    "computational_gate_order_3": true,
+    "cx_centralizer_order_108": true,
+    "cx_conjugacy_class_size_480": true,
+    "each_line_profile_bucket_is_one_conjugacy_class": true,
+    "fixed_line_profile_axis_plus_six": true,
+    "fixed_points_form_one_isotropic_line": true,
+    "fixed_vector_space_dimension_2": true,
+    "four_points_per_line": true,
+    "full_sp4_3_closure_51840": true,
+    "image_equals_fixed_lagrangian_line": true,
+    "matrix_order_3": true,
+    "nilpotent_square_zero": true,
+    "point_cycle_profile_1^4_3^12": true,
+    "six_external_fixed_lines_form_two_three_line_pencils": true,
+    "six_fixed_edges_are_exactly_axis_K4": true,
+    "symplectic_identity": true,
+    "two_rank2_square_zero_unipotent_classes": true,
+    "w33_edge_count_240": true,
+    "w33_line_count_40": true,
+    "w33_point_count_40": true
+  },
+  "field": "F3",
+  "fixed_vector_dimension": 2,
+  "generator_closure": {
+    "generators": ["F_p", "F_f", "S_p", "S_f", "CX_p_to_f"],
+    "group": "Sp(4,3)",
+    "order": 51840
+  },
+  "jordan_type": "2+2",
+  "matrix_order": 3,
+  "nilpotent_index_of_M_minus_I": 2,
+  "pauli_coordinates": ["x_p", "z_p", "x_f", "z_f"],
+  "rank_of_M_minus_I": 2,
+  "scope": {
+    "not_proved": "a deterministic physical two-qutrit photonic gate with a particular loss/fidelity budget",
+    "proved": "exact gate, Pauli-frame action, W33 permutation action, Bell preparation, symplectic closure"
+  },
+  "symplectic_matrix": [[1,0,0,0],[0,1,0,2],[1,0,1,0],[0,0,0,1]],
+  "terminology": "rank-two symplectic Lagrangian unipotent (not a rank-one transvection)",
+  "title": "Qutrit controlled-add / W33 Lagrangian-unipotent certificate",
+  "unipotent_class_resolution": {
+    "classes": [
+      {
+        "centralizer_order": 216,
+        "conjugacy_class_size": 240,
+        "element_count": 240,
+        "line_cycle_profile": {"1": 1, "3": 13}
+      },
+      {
+        "centralizer_order": 108,
+        "conjugacy_class_size": 480,
+        "element_count": 480,
+        "line_cycle_profile": {"1": 7, "3": 11}
+      }
+    ],
+    "cx_centralizer_order": 108,
+    "cx_class_size": 480,
+    "cx_identifier": "line cycle profile 1^7 3^11",
+    "family": "order 3, rank(M-I)=2, (M-I)^2=0",
+    "lesson": "Jordan type 2+2 is insufficient; W33 line action resolves the two Sp(4,3) classes",
+    "total_elements": 720
+  },
+  "w33": {
+    "edge_cycle_profile": {"1": 6, "3": 78},
+    "edges": 240,
+    "fixed_line_structure": {
+      "axis_plus_external": "1 + 6",
+      "external_pencils_on_axis": [3, 3],
+      "fixed_edges": 6,
+      "fixed_edges_are_axis_K4": true,
+      "fixed_lines": 7
+    },
+    "fixed_points": [[0,0,1,0],[0,1,0,0],[0,1,1,0],[0,1,2,0]],
+    "fixed_points_are_one_isotropic_line": true,
+    "flag_cycle_profile": {"1": 10, "3": 50},
+    "flags": 160,
+    "line_cycle_profile": {"1": 7, "3": 11},
+    "lines": 40,
+    "point_cycle_profile": {"1": 4, "3": 12},
+    "points": 40
+  }
+}

--- a/data/w33_pass_namespace_registry_v2.d/2757-2761.json
+++ b/data/w33_pass_namespace_registry_v2.d/2757-2761.json
@@ -1,0 +1,20 @@
+{
+  "schema": "w33.pass_namespace_registry.v2.supplement",
+  "status": "ACTIVE",
+  "canonical_blocks": [
+    {
+      "range": "2757-2761",
+      "owner": "qutrit-cx-w33-lagrangian-unipotent-track",
+      "status": "COMPLETE_LOCAL_EXACT_REMOTE_PENDING",
+      "artifacts": {
+        "2757": "exact qutrit controlled-add computational and Pauli-frame verifier",
+        "2758": "fixed W33 Lagrangian line and point/line/flag/edge cycle profiles",
+        "2759": "complete rank-two square-zero unipotent class split and CX centralizer",
+        "2760": "synthesizable data/frame RTL, exhaustive testbench, tests, and CI",
+        "2761": "Holonet theorem insert, wrapper promotion, and physical evidence firewall"
+      },
+      "certificate_sha256": "c3b10f39320fe8941a73bbe2f513e077aca4c6096d16319fc226343d76e8026e",
+      "runtime_boundary": "All exact Python checks and focused regressions completed locally; the standalone TeX insert compiled locally. The RTL workflow is independent remote evidence and is not counted as successful until observed."
+    }
+  ]
+}

--- a/photonic_holonet.tex
+++ b/photonic_holonet.tex
@@ -50,6 +50,7 @@
     \input{analysis/BT2475_five_frontiers_insert}%
     \input{analysis/BT2557_seven_frontiers_insert}%
     \input{analysis/BT2567_seven_frontiers_insert}%
+    \input{analysis/BT2758_qutrit_cx_holonet_insert}%
   }%
 }
 \input{photonic_holonet_body.tex}

--- a/rtl/tb_w33_pass2757_qutrit_cx.sv
+++ b/rtl/tb_w33_pass2757_qutrit_cx.sv
@@ -1,0 +1,32 @@
+`timescale 1ns/1ps
+module tb_w33_pass2757_qutrit_cx;
+ reg [1:0] p,f,xp,zp,xf,zf,yp,yzp,yf,yzf;
+ wire [1:0] po,fo,x1,z1,y1,w1,x3,z3,y3,w3,u1,v1,s1,t1;
+ integer a,b,c,d,e,g,h,k,before_form,after_form;
+ w33_qutrit_cx_data du(p,f,po,fo);
+ w33_qutrit_cx_frame_map mu(xp,zp,xf,zf,x1,z1,y1,w1);
+ w33_qutrit_cx_order3 ou(xp,zp,xf,zf,x3,z3,y3,w3);
+ w33_qutrit_cx_frame_map mv(yp,yzp,yf,yzf,u1,v1,s1,t1);
+ function integer mod3(input integer q); begin mod3=q%3;if(mod3<0)mod3=mod3+3;end endfunction
+ function integer symp(input integer ax,input integer az,input integer bx,input integer bz,input integer cx,input integer cz,input integer dx,input integer dz);
+  begin symp=mod3(ax*cz-az*cx+bx*dz-bz*dx); end
+ endfunction
+ initial begin
+  for(a=0;a<3;a=a+1)for(b=0;b<3;b=b+1)begin
+   p=a;f=b;#1;
+   if(po!==a[1:0]||fo!==((a+b)%3))$fatal(1,"data");
+  end
+  for(a=0;a<3;a=a+1)for(b=0;b<3;b=b+1)for(c=0;c<3;c=c+1)for(d=0;d<3;d=d+1)begin
+   xp=a;zp=b;xf=c;zf=d;#1;
+   if(x1!==a[1:0]||z1!==mod3(b-d)||y1!==mod3(c+a)||w1!==d[1:0])$fatal(1,"frame");
+   if(x3!==a[1:0]||z3!==b[1:0]||y3!==c[1:0]||w3!==d[1:0])$fatal(1,"order3");
+  end
+  for(a=0;a<3;a=a+1)for(b=0;b<3;b=b+1)for(c=0;c<3;c=c+1)for(d=0;d<3;d=d+1)
+  for(e=0;e<3;e=e+1)for(g=0;g<3;g=g+1)for(h=0;h<3;h=h+1)for(k=0;k<3;k=k+1)begin
+   xp=a;zp=b;xf=c;zf=d;yp=e;yzp=g;yf=h;yzf=k;#1;
+   before_form=symp(a,b,c,d,e,g,h,k);after_form=symp(x1,z1,y1,w1,u1,v1,s1,t1);
+   if(before_form!=after_form)$fatal(1,"symplectic");
+  end
+  $display("PASS: 9 basis states, 81 frames, order 3, and 81^2 symplectic pairs");$finish;
+ end
+endmodule

--- a/rtl/w33_pass2757_qutrit_cx.sv
+++ b/rtl/w33_pass2757_qutrit_cx.sv
@@ -1,0 +1,71 @@
+// Pass 2757 -- qutrit controlled-add (SUM/CX) instruction.
+//
+// Computational data path: |p,f> -> |p,f+p mod 3>
+// Pauli frame: (xp,zp,xf,zf) -> (xp,zp-zf,xf+xp,zf).
+// The matrix has order 3 and (M-I)^2=0 with rank(M-I)=2: a
+// rank-two Lagrangian unipotent (Jordan type 2+2), not a transvection.
+`timescale 1ns/1ps
+
+module w33_qutrit_cx_data(
+    input wire [1:0] p, input wire [1:0] f,
+    output wire [1:0] p_out, output wire [1:0] f_out
+);
+    function automatic [1:0] add3(input [1:0] a,input [1:0] b);
+        reg [2:0] sum;
+        begin sum=a+b; add3=(sum>=3)?sum-3:sum[1:0]; end
+    endfunction
+    assign p_out=p;
+    assign f_out=add3(f,p);
+endmodule
+
+module w33_qutrit_cx_frame_map(
+    input wire [1:0] xp,input wire [1:0] zp,
+    input wire [1:0] xf,input wire [1:0] zf,
+    output wire [1:0] xp_out,output wire [1:0] zp_out,
+    output wire [1:0] xf_out,output wire [1:0] zf_out
+);
+    function automatic [1:0] add3(input [1:0] a,input [1:0] b);
+        reg [2:0] sum;
+        begin sum=a+b; add3=(sum>=3)?sum-3:sum[1:0]; end
+    endfunction
+    function automatic [1:0] sub3(input [1:0] a,input [1:0] b);
+        begin
+            case({a,b})
+                {2'd0,2'd0}:sub3=2'd0; {2'd0,2'd1}:sub3=2'd2;
+                {2'd0,2'd2}:sub3=2'd1; {2'd1,2'd0}:sub3=2'd1;
+                {2'd1,2'd1}:sub3=2'd0; {2'd1,2'd2}:sub3=2'd2;
+                {2'd2,2'd0}:sub3=2'd2; {2'd2,2'd1}:sub3=2'd1;
+                default:sub3=2'd0;
+            endcase
+        end
+    endfunction
+    assign xp_out=xp;
+    assign zp_out=sub3(zp,zf);
+    assign xf_out=add3(xf,xp);
+    assign zf_out=zf;
+endmodule
+
+module w33_qutrit_cx_frame(
+    input wire clk,input wire rst,input wire apply_cx,
+    output reg [1:0] xp,output reg [1:0] zp,
+    output reg [1:0] xf,output reg [1:0] zf
+);
+    wire [1:0] xn,zn,yn,wn;
+    w33_qutrit_cx_frame_map m(xp,zp,xf,zf,xn,zn,yn,wn);
+    always_ff @(posedge clk) begin
+        if(rst) begin xp<=0;zp<=0;xf<=0;zf<=0; end
+        else if(apply_cx) begin xp<=xn;zp<=zn;xf<=yn;zf<=wn; end
+    end
+endmodule
+
+module w33_qutrit_cx_order3(
+    input wire [1:0] xp,input wire [1:0] zp,
+    input wire [1:0] xf,input wire [1:0] zf,
+    output wire [1:0] xp3,output wire [1:0] zp3,
+    output wire [1:0] xf3,output wire [1:0] zf3
+);
+    wire [1:0] x1,z1,y1,w1,x2,z2,y2,w2;
+    w33_qutrit_cx_frame_map m1(xp,zp,xf,zf,x1,z1,y1,w1);
+    w33_qutrit_cx_frame_map m2(x1,z1,y1,w1,x2,z2,y2,w2);
+    w33_qutrit_cx_frame_map m3(x2,z2,y2,w2,xp3,zp3,xf3,zf3);
+endmodule

--- a/tests/test_bt2757_qutrit_cx_w33.py
+++ b/tests/test_bt2757_qutrit_cx_w33.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import importlib.util
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+MODULE=ROOT/'analysis/bt2757_qutrit_cx_w33_lagrangian_unipotent.py'
+
+def load():
+ spec=importlib.util.spec_from_file_location('bt2757_cx',MODULE);assert spec and spec.loader
+ m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m);return m
+
+def test_exact_cx_certificate():
+ c=load().build_certificate();assert c['all_checks_pass'];assert c['matrix_order']==3
+ assert c['rank_of_M_minus_I']==2 and c['jordan_type']=='2+2'
+ assert c['generator_closure']=={'generators':['F_p','F_f','S_p','S_f','CX_p_to_f'],'order':51840,'group':'Sp(4,3)'}
+ assert c['unipotent_class_resolution']['classes']==[
+  {'line_cycle_profile':{'1':1,'3':13},'element_count':240,'centralizer_order':216,'conjugacy_class_size':240},
+  {'line_cycle_profile':{'1':7,'3':11},'element_count':480,'centralizer_order':108,'conjugacy_class_size':480}]
+
+def test_induced_w33_cycle_profiles():
+ w=load().build_certificate()['w33']
+ assert w['point_cycle_profile']=={'1':4,'3':12}
+ assert w['line_cycle_profile']=={'1':7,'3':11}
+ assert w['flag_cycle_profile']=={'1':10,'3':50}
+ assert w['edge_cycle_profile']=={'1':6,'3':78}
+ assert w['fixed_line_structure']=={'fixed_lines':7,'axis_plus_external':'1 + 6','external_pencils_on_axis':[3,3],'fixed_edges':6,'fixed_edges_are_axis_K4':True}
+
+def test_scope_firewall_present():
+ c=load().build_certificate();assert 'physical' in c['scope']['not_proved']


### PR DESCRIPTION
## Summary

Build and certify the missing two-register qutrit controlled-add/SUM instruction.

- exact computational and Pauli-frame action over F3
- 24-check certificate and 3/3 focused regressions
- full Sp(4,3) closure of order 51,840
- W33 point/line/flag/edge cycle profiles
- fixed Lagrangian line with a rigid 3+3 fixed-line fringe
- complete split of the two rank-two square-zero unipotent classes (480/240)
- synthesizable RTL plus exhaustive 9, 81, and 81^2-vector testbench
- focused CI and Holonet theorem promotion

## Evidence boundary

Local Python tests pass and the standalone TeX insert compiles. Local Icarus/Yosys binaries were unavailable, so the checked-in workflow is independent remote evidence and is not counted as passed until observed. Exact RTL/controller logic does not by itself establish a deterministic physical photonic qutrit SUM loss/fidelity budget.