### PR TITLE
Passes 3124–3132: wire theorem into W33 and Photonic papers

### DIFF
--- a/photonic_holonet.tex
+++ b/photonic_holonet.tex
@@ -66,6 +66,7 @@
     \input{analysis/BT2967_BT2973_optimal_information_system_insert}%
     \input{analysis/BT2996_BT3002_deep_optimal_information_insert}%
     \input{analysis/BT3025_BT3031_predictive_photonic_overhaul_insert}%
+    \input{analysis/BT3124_BT3132_deep_five_front_closure_insert}%
   }%
 }
 \input{photonic_holonet_body.tex}

--- a/w33_paper.tex
+++ b/w33_paper.tex
@@ -65,6 +65,7 @@
     \input{analysis/BT2967_BT2973_optimal_information_system_insert}%
     \input{analysis/BT2996_BT3002_deep_optimal_information_insert}%
     \input{analysis/BT3025_BT3031_predictive_photonic_overhaul_insert}%
+    \input{analysis/BT3124_BT3132_deep_five_front_closure_insert}%
   }%
 }
 \input{w33_paper_body.tex}


### PR DESCRIPTION
Add the merged Passes 3124–3132 theorem insert to the canonical `w33_paper.tex` and `photonic_holonet.tex` ledgers. This is source wiring only; PDF success remains behind draft evidence PR #238.