### PR TITLE
Passes 2967–2973: S6 curvature, route code, and chirality correction

### DIFF
--- a/.github/workflows/w33_pass2967_2973_s6_curvature_route.yml
+++ b/.github/workflows/w33_pass2967_2973_s6_curvature_route.yml
@@ -1,0 +1,95 @@
+name: Passes 2967-2973 S6 Curvature Route
+
+on:
+  push:
+    branches:
+      - agent/pass2967-2973-s6-two-graph-route-code-r2
+  pull_request:
+    paths:
+      - 'analysis/bt2967_*'
+      - 'analysis/bt2968_*'
+      - 'analysis/bt2969_*'
+      - 'analysis/bt2970_*'
+      - 'analysis/BT2967*'
+      - 'data/PART_BT2967*'
+      - 'data/PART_BT2968*'
+      - 'data/PART_BT2969*'
+      - 'data/PART_BT2970*'
+      - 'tools/integrate_bt2967_bt2970_blueprint_index.py'
+      - 'tests/test_bt2967_bt2970_s6_curvature_chirality_route.py'
+      - 'w33_paper.tex'
+      - 'photonic_holonet.tex'
+      - 'holonet_machine_blueprint.tex'
+      - 'docs/index.html'
+      - '.github/workflows/w33_pass2967_2973_s6_curvature_route.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  materialize-verify-integrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+      - name: Materialize verified continuation onto current master tip
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin agent/pass2967-2973-s6-two-graph-route-code
+          git checkout origin/agent/pass2967-2973-s6-two-graph-route-code -- \
+            analysis/BT2967_BT2970_s6_curvature_chirality_route.md \
+            analysis/BT2967_BT2970_s6_curvature_chirality_route_blueprint_insert.tex \
+            analysis/BT2967_BT2970_s6_curvature_chirality_route_insert.tex \
+            analysis/bt2967_oam_holonomy_s6_two_graph.py \
+            analysis/bt2968_curvature_route_code.py \
+            analysis/bt2969_chirality_receiver_correction.py \
+            analysis/bt2970_layered_route_fault_architecture.py \
+            data/PART_BT2967_OAM_HOLONOMY_S6_TWO_GRAPH_results.json \
+            data/PART_BT2968_CURVATURE_ROUTE_CODE_results.json \
+            data/PART_BT2969_CHIRALITY_RECEIVER_CORRECTION_results.json \
+            data/PART_BT2970_LAYERED_ROUTE_FAULT_ARCHITECTURE_results.json \
+            data/w33_pass_namespace_registry_v2.d/2967-2973.json \
+            tests/test_bt2967_bt2970_s6_curvature_chirality_route.py \
+            tools/integrate_bt2967_bt2970_blueprint_index.py \
+            w33_paper.tex \
+            photonic_holonet.tex
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install focused dependencies
+        run: python -m pip install --upgrade numpy networkx pytest
+      - name: Recompute exact continuation
+        run: |
+          python analysis/bt2967_oam_holonomy_s6_two_graph.py
+          python analysis/bt2968_curvature_route_code.py
+          python analysis/bt2969_chirality_receiver_correction.py
+          python analysis/bt2970_layered_route_fault_architecture.py
+      - name: Focused regression
+        run: pytest -q tests/test_bt2967_bt2970_s6_curvature_chirality_route.py
+      - name: Integrate blueprint and live atlas idempotently
+        run: |
+          python tools/integrate_bt2967_bt2970_blueprint_index.py
+          python tools/integrate_bt2967_bt2970_blueprint_index.py --check
+          grep -Fq '\input{analysis/BT2967_BT2970_s6_curvature_chirality_route_blueprint_insert}' holonet_machine_blueprint.tex
+          grep -Fq 'BT2967-BT2970-S6-CURVATURE-ROUTE-V1' docs/index.html
+      - name: Verify manuscript promotion and whitespace
+        run: |
+          grep -Fq '\input{analysis/BT2960_BT2966_physical_compiler_insert}' w33_paper.tex
+          grep -Fq '\input{analysis/BT2967_BT2970_s6_curvature_chirality_route_insert}' w33_paper.tex
+          grep -Fq '\input{analysis/BT2960_BT2966_physical_compiler_insert}' photonic_holonet.tex
+          grep -Fq '\input{analysis/BT2967_BT2970_s6_curvature_chirality_route_insert}' photonic_holonet.tex
+          git diff --check
+      - name: Commit clean rebased packet and generated front doors
+        if: github.event_name == 'push'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .
+          if ! git diff --cached --quiet; then
+            git commit -m 'Passes 2967-2973: materialize verified S6 curvature continuation'
+            git push origin HEAD:agent/pass2967-2973-s6-two-graph-route-code-r2
+          fi

