### PR TITLE
Passes 3124–3132: publish canonical theorem insert

### DIFF
--- a/analysis/BT3124_BT3132_deep_five_front_closure_insert.tex
+++ b/analysis/BT3124_BT3132_deep_five_front_closure_insert.tex
@@ -1,0 +1,111 @@
+% Passes 3124--3132: deep five-front closure
+\section{The two-layer information machine: routing, computation, prediction, and time}
+\label{sec:bt3124-3132}
+
+The newest exact results force a sharper architecture than a single universal controller graph.
+The machine separates six typed layers: collision-free translation routing; a selectable
+universal compute ISA; nonabelian $D_4$ route localization; high-distance self-dual phase
+synchronization; symmetry-quotiented prediction when invariance is certified; and irreversible
+readout only at the posterior decision boundary.
+
+\subsection{The fixed $D_4$ frontier is a distance-five parity-check problem}
+For the central involution $r^2$, the $120$ triangles of $K_{10}$ are binary parity-check
+rows on its $45$ edges.  Separating all supports of weight at most two is equivalent to
+hitting every nonzero edge word of weight at most four.  The exact $27$-row feasibility
+model has
+\[
+ {45\choose1}+{45\choose2}+{45\choose3}+{45\choose4}=164220
+\]
+constraints.  A new $66$-round cutting-plane run accumulated $1860$ exact cuts and reached
+eight residual collisions, but did not produce a witness or an infeasibility proof.  Hence
+\[
+ 23\le m_{\rm fixed}^{(2)}\le 28
+\]
+remains the theorem.
+
+\subsection{The rank-three M36 question is now exhaustively parameterized}
+A rank-three commuting Pauli subgroup has eight signed eigenspaces of dimension eight.  The
+duplicate-free RREF census contains $220$ pivot patterns and exactly
+\[
+ 50{,}868{,}675
+\]
+totally isotropic three-subspaces of $\mathbb F_2^{12}$.  A local $4096$-assignment pilot
+found no zero-leak code; the best pilot syndrome retained clean probability $1/216$ with
+maximum single-error probability $5/72$.  This is an obstruction, not a no-go theorem; the
+full sharded census is the decision procedure.
+
+\subsection{Complete character decomposition of the $6480$ flags}
+The flag stabilizer is $H\cong V_4$ and fuses as
+\[
+ H=1A+2(2A)+1(2B),\qquad |2A|=45,\quad |2B|=270.
+\]
+Thus
+\[
+ m_\chi={\chi(1)+2\chi(2A)+\chi(2B)\over4}.
+\]
+For irreducible degrees
+\[
+1,5,5,6,10,10,15,15,20,24,30,30,30,40,40,45,45,60,64,81,
+\]
+the multiplicities in $\mathbb C[X]$ are
+\[
+1,0,0,1,3,3,3,8,8,10,3,11,11,6,6,9,9,14,16,24.
+\]
+They satisfy
+\[
+ \sum_\chi \chi(1)m_\chi=6480,
+ \qquad
+ \sum_\chi m_\chi^2=1770.
+\]
+Consequently $6480=27(81+120+24+15)$ is dimensional arithmetic, not a decomposition into
+$27$ repeated Hodge copies: the $81$ occurs $24$ times, the $24$ occurs $10$ times, the two
+$15$'s occur $3$ and $8$ times, and no irreducible of degree $120$ exists.
+
+\subsection{Robust posterior control}
+The explicit hidden state
+\[
+({\rm route},{\rm calibration},{\rm chirality},{\rm drift},{\rm regime})
+\]
+has $32$ states.  A horizon-five Bayes controller treats the nominal/adverse observation
+regime as hidden.  Under the frozen synthetic model, its adverse-case objective is
+$0.3065079301$, compared with $0.3199090606$ for the nominal-only policy, a $4.189\%$
+reduction.  The first action is route diagnosis.  These are exact Bellman values for the
+stated model, not measured receiver performance.
+
+\subsection{Self-dual timing fabric}
+The word $001032122313$ and the $89/233$ Christoffel calendar form a $2796$-tick fabric with
+\[
+ R(t)=1952-t\pmod{2796}.
+\]
+All ticks satisfy phase and calibration-event covariance.  There are $1068$ events, exactly
+$89$ in every $D_{12}$ phase, with global gaps $2$ or $3$ and per-phase gaps $24,36,60$.
+The synthesizable controller enforces a typed $A_4$ shell/$D_4$ core boundary: unauthorized
+core commands cannot mutate route state.
+
+\subsection{The universal ISA has a two-point Pareto frontier}
+Of the $210$ four-opcode subsets considered, $80$ are connected on the $81$ frames and $24$
+generate the full linear group $Sp(4,3)$ of order $51840$.  The minimum collision count
+among fully universal sets is $36$, achieved for example by
+\[
+\{CX_{fp},F_f,F_p,Z_2\},
+\]
+with normalized symmetrized second eigenvalue $0.8942150876$.  The current ISA has $45$
+collisions but faster mixing, $0.8290244059$.  Thus collision count and mixing do not share
+a single optimum; the compiler must select the compute ISA by task while preserving the
+separate collision-free translation-routing graph.
+
+\subsection{Two outside-box closures}
+The $V_4$ stabilizer partitions the $6480$ flags into $1770$ orbits:
+$24$ of size one, $264$ of size two, and $1482$ of size four.  For $H$-invariant transition,
+observation, cost, and loss kernels, Bellman recursion factors exactly through these orbits.
+The quotient saves two fixed register bits and $1.9111111111$ average uniform bits.
+
+Finally, the product of $48826$ route hypotheses with $12$ phase offsets gives $585912$
+noiseless route-time states.  The phase code has minimum distance $21$ over $28$ symbols,
+whereas the route syndrome code has minimum distance one.  The product therefore supplies
+strong synchronization correction but only exact route localization; route-syndrome errors
+require authentication or remeasurement.
+
+\paragraph{Claim boundary.}
+No $27$-row impossibility, complete rank-three M36 census, laboratory optical result,
+physical Landauer heat, autonomous clock, or observed RTL/PDF evidence is inferred here.


### PR DESCRIPTION
Publish the readable theorem insert for the source-complete Passes 3124–3132 packet. The insert records the exact/modelled boundaries for the 27-row frontier, rank-three M36 census, complete 6,480-character decomposition, robust POMDP, self-dual timing fabric, universal-ISA Pareto frontier, 1,770-state quotient, and route-time product falsifier. It makes no observed RTL/PDF or exhaustive-search claim.