--- a/analysis/BT2967_BT2970_s6_curvature_chirality_route.md
+++ b/analysis/BT2967_BT2970_s6_curvature_chirality_route.md
@@ -1,0 +1,22 @@
+# Passes 2967–2970 — S6 curvature, route decoding, and receiver correction
+
+Pass 2967 refines the completed all-spread D4 holonomy theorem. Taking permutation sign yields a gauge-invariant triangle curvature. On every one of the 36 spreads, the 60 odd triangles form a 2-(10,3,4) design and every tetrahedron contains an even number of odd faces. All 1024 vertex-sign gauges preserve the curvature. Its switching class contains the Petersen graph and has automorphism group PΣL(2,9) ≅ S6 of order 720 in the degree-ten action on 3+3 partitions of a six-set. The abstract identification is standard two-graph theory; the project-specific theorem is its exact emergence from every W33 spread router.
+
+Pass 2968 proves the triangle-edge matrix H has rank 36 and kernel equal to the cut space of K10. Therefore the parity layer is the binary [45,9,9] code with weight enumerator
+
+1 + 10 z^9 + 45 z^16 + 120 z^21 + 210 z^24 + 126 z^25.
+
+All nongauge odd faults through weight 8 are detected and odd faults through weight 4 are correctable modulo slot gauge.
+
+Pass 2969 corrects the Pass 2954 receiver label. The minimum project-local Pauli cover remains {YI,IY}, but its success (1+1/sqrt(3))/2 = 0.788675 is not the unrestricted Helstrom bound. Since every conjugate pair has squared overlap 1/3, ideal equal-prior Helstrom success is (1+sqrt(2/3))/2 = 0.908248. For n copies it is (1+sqrt(1-3^-n))/2. Adaptive individual attainability is published prior art: Acín et al., Phys. Rev. A 71, 032338 (2005), arXiv:quant-ph/0410097.
+
+Pass 2970 welds the completed three-pilot theorem to the parity code. Three pilots identify one arbitrary nonidentity S4 edge error, including even errors invisible to sign curvature. The curvature layer adds multi-edge correction for odd faults. No simultaneous arbitrary-S4 pilot theorem is claimed.
+
+Reproduce with:
+
+```bash
+python analysis/bt2967_oam_holonomy_s6_two_graph.py
+python analysis/bt2968_curvature_route_code.py
+python analysis/bt2969_chirality_receiver_correction.py
+python analysis/bt2970_layered_route_fault_architecture.py
+```

--- a/analysis/BT2967_BT2970_s6_curvature_chirality_route_blueprint_insert.tex
+++ b/analysis/BT2967_BT2970_s6_curvature_chirality_route_blueprint_insert.tex
@@ -1,0 +1,45 @@
+\section{The spread router can certify its own curvature}
+\label{sec:bt2967-bt2970-blueprint}
+
+\begin{plain}
+The ten spread modes carry exact four-channel permutations.  Local slot labels
+can change which links look even or odd, but not the parity accumulated around
+a triangle.  Across all thirty-six spreads, those triangle parities form one
+standard object whose switching class contains the Petersen graph.  The machine
+can compare an observed parity table with that certified baseline and decode
+route faults.
+\end{plain}
+
+\begin{spec}[Exact curvature and route code]
+Pass~2967 proves that the sixty odd triangle holonomies form a
+\(2-(10,3,4)\) two-graph with
+\[
+ \delta^2a=0,
+ \qquad
+ \operatorname{Aut}(\mathcal T)\cong S_6,
+ \qquad |S_6|=720.
+\]
+Pass~2968 proves that the \(120\times45\) triangle--edge matrix has rank \(36\)
+and kernel
+\[
+ \operatorname{Cut}(K_{10})=[45,9,9]_2.
+\]
+All nongauge odd faults through weight eight are detected; odd faults through
+weight four are correctable modulo slot gauge.
+\end{spec}
+
+\begin{spec}[Complementary pilot layer]
+Three distinct pilot slots identify every one of the twenty-three nonidentity
+\(S_4\) errors on one faulty edge.  The pilot layer therefore catches even
+errors that parity cannot see, while the curvature layer adds multi-edge
+correction for odd faults.
+\end{spec}
+
+\begin{gotwrong}[Receiver correction]
+The local Pauli cover \(\{YI,IY\}\) remains minimal, but its success
+\(\tfrac12(1+1/\sqrt3)=0.788675\ldots\) is not Helstrom-optimal.  With squared
+overlap \(1/3\), the ideal one-copy optimum is
+\(\tfrac12(1+\sqrt{2/3})=0.908248\ldots\), and the \(n\)-copy optimum is
+\(\tfrac12(1+\sqrt{1-3^{-n}})\).  Adaptive attainability is published prior
+art, not a new machine theorem.
+\end{gotwrong}

--- a/analysis/BT2967_BT2970_s6_curvature_chirality_route_insert.tex
+++ b/analysis/BT2967_BT2970_s6_curvature_chirality_route_insert.tex
@@ -1,0 +1,59 @@
+\section{Spread curvature, route decoding, and corrected chirality readout}
+\label{sec:bt2967-bt2970}
+
+For spread transport permutations \(g_{ij}\in S_4\), define
+\[
+ a_{ij}=\operatorname{sgn}(g_{ij}),\qquad
+ \kappa_{ijk}=\operatorname{sgn}(g_{ki}g_{jk}g_{ij})=(\delta a)_{ijk}.
+\]
+Pass~2967 enumerates all \(36\) spreads.  Each has \(60\) transposition and
+\(60\) double-transposition triangle holonomies.  The odd triangles form a
+\(2-(10,3,4)\) design and satisfy the exact Bianchi identity
+\[
+ \delta\kappa=\delta^2a=0
+\]
+on all \(210\) tetrahedra.  All vertex-sign gauges preserve \(\kappa\).  The
+common switching class contains the Petersen graph and has
+\[
+ \operatorname{Aut}(\mathcal T)\cong\mathrm{P}\Sigma\mathrm L(2,9)\cong S_6,
+ \qquad |\operatorname{Aut}(\mathcal T)|=720.
+\]
+The abstract two-graph identification is standard; the exact emergence from
+every W33 spread-router table is the project-specific result.
+
+Let \(H\in\mathbb F_2^{120\times45}\) be triangle--edge incidence.  Pass~2968
+proves
+\[
+ \operatorname{rank}H=36,
+ \qquad \ker H=\operatorname{Cut}(K_{10})=[45,9,9]_2.
+\]
+Thus every nongauge odd-parity fault through weight eight is detected and every
+odd-parity fault through weight four is correctable modulo vertex switching.
+
+Pass~2969 corrects the receiver optimality label.  The minimum project-local
+Pauli cover remains \(\{YI,IY\}\), but
+\[
+ \tfrac12(1+1/\sqrt3)=0.788675\ldots
+\]
+is its selected local-Pauli success, not the unrestricted Helstrom bound.  Since
+all conjugate pairs have squared overlap \(1/3\), the ideal equal-prior optimum is
+\[
+ \boxed{P_{\rm H}^{(1)}=\tfrac12(1+\sqrt{2/3})=0.908248\ldots .}
+\]
+For \(n\) copies,
+\[
+ P_{\rm H}^{(n)}=\tfrac12(1+\sqrt{1-3^{-n}}).
+\]
+Adaptive individual measurements are known to attain this collective bound for
+binary pure states (Ac\'in et al., Phys. Rev. A \textbf{71}, 032338 (2005));
+this attainability theorem is prior art.
+
+Finally, Pass~2970 combines the completed three-pilot theorem with the parity
+code.  Three pilots identify one arbitrary nonidentity \(S_4\) error on one
+route edge, including even errors invisible to sign curvature.  The curvature
+layer adds exact multi-edge correction for the odd-parity projection.
+
+\paragraph{Boundary.}
+These are finite routing and ideal receiver statements, not measured optical
+Berry phases, continuum gauge fields, loss budgets, or simultaneous
+arbitrary-\(S_4\) multi-edge guarantees.

--- a/analysis/bt2967_oam_holonomy_s6_two_graph.py
+++ b/analysis/bt2967_oam_holonomy_s6_two_graph.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Pass 2967: exact OAM spread-router gauge curvature and S6 two-graph closure."""
+from __future__ import annotations
+import collections,itertools,json
+from pathlib import Path
+import networkx as nx
+import numpy as np
+ROOT=Path(__file__).resolve().parents[1]
+OUT=ROOT/'data/PART_BT2967_OAM_HOLONOMY_S6_TWO_GRAPH_results.json'
+
+def norm(v):
+ v=tuple(int(x)%3 for x in v);i=next(i for i,x in enumerate(v) if x)
+ return tuple(2*x%3 for x in v) if v[i]==2 else v
+POINTS=[v for v in itertools.product(range(3),repeat=4) if any(v) and norm(v)==v]
+PIN={p:i for i,p in enumerate(POINTS)}
+J=np.array([[0,1,0,0],[2,0,0,0],[0,0,0,1],[0,0,2,0]],dtype=int)
+def symp(p,q):return int(np.array(p)@J@np.array(q)%3)
+LS=set()
+for i,j in itertools.combinations(range(40),2):
+ if symp(POINTS[i],POINTS[j]):continue
+ p=np.array(POINTS[i]);q=np.array(POINTS[j])
+ LS.add(tuple(sorted({PIN[norm(a*p+b*q)] for a,b in itertools.product(range(3),repeat=2) if a or b})))
+LINES=sorted(LS);BY={p:[] for p in range(40)}
+for li,line in enumerate(LINES):
+ for p in line:BY[p].append(li)
+def spreads():
+ out=[]
+ def walk(covered,chosen):
+  if len(covered)==40:out.append(tuple(sorted(chosen)));return
+  rem=set(range(40))-covered
+  p=min(rem,key=lambda x:sum(1 for li in BY[x] if not(set(LINES[li])&covered)))
+  for li in BY[p]:
+   line=set(LINES[li])
+   if line&covered:continue
+   walk(covered|line,chosen+[li])
+ walk(set(),[]);return sorted(set(out))
+def compose(p,q):return tuple(p[q[a]] for a in range(4))
+def parity(p):return sum(p[a]>p[b] for a in range(4) for b in range(a+1,4))%2
+def ctype(p):
+ seen=set();lens=[]
+ for a in range(4):
+  if a in seen:continue
+  b=a;n=0
+  while b not in seen:seen.add(b);n+=1;b=p[b]
+  lens.append(n)
+ return tuple(sorted(lens,reverse=True))
+def transport(ids):
+ spread=[LINES[i] for i in ids];slot={p:s for line in spread for s,p in enumerate(line)};g={}
+ for i,j in itertools.permutations(range(10),2):
+  perm=[]
+  for p in spread[i]:
+   target=[q for q in spread[j] if symp(POINTS[p],POINTS[q])==0]
+   assert len(target)==1;perm.append(slot[target[0]])
+  g[i,j]=tuple(perm);assert sorted(g[i,j])==list(range(4))
+ return g
+def incidence(blocks):
+ G=nx.Graph()
+ for p in range(10):G.add_node(('p',p),kind='point')
+ for bi,b in enumerate(sorted(blocks)):
+  G.add_node(('b',bi),kind='block')
+  for p in b:G.add_edge(('p',p),('b',bi))
+ return G
+def pkey(s):
+ s=frozenset(s);c=frozenset(set(range(6))-set(s));return min(tuple(sorted(s)),tuple(sorted(c)))
+PARTS=sorted({pkey(s) for s in itertools.combinations(range(6),3)});PI={p:i for i,p in enumerate(PARTS)}
+ACTIONS=set()
+for sigma in itertools.permutations(range(6)):
+ ACTIONS.add(tuple(PI[pkey({sigma[x] for x in p})] for p in PARTS))
+assert len(ACTIONS)==720
+unseen=set(itertools.combinations(range(10),3));orbits=[]
+while unseen:
+ seed=min(unseen);orb={tuple(sorted(a[i] for i in seed)) for a in ACTIONS};orbits.append(orb);unseen-=orb
+orbits.sort(key=lambda o:min(o));assert [len(o) for o in orbits]==[60,60]
+CANON=orbits[0];CIG=incidence(CANON)
+def analyze(ids):
+ g=transport(ids);edge={(i,j):parity(g[i,j]) for i,j in itertools.combinations(range(10),2)};odd=set();hist=collections.Counter()
+ for i,j,k in itertools.combinations(range(10),3):
+  h=compose(g[k,i],compose(g[j,k],g[i,j]));hist[ctype(h)]+=1
+  cur=parity(h);assert cur==(edge[i,j]+edge[i,k]+edge[j,k])%2
+  if cur:odd.add((i,j,k))
+ pc=collections.Counter(p for b in odd for p in b);qc=collections.Counter(tuple(sorted(e)) for b in odd for e in itertools.combinations(b,2))
+ design=len(odd)==60 and set(pc.values())=={18} and set(qc.values())=={4}
+ bianchi=all(sum(tuple(sorted(f)) in odd for f in itertools.combinations(t,3))%2==0 for t in itertools.combinations(range(10),4))
+ gauge=True
+ for bits in itertools.product(range(2),repeat=10):
+  sw={(i,j):(edge[i,j]+bits[i]+bits[j])%2 for i,j in itertools.combinations(range(10),2)}
+  rebuilt={(i,j,k) for i,j,k in itertools.combinations(range(10),3) if (sw[i,j]+sw[i,k]+sw[j,k])%2}
+  if rebuilt!=odd:gauge=False;break
+ iso=nx.algorithms.isomorphism.GraphMatcher(incidence(odd),CIG,node_match=lambda a,b:a['kind']==b['kind']).is_isomorphic()
+ R=nx.Graph();R.add_nodes_from(range(10));R.add_edges_from([e for e,v in edge.items() if v])
+ return {'hist':hist,'design':design,'bianchi':bianchi,'gauge':gauge,'iso':iso,'edges':R.number_of_edges(),'degrees':tuple(sorted(dict(R.degree()).values())),'petersen':nx.is_isomorphic(R,nx.petersen_graph())}
+def main():
+ assert len(POINTS)==len(LINES)==40;ss=spreads();assert len(ss)==36;rs=[analyze(s) for s in ss]
+ assert all(r['hist']==collections.Counter({(2,1,1):60,(2,2):60}) for r in rs)
+ assert all(r['design'] and r['bianchi'] and r['gauge'] and r['iso'] for r in rs);assert rs[0]['petersen']
+ aut=sum(1 for _ in nx.algorithms.isomorphism.GraphMatcher(CIG,CIG,node_match=lambda a,b:a['kind']==b['kind']).isomorphisms_iter());assert aut==720
+ assert all({tuple(sorted(a[i] for i in b)) for b in CANON}==CANON for a in ACTIONS)
+ rh=collections.Counter((r['edges'],r['degrees'],r['petersen']) for r in rs)
+ checks={'w33_40_points_40_lines':True,'all_36_spreads_enumerated':True,'every_spread_has_60_transposition_and_60_double_transposition_triangles':True,'odd_holonomies_form_2_10_3_4_design_on_every_spread':True,'tetrahedral_bianchi_identity_on_every_spread':True,'curvature_is_invariant_under_all_1024_vertex_sign_gauges':True,'all_spread_curvatures_are_the_same_s6_two_graph':True,'canonical_switching_representative_is_petersen':True,'two_graph_automorphism_group_order_720':True,'explicit_s6_degree10_action_preserves_curvature_blocks':True}
+ result={'schema':'w33.pass2967.oam_holonomy_s6_two_graph.v1','status':'COMPLETE_EXACT_FINITE_GAUGE_CLASSIFICATION','checks':checks,'check_count':10,'spreads':36,'triangle_holonomy':{'transpositions':60,'double_transpositions':60,'odd_curvature_blocks':60,'even_curvature_blocks':60},'odd_curvature_design':{'parameters':'2-(10,3,4)','point_replication':18,'pair_replication':4,'two_graph_axiom':'Every four-mode tetrahedron contains an even number of odd-curvature faces.'},'gauge_field':{'connection':'sign of each S4 inter-line transport permutation','gauge_group_seen_by_parity':'C2^10 / diagonal C2','curvature':'triangle coboundary of the edge-sign 1-cochain','bianchi':'delta^2=0 on every one of the 210 tetrahedra'},'classification':{'switching_class_contains':'Petersen graph','automorphism_group_order':720,'automorphism_group':'PΣL(2,9) ≅ S6','degree10_model':'S6 acting on the ten unordered 3+3 partitions of a six-set','s6_triple_orbits':[60,60]},'raw_slot_gauge_representative_histogram':[{'spread_count':n,'edge_count':k[0],'degree_multiset':list(k[1]),'is_petersen':k[2]} for k,n in sorted(rh.items())],'headline':'The 10x4 OAM spread router carries a spread-independent Z2 curvature: its 60 odd triangle holonomies are the exceptional 10-point S6 two-graph, with the Petersen graph as a switching representative and an exact tetrahedral Bianchi identity.','claim_boundary':'Exact for finite routing permutations; not a measured optical Berry phase or continuum gauge field.'}
+ OUT.write_text(json.dumps(result,indent=2,sort_keys=True)+'\n');print('PASS 10 / 10',result['headline'])
+if __name__=='__main__':main()

--- a/analysis/bt2968_curvature_route_code.py
+++ b/analysis/bt2968_curvature_route_code.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Pass 2968: exact [45,9,9]_2 curvature route code."""
+from __future__ import annotations
+import collections,itertools,json
+from pathlib import Path
+import numpy as np
+ROOT=Path(__file__).resolve().parents[1];OUT=ROOT/'data/PART_BT2968_CURVATURE_ROUTE_CODE_results.json'
+V=tuple(range(10));E=list(itertools.combinations(V,2));T=list(itertools.combinations(V,3));Q=list(itertools.combinations(V,4));EI={e:i for i,e in enumerate(E)};TI={t:i for i,t in enumerate(T)}
+def rref(m):
+ a=np.asarray(m,dtype=np.uint8).copy()%2;rows,cols=a.shape;p=[];r=0
+ for c in range(cols):
+  q=next((i for i in range(r,rows) if a[i,c]),None)
+  if q is None:continue
+  a[[r,q]]=a[[q,r]]
+  for i in range(rows):
+   if i!=r and a[i,c]:a[i]^=a[r]
+  p.append(c);r+=1
+  if r==rows:break
+ return a,p
+def rank(m):return len(rref(m)[1])
+H=np.zeros((120,45),dtype=np.uint8)
+for i,t in enumerate(T):
+ for e in itertools.combinations(t,2):H[i,EI[tuple(sorted(e))]]=1
+B=np.zeros((210,120),dtype=np.uint8)
+for i,q in enumerate(Q):
+ for f in itertools.combinations(q,3):B[i,TI[tuple(sorted(f))]]=1
+def cut(s):
+ s=set(s);return np.array([int((u in s)^(v in s)) for u,v in E],dtype=np.uint8)
+def key(v):return bytes(np.packbits(v))
+def main():
+ rh=rank(H);assert rh==36 and np.count_nonzero((B@H)%2)==0
+ cuts={}
+ for mask in range(1<<10):
+  v=cut([i for i in V if mask>>i&1]);cuts[key(v)]=v
+ assert len(cuts)==512 and all(np.count_nonzero((H@v)%2)==0 for v in cuts.values()) and 45-rh==9
+ weights=collections.Counter(int(np.count_nonzero(v)) for v in cuts.values());assert dict(sorted(weights.items()))=={0:1,9:10,16:45,21:120,24:210,25:126};d=9
+ _,piv=rref(H.T);H36=H[piv];assert len(piv)==rank(H36)==36
+ cw=[int(np.count_nonzero(H[:,j])) for j in range(45)];assert set(cw)=={8} and len({key(H[:,j]) for j in range(45)})==45
+ pw=collections.Counter(int(np.count_nonzero(H[:,a]^H[:,b])) for a,b in itertools.combinations(range(45),2));assert pw==collections.Counter({14:360,16:630})
+ checks={'triangle_edge_matrix_shape_120x45':H.shape==(120,45),'triangle_coboundary_rank_36':rh==36,'kernel_dimension_9':45-rh==9,'kernel_equals_512_vertex_switching_cuts':len(cuts)==512,'cut_code_parameters_45_9_9':d==9,'tetrahedral_bianchi_BH_zero':np.count_nonzero((B@H)%2)==0,'all_single_edge_faults_have_unique_weight8_syndromes':set(cw)=={8} and len({key(H[:,j]) for j in range(45)})==45,'all_weight_at_most_8_nongauge_faults_detected':d==9,'all_weight_at_most_4_faults_correctable_modulo_gauge':d>=9,'36_independent_triangle_checks_suffice':rank(H36)==36};assert all(checks.values())
+ result={'schema':'w33.pass2968.curvature_route_code.v1','status':'COMPLETE_EXACT_BINARY_GAUGE_CODE','checks':{k:bool(v) for k,v in checks.items()},'check_count':10,'raw_registers':{'spread_modes':10,'transport_edges':45,'triangle_curvature_checks':120,'independent_syndrome_bits':36,'tetrahedral_bianchi_relations':210},'code':{'kernel':'vertex-switching cut space of K10','parameters':'[45,9,9]_2','weight_enumerator':{str(k):v for k,v in sorted(weights.items())},'minimum_undetectable_weight':9,'correctable_fault_weight_modulo_gauge':4,'detectable_nongauge_fault_weight':8},'syndromes':{'single_edge_syndrome_weight':8,'single_edge_syndromes_unique':True,'two_edge_syndrome_weight_histogram':{str(k):v for k,v in sorted(pw.items())},'independent_triangle_indices':[int(i) for i in piv]},'decoder_statement':'Subtract the Pass-2967 baseline and decode H e to a minimum-weight edge-fault coset.','headline':'The spread router parity curvature is an exact [45,9,9]_2 gauge code with 36 independent checks and correction through four odd faults modulo gauge.','claim_boundary':'Parity only: even S4 errors, loss, drift and detector faults require the pilot/channel layers.'}
+ OUT.write_text(json.dumps(result,indent=2,sort_keys=True)+'\n');print('PASS 10 / 10',result['headline'])
+if __name__=='__main__':main()

--- a/analysis/bt2969_chirality_receiver_correction.py
+++ b/analysis/bt2969_chirality_receiver_correction.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Pass 2969: correct the chirality receiver optimum and n-copy formulas."""
+from __future__ import annotations
+import itertools,json,math
+from pathlib import Path
+import numpy as np
+ROOT=Path(__file__).resolve().parents[1];OUT=ROOT/'data/PART_BT2969_CHIRALITY_RECEIVER_CORRECTION_results.json';W=np.exp(2j*np.pi/3);I=np.eye(2);Y=np.array([[0,-1j],[1j,0]]);P={'IY':np.kron(I,Y),'YI':np.kron(Y,I)}
+PAIRS=[[1,2,'IY',-1],[3,6,'IY',1],[8,4,'YI',-1],[10,11,'IY',1],[12,15,'IY',-1],[17,13,'YI',1],[19,20,'YI',-1],[21,24,'IY',-1],[26,22,'IY',1],[28,29,'YI',1],[30,33,'IY',1],[35,31,'IY',-1]]
+def rays():
+ r=[1,W,W**2];raw=[]
+ for a,b in itertools.product(range(3),repeat=2):raw.append([0,1,-r[a],r[b]])
+ for a,b in itertools.product(range(3),repeat=2):raw.append([1,0,-r[a],-r[b]])
+ for a,b in itertools.product(range(3),repeat=2):raw.append([1,-r[a],0,r[b]])
+ for a,b in itertools.product(range(3),repeat=2):raw.append([1,r[a],r[b],0])
+ return [np.asarray(v,dtype=complex)/np.sqrt(3) for v in raw]
+def majority(p,n):
+ return sum(math.comb(n,k)*p**k*(1-p)**(n-k)*(1 if k>n/2 else .5 if 2*k==n else 0) for k in range(n+1))
+def main():
+ rs=rays();ov=[];ex=[]
+ for l,r,probe,sign in PAIRS:
+  ov.append(float(abs(np.vdot(rs[l],rs[r]))**2));a=float(np.vdot(rs[l],P[probe]@rs[l]).real);b=float(np.vdot(rs[r],P[probe]@rs[r]).real);assert abs(a+b)<1e-9 and (1 if a>0 else -1)==sign;ex.append(abs(a))
+ assert all(abs(x-1/3)<1e-9 for x in ov) and all(abs(x-1/math.sqrt(3))<1e-9 for x in ex)
+ pauli=(1+1/math.sqrt(3))/2;hel=(1+math.sqrt(2/3))/2;assert hel>pauli
+ table=[]
+ for n in range(1,13):
+  err=(1-math.sqrt(1-3**(-n)))/2;table.append({'copies':n,'collective_or_adaptive_helstrom_success':1-err,'collective_or_adaptive_helstrom_error':err,'fixed_repeated_pauli_majority_success':majority(pauli,n),'unambiguous_success':1-3**(-n/2)})
+ assert next(x['copies'] for x in table if x['collective_or_adaptive_helstrom_error']<1e-3)==6 and next(x['copies'] for x in table if x['collective_or_adaptive_helstrom_error']<1e-6)==12
+ checks={'twelve_conjugate_pairs_reconstructed':len(PAIRS)==12,'all_squared_overlaps_equal_one_third':True,'selected_pauli_expectation_magnitude_one_over_sqrt3':True,'pauli_receiver_success_is_0p788675':abs(pauli-.7886751345948129)<1e-12,'unrestricted_helstrom_success_is_0p908248':abs(hel-.908248290463863)<1e-12,'prior_helstrom_label_is_corrected':hel-pauli>.11,'ncopy_overlap_squared_is_three_to_minus_n':True,'adaptive_individual_receiver_matches_collective_bound_by_published_theorem':True,'six_copies_cross_one_per_thousand_error':True,'twelve_copies_cross_one_per_million_error':True};assert all(checks.values())
+ result={'schema':'w33.pass2969.chirality_receiver_correction.v1','status':'COMPLETE_EXACT_CORRECTION_AND_STANDARD_RECEIVER_APPLICATION','checks':checks,'check_count':10,'pair_squared_overlap':'1/3','minimum_project_local_pauli_cover':['YI','IY'],'selected_local_pauli_success':'(1+1/sqrt(3))/2','selected_local_pauli_success_decimal':pauli,'unrestricted_single_copy_helstrom_success':'(1+sqrt(2/3))/2','unrestricted_single_copy_helstrom_success_decimal':hel,'mislabelled_gap':hel-pauli,'ncopy_helstrom_success':'(1+sqrt(1-3^(-n)))/2','ncopy_helstrom_error':'(1-sqrt(1-3^(-n)))/2','quantum_chernoff_exponent':'log(3)','adaptive_receiver_prior_art':'Acin et al., PRA 71, 032338 (2005): adaptive individual measurements attain the collective bound for binary pure states.','table':table,'headline':'The two-Pauli readout is minimum-alphabet but not Helstrom-optimal: unrestricted one-copy success is 90.825%, with the exact n-copy bound attainable adaptively.','claim_boundary':'Known pair/frame, equal priors, perfect copies and ideal measurements; adaptive attainability is prior art.'}
+ OUT.write_text(json.dumps(result,indent=2,sort_keys=True)+'\n');print('PASS 10 / 10',result['headline'])
+if __name__=='__main__':main()

--- a/analysis/bt2970_layered_route_fault_architecture.py
+++ b/analysis/bt2970_layered_route_fault_architecture.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Pass 2970: weld full-S4 pilots to the parity-curvature decoder."""
+from __future__ import annotations
+import itertools,json
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1];OUT=ROOT/'data/PART_BT2970_LAYERED_ROUTE_FAULT_ARCHITECTURE_results.json'
+def parity(p):return sum(p[i]>p[j] for i in range(4) for j in range(i+1,4))%2
+def agree(p,q,s):return all(p[x]==q[x] for x in s)
+def main():
+ ps=list(itertools.permutations(range(4)));non=[p for p in ps if p!=tuple(range(4))];odd=[p for p in non if parity(p)];even=[p for p in non if not parity(p)];assert (len(non),len(odd),len(even))==(23,12,11)
+ one=[any(p[s]!=s for s in(0,)) for p in non];two=[any(p[s]!=s for s in(0,1)) for p in non];three=[any(p[s]!=s for s in(0,1,2)) for p in non];assert (sum(one),sum(two),sum(three))==(18,22,23)
+ assert all(sum(agree(p,q,(0,1,2)) for q in ps)==1 for p in ps) and all(sum(agree(p,q,(0,1)) for q in ps)==2 for p in ps)
+ pilot=json.loads((ROOT/'data/PART_BT2965_CURVATURE_ROUTE_CODE_results.json').read_text());cur=json.loads((ROOT/'data/PART_BT2968_CURVATURE_ROUTE_CODE_results.json').read_text());assert pilot['minimum_universal_pilot_slots']==3 and pilot['three_pilot_detected']==pilot['three_pilot_fault_cases']==8280 and cur['code']['parameters']=='[45,9,9]_2'
+ checks={'s4_has_23_nonidentity_faults':True,'nonidentity_split_12_odd_11_even':True,'one_pilot_detects_18_of_23':True,'two_pilots_detect_22_of_23':True,'three_pilots_detect_all_23':True,'three_point_images_uniquely_determine_s4_permutation':True,'two_point_images_leave_exactly_two_permutations':True,'master_pilot_certificate_covers_all_8280_single_fault_cases':True,'parity_layer_is_45_9_9_code':True,'parity_layer_corrects_four_odd_faults_modulo_gauge':cur['code']['correctable_fault_weight_modulo_gauge']==4};assert all(checks.values())
+ result={'schema':'w33.pass2970.layered_route_fault_architecture.v1','status':'COMPLETE_EXACT_LAYERED_FAULT_MODEL','checks':checks,'check_count':10,'layer_A':{'name':'three-slot full-S4 pilot audit','coverage':'all 23 nonidentity S4 faults on one route edge','cases':8280,'role':'detect and identify even or odd single-edge route permutations'},'layer_B':{'name':'triangle-parity curvature decoder','code':'[45,9,9]_2','independent_bits':36,'role':'correct up to four odd edge faults modulo gauge and detect nongauge odd faults through weight eight'},'combined_single_fault_theorem':'Three pilots identify one arbitrary nonidentity S4 edge fault. Odd faults additionally enter the multi-edge curvature decoder; even faults require pilots because sign curvature is silent.','headline':'Three pilots and the [45,9,9]_2 curvature code form complementary route defenses.','claim_boundary':'No simultaneous arbitrary-S4 pilot theorem; multi-edge guarantees apply only to odd parity.'}
+ OUT.write_text(json.dumps(result,indent=2,sort_keys=True)+'\n');print('PASS 10 / 10',result['headline'])
+if __name__=='__main__':main()

--- a/data/w33_pass_namespace_registry_v2.d/2967-2973.json
+++ b/data/w33_pass_namespace_registry_v2.d/2967-2973.json
@@ -1,0 +1,17 @@
+{
+  "schema": "w33.pass_namespace_reservation.v2",
+  "range": "2967-2973",
+  "owner": "agent/pass2967-2973-s6-two-graph-route-code-r2",
+  "status": "source_complete_pending_observed_ci_and_pdf_evidence",
+  "reserved_after": "completed Passes 2960-2966 physical compiler packet",
+  "passes": {
+    "2967": "refine all-spread D4 holonomy to the exceptional ten-point S6 two-graph and exact Bianchi design",
+    "2968": "derive the parity-curvature [45,9,9]_2 gauge code and compressed 36-bit route syndrome",
+    "2969": "correct the chirality receiver optimality label and close ideal n-copy discrimination formulas",
+    "2970": "weld the three-pilot full-S4 detector to the multi-edge odd-parity decoder",
+    "2971": "promote corrected theorems into w33_paper.tex and photonic_holonet.tex",
+    "2972": "integrate holonet_machine_blueprint.tex and docs/index.html fail-closed",
+    "2973": "audit claims against Chat7, primary literature and the completed 2960-2966 packet"
+  },
+  "claim_boundary": "Exact finite routing and ideal pure-state results only; measured optical performance and continuum gauge claims remain outside scope."
+}

--- a/photonic_holonet.tex
+++ b/photonic_holonet.tex
@@ -1,4 +1,4 @@
-% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2966 plus frame-Hoffman wrapper:
+% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2971 plus frame-Hoffman wrapper:
 % preserve the complete historical manuscript body verbatim while injecting the
 % certified theorem inserts immediately after the contents.
 \AtBeginDocument{%
@@ -62,6 +62,7 @@
     \input{analysis/BT2937_BT2945_global_code_landauer_oam_insert}%
     \input{analysis/BT2946_BT2952_seven_front_closure_insert}%
     \input{analysis/BT2960_BT2966_physical_compiler_insert}%
+    \input{analysis/BT2967_BT2970_s6_curvature_chirality_route_insert}%
   }%
 }
 \input{photonic_holonet_body.tex}

--- a/tests/test_bt2967_bt2970_s6_curvature_chirality_route.py
+++ b/tests/test_bt2967_bt2970_s6_curvature_chirality_route.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+import json,subprocess,sys
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+def run(path):
+ p=subprocess.run([sys.executable,str(ROOT/path)],cwd=ROOT,check=True,capture_output=True,text=True,timeout=240);assert 'PASS 10 / 10' in p.stdout
+def test_exact_continuation():
+ for path in ['analysis/bt2967_oam_holonomy_s6_two_graph.py','analysis/bt2968_curvature_route_code.py','analysis/bt2969_chirality_receiver_correction.py','analysis/bt2970_layered_route_fault_architecture.py']:run(path)
+ assert json.loads((ROOT/'data/PART_BT2967_OAM_HOLONOMY_S6_TWO_GRAPH_results.json').read_text())['classification']['automorphism_group_order']==720
+ assert json.loads((ROOT/'data/PART_BT2968_CURVATURE_ROUTE_CODE_results.json').read_text())['code']['parameters']=='[45,9,9]_2'
+ assert json.loads((ROOT/'data/PART_BT2969_CHIRALITY_RECEIVER_CORRECTION_results.json').read_text())['unrestricted_single_copy_helstrom_success_decimal']==0.908248290463863
+ assert json.loads((ROOT/'data/PART_BT2970_LAYERED_ROUTE_FAULT_ARCHITECTURE_results.json').read_text())['layer_A']['cases']==8280
+def test_integrator(tmp_path):
+ (tmp_path/'docs').mkdir();(tmp_path/'holonet_machine_blueprint.tex').write_text('\\begin{document}\n\\end{document}\n');(tmp_path/'docs/index.html').write_text('<html><body></body></html>')
+ tool=ROOT/'tools/integrate_bt2967_bt2970_blueprint_index.py';subprocess.run([sys.executable,str(tool),'--root',str(tmp_path)],check=True);subprocess.run([sys.executable,str(tool),'--root',str(tmp_path),'--check'],check=True)

--- a/tools/integrate_bt2967_bt2970_blueprint_index.py
+++ b/tools/integrate_bt2967_bt2970_blueprint_index.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Idempotently integrate Passes 2967-2970 into blueprint and live atlas."""
+from __future__ import annotations
+import argparse,json
+from pathlib import Path
+BI=r"\input{analysis/BT2967_BT2970_s6_curvature_chirality_route_blueprint_insert}";MARK='<!-- BT2967-BT2970-S6-CURVATURE-ROUTE-V1 -->'
+CARD='''<!-- BT2967-BT2970-S6-CURVATURE-ROUTE-V1 -->
+<section id="bt2967-bt2970-s6-curvature-route" style="max-width:1100px;margin:3rem auto;padding:1.5rem;border:1px solid #6f7f91;border-radius:12px;">
+<h2>Latest exact result: S6 spread curvature and route decoding</h2>
+<p><strong>Pass 2967.</strong> All 36 spreads give the same parity two-graph: 60 odd triangles, a Petersen switching representative, automorphism group PΣL(2,9) ≅ S<sub>6</sub>, and exact tetrahedral Bianchi identity.</p>
+<p><strong>Pass 2968.</strong> The parity syndrome is a binary [45,9,9] gauge code with 36 independent checks, detection through weight 8 and correction through weight 4 modulo slot gauge.</p>
+<p><strong>Pass 2969 correction.</strong> The 0.788675 two-Pauli receiver is not Helstrom-optimal; squared overlap 1/3 gives ideal unrestricted one-copy success 0.908248.</p>
+<p><strong>Pass 2970.</strong> Three pilots identify one arbitrary S4 edge fault; curvature adds multi-edge correction for odd faults.</p>
+<p><strong>Boundary.</strong> Exact finite routing and ideal receiver statements only—not measured loss, crosstalk, Berry phase, or continuum gauge claims.</p>
+</section>'''
+def ins(text,anchor,payload,marker):
+ if marker in text:return text,False
+ if anchor not in text:raise RuntimeError(f'missing anchor {anchor}')
+ return text.replace(anchor,payload+'\n'+anchor,1),True
+def main():
+ p=argparse.ArgumentParser();p.add_argument('--root',type=Path,default=Path(__file__).resolve().parents[1]);p.add_argument('--check',action='store_true');a=p.parse_args();root=a.root.resolve();bp=root/'holonet_machine_blueprint.tex';idx=root/'docs/index.html';b=bp.read_text();i=idx.read_text();nb,bc=ins(b,r'\end{document}',BI,BI);ni,ic=ins(i,'</body>',CARD,MARK)
+ if a.check and (bc or ic):raise SystemExit('not integrated')
+ if not a.check:
+  if bc:bp.write_text(nb,newline='\n')
+  if ic:idx.write_text(ni,newline='\n')
+ print(json.dumps({'blueprint_changed':bc,'index_changed':ic,'blueprint_integrated':BI in nb,'index_integrated':MARK in ni},sort_keys=True))
+if __name__=='__main__':main()

--- a/w33_paper.tex
+++ b/w33_paper.tex
@@ -1,4 +1,4 @@
-% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2966 plus frame-Hoffman wrapper:
+% Pass 1420/1425/1408/1509/1510/1511-1515/1531-1541/1601-1616/1701-1705/1801-1810/1821-2971 plus frame-Hoffman wrapper:
 % preserve the complete historical manuscript body verbatim while injecting the
 % certified theorem inserts immediately after the contents.
 \AtBeginDocument{%
@@ -61,6 +61,7 @@
     \input{analysis/BT2937_BT2945_global_code_landauer_oam_insert}%
     \input{analysis/BT2946_BT2952_seven_front_closure_insert}%
     \input{analysis/BT2960_BT2966_physical_compiler_insert}%
+    \input{analysis/BT2967_BT2970_s6_curvature_chirality_route_insert}%
   }%
 }
 \input{w33_paper_body.tex}


### PR DESCRIPTION
Clean rebased continuation of the completed Passes 2960–2966 packet.

- **2967:** all 36 spread-router parity curvatures are the exceptional ten-point two-graph; Petersen switching representative; automorphism group PΣL(2,9) ≅ S6 of order 720; exact tetrahedral Bianchi identity.
- **2968:** triangle parity gives the exact binary [45,9,9] cut code, 36 independent checks, detection of nongauge odd faults through weight 8 and correction through weight 4 modulo gauge.
- **2969:** corrects the Pass-2954 label: 0.788675 is the selected {YI,IY} Pauli receiver, not the Helstrom bound. Squared overlap 1/3 gives ideal one-copy Helstrom success 0.908248 and n-copy success (1+sqrt(1-3^-n))/2. Adaptive attainability is attributed to Acín et al.
- **2970:** three pilots identify one arbitrary S4 edge error; curvature adds multi-edge correction for odd faults.
- **2971–2973:** promote to both core manuscripts and provide fail-closed blueprint/index integration and focused CI.

Evidence boundary: exact finite routing and ideal pure-state results only. No measured optical loss/crosstalk/Berry-phase or simultaneous arbitrary-S4 multi-edge claim. Do not merge before the focused gate is observed green.