### PR TITLE
Passes 3262–3265: exact-cover signature S3 Fourier and five-bit affine lift

### DIFF
--- a/.github/workflows/w33_bt3262_3265_signature_s3_affine_lift.yml
+++ b/.github/workflows/w33_bt3262_3265_signature_s3_affine_lift.yml
@@ -1,0 +1,35 @@
+name: Passes 3262-3265 Signature S3 Affine Lift
+on:
+  pull_request:
+    paths:
+      - 'analysis/bt3262_3265_signature_s3_affine_lift.py'
+      - 'analysis/BT3262_BT3265_signature_s3_affine_lift*'
+      - 'data/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json'
+      - 'tests/test_bt3262_3265_signature_s3_affine_lift.py'
+      - '.github/workflows/w33_bt3262_3265_signature_s3_affine_lift.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'analysis/bt3262_3265_signature_s3_affine_lift.py'
+      - 'analysis/BT3262_BT3265_signature_s3_affine_lift*'
+      - 'data/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json'
+      - 'tests/test_bt3262_3265_signature_s3_affine_lift.py'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  exact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Regenerate exact certificate
+        run: |
+          python analysis/bt3262_3265_signature_s3_affine_lift.py \
+            --json /tmp/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json
+          cmp /tmp/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json \
+            data/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json
+      - name: Frozen regression
+        run: python -m pytest -q tests/test_bt3262_3265_signature_s3_affine_lift.py

--- a/analysis/BT3262_BT3265_signature_s3_affine_lift.md
+++ b/analysis/BT3262_BT3265_signature_s3_affine_lift.md
@@ -1,0 +1,273 @@
+# Passes 3262–3265 — Exact-cover signature \(S_3\) Fourier and five-bit affine-lift theorem
+
+## Status
+
+**Exact finite theorem.** The verifier is self-contained, uses integer/binary arithmetic only, and passes all six frozen checks.
+
+## Input from the complete cover census
+
+The complete nonlinear exact-cover signature classification supplies 45 anchor octets. Relative to the unique anchor, the three independent four-cells of the induced \(K_{4,4,4}\) carry one of four unordered patterns:
+
+\[
+(2,2,2),\qquad(0,3,3),\qquad(1,2,3),\qquad(0,2,4).
+\]
+
+Permuting the three cells gives orbit sizes
+
+\[
+1,\qquad3,\qquad6,\qquad6.
+\]
+
+Thus the local signature alphabet is the sixteen-state \(S_3\)-set
+
+\[
+\Omega\cong 1\;\sqcup\;S_3/C_2\;\sqcup\;S_3\;\sqcup\;S_3,
+\qquad |\Omega|=16,
+\]
+
+and the global census count is
+
+\[
+45\cdot16=720.
+\]
+
+This imports only the already-frozen cell patterns and anchor count. Everything below is recomputed independently.
+
+## Pass 3262 — exact \(S_3\) Fourier decomposition
+
+The permutation character of \(\Omega\), on the identity, transposition and three-cycle classes, is
+
+\[
+\boxed{\chi_\Omega=(16,2,1).}
+\]
+
+Indeed, the identity fixes all sixteen states, a transposition fixes the constant state and one state in the three-point orbit, and a three-cycle fixes only the constant state.
+
+Taking inner products with the rational irreducible characters of \(S_3\) gives
+
+\[
+\boxed{
+\mathbb Q[\Omega]
+\cong
+4\,\mathbf 1
+\oplus
+2\,\mathrm{sgn}
+\oplus
+5\,V_{\mathrm{std}}.
+}
+\]
+
+The local signature algebra therefore contains four invariant scalar channels, two sign channels and five standard Fourier doublets. This refines the newest port result that the sign bit alone is only the Abelian shadow of the full non-Abelian \(S_3\) connection.
+
+## Pass 3263 — the rank-45 coherent algebra
+
+Burnside/Schur gives
+
+\[
+\dim_{\mathbb Q}\operatorname{End}_{S_3}(\mathbb Q[\Omega])
+=4^2+2^2+5^2
+=\boxed{45}.
+\]
+
+The verifier also constructs the orbitals directly. The diagonal action of \(S_3\) on \(\Omega\times\Omega\) has exactly
+
+\[
+\boxed{45}
+\]
+
+orbits, with size histogram
+
+\[
+\boxed{1^1\,3^3\,6^{41}}.
+\]
+
+Hence the exact rank-degree identity is
+
+\[
+\boxed{
+720
+=45\cdot16
+=\dim\operatorname{End}_{S_3}(\mathbb Q[\Omega])\,|\Omega|.
+}
+\]
+
+The corresponding rational commutant has Wedderburn form
+
+\[
+\boxed{
+M_4(\mathbb Q)\oplus M_2(\mathbb Q)\oplus M_5(\mathbb Q).
+}
+\]
+
+**Boundary.** The equality between the 45 anchor octets and the 45 local orbitals does not by itself produce a canonical bijection. It is an exact equality of two independently constructed ranks, not an asserted object-level identification.
+
+## Pass 3264 — four-bit affine no-go
+
+Set-theoretically, sixteen states require only four bits. The natural next question is stronger:
+
+> Can the exact cell-permutation \(S_3\)-action be implemented by affine transformations of \(\mathbb F_2^4\)?
+
+The answer is no.
+
+The local signature action has a unique fixed state, \((2,2,2)\). Any affine realization with a fixed point is translation-conjugate to a linear realization. The verifier therefore enumerates all
+
+\[
+|GL(4,2)|=20160
+\]
+
+invertible binary matrices and all
+
+\[
+\boxed{2800}
+\]
+
+embedded \(S_3\) subgroups. Their orbit profiles on \(\mathbb F_2^4\) are exactly
+
+\[
+(1,1,2,3,3,6)^{1680},
+\]
+
+\[
+(1,1,1,1,3,3,3,3)^{560},
+\]
+
+and
+
+\[
+(1,3,3,3,6)^{560}.
+\]
+
+The required profile
+
+\[
+\boxed{(1,3,6,6)}
+\]
+
+never occurs. Therefore:
+
+\[
+\boxed{
+\text{No four-bit affine }\mathbb F_2\text{ register realizes the exact signature }S_3\text{-action.}
+}
+\]
+
+A four-bit controller is still possible with nonlinear lookup/permutation logic. The no-go concerns affine binary gates only.
+
+## Pass 3265 — explicit minimal five-bit lift
+
+The obstruction is sharp. Take
+
+\[
+\mathbb F_2^5
+=\mathbb F_2^3_{\mathrm{perm}}
+\oplus
+\mathbb F_2^2_{\mathrm{std}},
+\]
+
+where \(S_3\) permutes the first three coordinates and acts as
+
+\[
+GL(2,2)\cong S_3
+\]
+
+on the final two coordinates. For generators \(r=(012)\) and \(s=(12)\), one exact row-matrix realization is
+
+\[
+R=
+\begin{pmatrix}
+0&0&1&0&0\\
+1&0&0&0&0\\
+0&1&0&0&0\\
+0&0&0&0&1\\
+0&0&0&1&1
+\end{pmatrix},
+\qquad
+S=
+\begin{pmatrix}
+1&0&0&0&0\\
+0&0&1&0&0\\
+0&1&0&0&0\\
+0&0&0&1&1\\
+0&0&0&0&1
+\end{pmatrix}.
+\]
+
+They satisfy
+
+\[
+R^3=S^2=I,
+\qquad
+SRS=R^{-1}.
+\]
+
+Let \(u_0=01,u_1=10,u_2=11\) be the three nonzero vectors of \(\mathbb F_2^2\), and let \(e_i\) be the coordinate vectors of \(\mathbb F_2^3\). An explicit equivariant encoding is:
+
+\[
+(2,2,2)\longmapsto(000,00),
+\]
+
+\[
+\operatorname{pos}_x(0)=i,
+\quad x\in S_3(0,3,3)
+\quad\Longrightarrow\quad
+x\longmapsto(e_i,00),
+\]
+
+\[
+\operatorname{pos}_x(1)=i,
+\quad\operatorname{pos}_x(2)=j,
+\quad x\in S_3(1,2,3)
+\quad\Longrightarrow\quad
+x\longmapsto(e_j,u_i),
+\]
+
+and
+
+\[
+\operatorname{pos}_x(0)=i,
+\quad\operatorname{pos}_x(4)=k,
+\quad x\in S_3(0,2,4)
+\quad\Longrightarrow\quad
+x\longmapsto(111+e_k,u_i).
+\]
+
+The selected sixteen vectors have orbit profile \(1+3+6+6\), and the verifier checks equivariance for all \(6\cdot16=96\) group-state pairs.
+
+Since four dimensions are ruled out and five dimensions are explicit,
+
+\[
+\boxed{
+\text{the minimal affine binary signature register has dimension }5.
+}
+\]
+
+Thus the exact hardware law is
+
+\[
+\boxed{
+4\text{ information bits}+1\text{ symmetry bit}=5\text{ affine-equivariant bits}.
+}
+\]
+
+## Engineering consequence
+
+The 16 exact-cover signature states and the 16 OA ports have the same cardinality, but the signature action cannot be identified with a four-bit affine port register without an explicit nonlinear intertwiner. A controller has two honest options:
+
+1. retain four state bits and implement the \(S_3\) action by a small nonlinear LUT/permutation network; or
+2. add one bit and use the explicit five-bit linear representation above.
+
+No claim is made that the signature alphabet is already the OA\((16,3,4,2)\) port alphabet. The theorem instead supplies a falsifier: any proposed direct four-bit affine identification is impossible.
+
+## Reproduction
+
+```bash
+python analysis/bt3262_3265_signature_s3_affine_lift.py \
+  --json data/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json
+python -m pytest -q tests/test_bt3262_3265_signature_s3_affine_lift.py
+```
+
+Expected terminal line:
+
+```text
+PASS 6/6 exact signature-S3 affine-lift checks
+```

--- a/analysis/BT3262_BT3265_signature_s3_affine_lift_insert.tex
+++ b/analysis/BT3262_BT3265_signature_s3_affine_lift_insert.tex
@@ -1,0 +1,63 @@
+% BEGIN PASS 3262-3265 SIGNATURE S3 AFFINE LIFT
+\subsection{Exact-cover signature Fourier law and the one-bit symmetry overhead}
+The complete exact-cover census gives forty-five anchor octets.  Relative to an anchor,
+the three independent four-cells of the induced $K_{4,4,4}$ carry one of
+\[
+(2,2,2),\qquad(0,3,3),\qquad(1,2,3),\qquad(0,2,4).
+\]
+Permuting the three cells produces orbit sizes $1,3,6,6$.  Thus the local signature
+alphabet is the sixteen-state $S_3$-set
+\[
+\Omega\cong 1\sqcup S_3/C_2\sqcup S_3\sqcup S_3,
+\qquad 45|\Omega|=720.
+\]
+Its permutation character on the identity, transposition, and three-cycle classes is
+\[
+\chi_\Omega=(16,2,1),
+\]
+and therefore
+\[
+\mathbb Q[\Omega]\cong
+4\mathbf 1\oplus2\,\mathrm{sgn}\oplus5V_{\mathrm{std}}.
+\]
+Consequently
+\[
+\dim\operatorname{End}_{S_3}(\mathbb Q[\Omega])
+=4^2+2^2+5^2=45,
+\]
+with rational commutant
+\[
+M_4(\mathbb Q)\oplus M_2(\mathbb Q)\oplus M_5(\mathbb Q).
+\]
+Direct orbital enumeration gives forty-five relations on $\Omega\times\Omega$, with
+size profile $1^1 3^3 6^{41}$.  Hence
+\[
+720=45\cdot16
+=\dim\operatorname{End}_{S_3}(\mathbb Q[\Omega])\,|\Omega|.
+\]
+This rank equality does not itself identify the forty-five anchor octets with the
+forty-five orbitals.
+
+Although $|\Omega|=16$, its exact $S_3$ action cannot be affine on four binary bits.  The
+unique fixed state makes every affine realization translation-conjugate to a linear one.
+An exhaustive classification of all $2800$ embedded $S_3$ subgroups of $GL(4,2)$ finds
+only the orbit profiles
+\[
+(1,1,2,3,3,6),\qquad
+(1,1,1,1,3,3,3,3),\qquad
+(1,3,3,3,6),
+\]
+never $(1,3,6,6)$.  The obstruction is sharp: on
+\[
+\mathbb F_2^5=\mathbb F_2^3_{\rm perm}\oplus\mathbb F_2^2_{\rm std}
+\]
+there is an explicit invariant sixteen-state subset with the required orbit profile and
+an exact equivariant encoding of all four signature classes.  Therefore the minimal
+affine binary register has dimension five:
+\[
+\boxed{4\text{ information bits}+1\text{ symmetry bit}=5\text{ affine-equivariant bits}.}
+\]
+A four-bit implementation remains possible only with nonlinear lookup/permutation logic.
+In particular, equal cardinality does not justify identifying this signature alphabet
+with the $\mathrm{OA}(16,3,4,2)$ port alphabet without a separate intertwiner.
+% END PASS 3262-3265 SIGNATURE S3 AFFINE LIFT

--- a/analysis/bt3262_3265_signature_s3_affine_lift.py
+++ b/analysis/bt3262_3265_signature_s3_affine_lift.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Passes 3262--3265: exact-cover signature S3 Fourier and affine-lift theorem.
+
+This verifier uses only exact finite calculations.  It starts from the four local
+K_{4,4,4} cell patterns in the complete 720-signature cover classification and
+proves:
+
+* the local signature alphabet has S3-orbit sizes 1+3+6+6 = 16;
+* its permutation character is (16,2,1) and decomposes as 4*1 + 2*sgn + 5*std;
+* its rational commutant has dimension 45 and exactly 45 orbitals;
+* no affine S3 action on F_2^4 has orbit profile (1,3,6,6);
+* an explicit linear action on F_2^5 does, and an equivariant 16-state encoding is given.
+
+The four-bit obstruction is exhaustive: GL(4,2) has 20,160 elements and all 2,800
+embedded S3 subgroups are classified by their orbit profiles on F_2^4.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from itertools import permutations, product
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+Permutation = Tuple[int, int, int]
+Matrix = Tuple[int, ...]  # binary row masks
+Vector3 = Tuple[int, int, int]
+
+S3: Tuple[Permutation, ...] = tuple(permutations(range(3)))
+IDENTITY_4: Matrix = (1, 2, 4, 8)
+
+PATTERN_SEEDS: Dict[str, Vector3] = {
+    "T128": (2, 2, 2),
+    "T120": (0, 3, 3),
+    "T104": (1, 2, 3),
+    "T96": (0, 2, 4),
+}
+EXPECTED_LOCAL_ORBIT_SIZES = (1, 3, 6, 6)
+
+
+def inverse_permutation(p: Permutation) -> Permutation:
+    out = [0, 0, 0]
+    for i, j in enumerate(p):
+        out[j] = i
+    return tuple(out)  # type: ignore[return-value]
+
+
+def compose_permutations(p: Permutation, q: Permutation) -> Permutation:
+    """Return p after q."""
+    return tuple(p[q[i]] for i in range(3))  # type: ignore[return-value]
+
+
+def act_on_pattern(p: Permutation, x: Vector3) -> Vector3:
+    pinv = inverse_permutation(p)
+    return tuple(x[pinv[i]] for i in range(3))  # type: ignore[return-value]
+
+
+def cycle_type(p: Permutation) -> Tuple[int, ...]:
+    seen = [False] * 3
+    lengths: List[int] = []
+    for i in range(3):
+        if seen[i]:
+            continue
+        j = i
+        length = 0
+        while not seen[j]:
+            seen[j] = True
+            length += 1
+            j = p[j]
+        lengths.append(length)
+    return tuple(sorted(lengths, reverse=True))
+
+
+def build_local_alphabet() -> Tuple[List[Vector3], Dict[str, List[Vector3]]]:
+    by_type: Dict[str, List[Vector3]] = {}
+    omega: List[Vector3] = []
+    for name, seed in PATTERN_SEEDS.items():
+        orbit = sorted({act_on_pattern(p, seed) for p in S3})
+        by_type[name] = orbit
+        omega.extend(orbit)
+    assert len(omega) == len(set(omega)) == 16
+    assert tuple(sorted(len(v) for v in by_type.values())) == EXPECTED_LOCAL_ORBIT_SIZES
+    return omega, by_type
+
+
+def character_and_multiplicities(omega: Sequence[Vector3]) -> Dict[str, object]:
+    classes: Dict[Tuple[int, ...], List[Permutation]] = defaultdict(list)
+    for p in S3:
+        classes[cycle_type(p)].append(p)
+
+    class_order = ((1, 1, 1), (2, 1), (3,))
+    fixed = []
+    for ctype in class_order:
+        p = classes[ctype][0]
+        fixed.append(sum(act_on_pattern(p, x) == x for x in omega))
+    assert fixed == [16, 2, 1]
+
+    class_sizes = [1, 3, 2]
+    irreducibles = {
+        "trivial": [1, 1, 1],
+        "sign": [1, -1, 1],
+        "standard": [2, 0, -1],
+    }
+    multiplicities: Dict[str, int] = {}
+    for name, chi in irreducibles.items():
+        inner = sum(class_sizes[i] * fixed[i] * chi[i] for i in range(3))
+        assert inner % 6 == 0
+        multiplicities[name] = inner // 6
+    assert multiplicities == {"trivial": 4, "sign": 2, "standard": 5}
+    assert 4 * 1 + 2 * 1 + 5 * 2 == 16
+
+    commutant_dimension = sum(m * m for m in multiplicities.values())
+    assert commutant_dimension == 45
+    return {
+        "class_order": ["identity", "transposition", "three_cycle"],
+        "class_sizes": class_sizes,
+        "fixed_point_character": fixed,
+        "irreducible_multiplicities": multiplicities,
+        "commutant_dimension": commutant_dimension,
+        "wedderburn_decomposition": "M4(Q) + M2(Q) + M5(Q)",
+    }
+
+
+def local_orbitals(omega: Sequence[Vector3]) -> Dict[str, object]:
+    index = {x: i for i, x in enumerate(omega)}
+    unseen: Set[Tuple[int, int]] = {(i, j) for i in range(16) for j in range(16)}
+    orbitals: List[Set[Tuple[int, int]]] = []
+    while unseen:
+        pair = next(iter(unseen))
+        orbital = {
+            (
+                index[act_on_pattern(p, omega[pair[0]])],
+                index[act_on_pattern(p, omega[pair[1]])],
+            )
+            for p in S3
+        }
+        orbitals.append(orbital)
+        unseen.difference_update(orbital)
+    size_histogram = Counter(len(o) for o in orbitals)
+    assert len(orbitals) == 45
+    assert size_histogram == Counter({6: 41, 3: 3, 1: 1})
+    assert sum(len(o) for o in orbitals) == 16 * 16
+    return {
+        "orbital_count": len(orbitals),
+        "orbital_size_histogram": {str(k): v for k, v in sorted(size_histogram.items())},
+    }
+
+
+def rank_binary_rows(rows: Sequence[int], n: int) -> int:
+    work = list(rows)
+    rank = 0
+    for col in range(n - 1, -1, -1):
+        pivot = next((i for i in range(rank, len(work)) if (work[i] >> col) & 1), None)
+        if pivot is None:
+            continue
+        work[rank], work[pivot] = work[pivot], work[rank]
+        for i in range(len(work)):
+            if i != rank and ((work[i] >> col) & 1):
+                work[i] ^= work[rank]
+        rank += 1
+    return rank
+
+
+def multiply_binary_matrices(a: Matrix, b: Matrix) -> Matrix:
+    out: List[int] = []
+    for row in a:
+        value = 0
+        for k in range(len(b)):
+            if (row >> k) & 1:
+                value ^= b[k]
+        out.append(value)
+    return tuple(out)
+
+
+def apply_binary_matrix(matrix: Matrix, x: int) -> int:
+    y = 0
+    for i, row in enumerate(matrix):
+        if (row & x).bit_count() & 1:
+            y |= 1 << i
+    return y
+
+
+def matrix_power(matrix: Matrix, exponent: int, identity: Matrix) -> Matrix:
+    out = identity
+    base = matrix
+    n = exponent
+    while n:
+        if n & 1:
+            out = multiply_binary_matrices(out, base)
+        base = multiply_binary_matrices(base, base)
+        n //= 2
+    return out
+
+
+def matrix_order(matrix: Matrix, identity: Matrix, maximum: int = 64) -> int:
+    current = identity
+    for order in range(1, maximum + 1):
+        current = multiply_binary_matrices(current, matrix)
+        if current == identity:
+            return order
+    raise RuntimeError("matrix order exceeded bound")
+
+
+def enumerate_gl4() -> List[Matrix]:
+    return [
+        tuple(rows)
+        for rows in product(range(16), repeat=4)
+        if rank_binary_rows(rows, 4) == 4
+    ]
+
+
+def orbit_profile(group: Iterable[Matrix], dimension: int) -> Tuple[int, ...]:
+    elements = tuple(group)
+    unseen = set(range(1 << dimension))
+    sizes: List[int] = []
+    while unseen:
+        x = next(iter(unseen))
+        orbit = {apply_binary_matrix(g, x) for g in elements}
+        sizes.append(len(orbit))
+        unseen.difference_update(orbit)
+    return tuple(sorted(sizes))
+
+
+def classify_s3_subgroups_gl4() -> Dict[str, object]:
+    gl4 = enumerate_gl4()
+    assert len(gl4) == 20160
+    by_order: Dict[int, List[Matrix]] = defaultdict(list)
+    for matrix in gl4:
+        by_order[matrix_order(matrix, IDENTITY_4, maximum=15)].append(matrix)
+
+    subgroups: Dict[Tuple[Matrix, ...], Set[Matrix]] = {}
+    for r in by_order[3]:
+        r_inv = multiply_binary_matrices(r, r)
+        for s in by_order[2]:
+            if multiply_binary_matrices(multiply_binary_matrices(s, r), s) != r_inv:
+                continue
+            group = {
+                IDENTITY_4,
+                r,
+                r_inv,
+                s,
+                multiply_binary_matrices(s, r),
+                multiply_binary_matrices(s, r_inv),
+            }
+            if len(group) == 6:
+                subgroups[tuple(sorted(group))] = group
+
+    profiles = Counter(orbit_profile(g, 4) for g in subgroups.values())
+    expected = Counter(
+        {
+            (1, 1, 2, 3, 3, 6): 1680,
+            (1, 1, 1, 1, 3, 3, 3, 3): 560,
+            (1, 3, 3, 3, 6): 560,
+        }
+    )
+    assert len(subgroups) == 2800
+    assert profiles == expected
+    assert EXPECTED_LOCAL_ORBIT_SIZES not in profiles
+
+    return {
+        "gl4_order": len(gl4),
+        "s3_subgroup_count": len(subgroups),
+        "orbit_profile_counts": {
+            "+".join(map(str, profile)): count
+            for profile, count in sorted(profiles.items())
+        },
+        "target_profile_present": False,
+        "affine_four_bit_realization": False,
+        "obstruction_reason": (
+            "The signature action has one fixed point, so any affine realization is "
+            "translation-conjugate to a linear action; no S3 subgroup of GL(4,2) has "
+            "orbit profile 1+3+6+6."
+        ),
+    }
+
+
+def gl2_natural_representation() -> Dict[Permutation, Matrix]:
+    gl2 = [
+        tuple(rows)
+        for rows in product(range(4), repeat=2)
+        if rank_binary_rows(rows, 2) == 2
+    ]
+    labels = (1, 2, 3)  # three nonzero vectors of F_2^2
+    representation: Dict[Permutation, Matrix] = {}
+    for p in S3:
+        matches = [
+            matrix
+            for matrix in gl2
+            if all(apply_binary_matrix(matrix, labels[i]) == labels[p[i]] for i in range(3))
+        ]
+        assert len(matches) == 1
+        representation[p] = matches[0]
+    return representation
+
+
+def permutation_matrix_3(p: Permutation) -> Matrix:
+    rows = [0, 0, 0]
+    for i in range(3):
+        rows[p[i]] |= 1 << i
+    return tuple(rows)
+
+
+def block_diagonal_3_plus_2(a: Matrix, b: Matrix) -> Matrix:
+    return tuple(a) + tuple(row << 3 for row in b)
+
+
+def explicit_five_bit_lift(omega: Sequence[Vector3], by_type: Dict[str, List[Vector3]]) -> Dict[str, object]:
+    rho2 = gl2_natural_representation()
+    rho5 = {
+        p: block_diagonal_3_plus_2(permutation_matrix_3(p), rho2[p])
+        for p in S3
+    }
+
+    identity_5: Matrix = (1, 2, 4, 8, 16)
+    for p, matrix in rho5.items():
+        assert rank_binary_rows(matrix, 5) == 5
+        assert rho5[compose_permutations(p, inverse_permutation(p))] == identity_5
+
+    r: Permutation = (1, 2, 0)
+    s: Permutation = (0, 2, 1)
+    r_matrix = rho5[r]
+    s_matrix = rho5[s]
+    assert matrix_power(r_matrix, 3, identity_5) == identity_5
+    assert matrix_power(s_matrix, 2, identity_5) == identity_5
+    assert multiply_binary_matrices(multiply_binary_matrices(s_matrix, r_matrix), s_matrix) == matrix_power(r_matrix, 2, identity_5)
+
+    full_profile = orbit_profile(rho5.values(), 5)
+    assert full_profile == (1, 1, 3, 3, 3, 3, 3, 3, 6, 6)
+
+    nonzero_labels = (1, 2, 3)
+
+    def position(x: Vector3, value: int) -> int:
+        return x.index(value)
+
+    def encode(x: Vector3) -> int:
+        if x in by_type["T128"]:
+            return 0
+        if x in by_type["T120"]:
+            i = position(x, 0)
+            return 1 << i
+        if x in by_type["T104"]:
+            i = position(x, 1)
+            j = position(x, 2)
+            return (1 << j) | (nonzero_labels[i] << 3)
+        if x in by_type["T96"]:
+            i = position(x, 0)
+            k = position(x, 4)
+            first_three = 0b111 ^ (1 << k)
+            return first_three | (nonzero_labels[i] << 3)
+        raise ValueError(f"unknown signature state {x}")
+
+    encoded = {x: encode(x) for x in omega}
+    assert len(set(encoded.values())) == 16
+    for p in S3:
+        for x in omega:
+            assert encoded[act_on_pattern(p, x)] == apply_binary_matrix(rho5[p], encoded[x])
+
+    selected_profile = []
+    remaining = set(encoded.values())
+    while remaining:
+        x = next(iter(remaining))
+        orbit = {apply_binary_matrix(matrix, x) for matrix in rho5.values()}
+        selected_profile.append(len(orbit))
+        remaining.difference_update(orbit)
+    assert tuple(sorted(selected_profile)) == EXPECTED_LOCAL_ORBIT_SIZES
+
+    def rows_to_dense(matrix: Matrix, dimension: int) -> List[List[int]]:
+        return [[(row >> j) & 1 for j in range(dimension)] for row in matrix]
+
+    encoding_table = {
+        ",".join(map(str, x)): format(code, "05b")
+        for x, code in sorted(encoded.items())
+    }
+    return {
+        "ambient_dimension": 5,
+        "ambient_orbit_profile": list(full_profile),
+        "selected_signature_orbit_profile": list(sorted(selected_profile)),
+        "generator_r_three_cycle": rows_to_dense(r_matrix, 5),
+        "generator_s_transposition": rows_to_dense(s_matrix, 5),
+        "encoding_table": encoding_table,
+        "equivariant": True,
+        "minimal_affine_binary_dimension": 5,
+        "information_bits": 4,
+        "symmetry_overhead_bits": 1,
+    }
+
+
+def build_results() -> Dict[str, object]:
+    omega, by_type = build_local_alphabet()
+    character = character_and_multiplicities(omega)
+    orbitals = local_orbitals(omega)
+    obstruction = classify_s3_subgroups_gl4()
+    lift = explicit_five_bit_lift(omega, by_type)
+
+    assert character["commutant_dimension"] == 45
+    assert orbitals["orbital_count"] == 45
+    assert 45 * 16 == 720
+
+    return {
+        "pass_range": "3262-3265",
+        "theorem": "Exact-cover signature S3 Fourier and five-bit affine-lift theorem",
+        "source_boundary": (
+            "The four cell-pattern seeds and 45-anchor/720-signature count are imported "
+            "from the frozen complete exact-cover signature classification."
+        ),
+        "local_signature_types": {
+            name: {
+                "seed": list(PATTERN_SEEDS[name]),
+                "orbit_size": len(states),
+                "states": [list(x) for x in states],
+            }
+            for name, states in by_type.items()
+        },
+        "local_alphabet_size": len(omega),
+        "anchor_count": 45,
+        "global_signature_count": 720,
+        "rank_degree_identity": "720 = 45 * 16 = dim(End_S3(Q^Omega)) * |Omega|",
+        "character": character,
+        "coherent_configuration": orbitals,
+        "four_bit_affine_obstruction": obstruction,
+        "five_bit_lift": lift,
+        "claim_boundaries": [
+            "The equality between the 45 anchor octets and the 45 local orbitals does not itself define a canonical bijection.",
+            "The 16-state signature alphabet is not identified with the OA(16,3,4,2) port alphabet without an explicit intertwiner.",
+            "A four-bit implementation remains possible with nonlinear lookup/permutation logic; only affine F_2 implementations are ruled out.",
+        ],
+        "checks": {
+            "local_orbit_sizes": True,
+            "character_decomposition": True,
+            "commutant_rank_45": True,
+            "all_gl4_s3_subgroups_classified": True,
+            "four_bit_affine_no_go": True,
+            "five_bit_equivariant_encoding": True,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", type=Path, help="optional output JSON path")
+    args = parser.parse_args()
+    results = build_results()
+    text = json.dumps(results, indent=2, sort_keys=True)
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    print("PASS 6/6 exact signature-S3 affine-lift checks")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json
+++ b/data/PART_BT3262_BT3265_SIGNATURE_S3_AFFINE_LIFT_results.json
@@ -1,0 +1,305 @@
+{
+  "anchor_count": 45,
+  "character": {
+    "class_order": [
+      "identity",
+      "transposition",
+      "three_cycle"
+    ],
+    "class_sizes": [
+      1,
+      3,
+      2
+    ],
+    "commutant_dimension": 45,
+    "fixed_point_character": [
+      16,
+      2,
+      1
+    ],
+    "irreducible_multiplicities": {
+      "sign": 2,
+      "standard": 5,
+      "trivial": 4
+    },
+    "wedderburn_decomposition": "M4(Q) + M2(Q) + M5(Q)"
+  },
+  "checks": {
+    "all_gl4_s3_subgroups_classified": true,
+    "character_decomposition": true,
+    "commutant_rank_45": true,
+    "five_bit_equivariant_encoding": true,
+    "four_bit_affine_no_go": true,
+    "local_orbit_sizes": true
+  },
+  "claim_boundaries": [
+    "The equality between the 45 anchor octets and the 45 local orbitals does not itself define a canonical bijection.",
+    "The 16-state signature alphabet is not identified with the OA(16,3,4,2) port alphabet without an explicit intertwiner.",
+    "A four-bit implementation remains possible with nonlinear lookup/permutation logic; only affine F_2 implementations are ruled out."
+  ],
+  "coherent_configuration": {
+    "orbital_count": 45,
+    "orbital_size_histogram": {
+      "1": 1,
+      "3": 3,
+      "6": 41
+    }
+  },
+  "five_bit_lift": {
+    "ambient_dimension": 5,
+    "ambient_orbit_profile": [
+      1,
+      1,
+      3,
+      3,
+      3,
+      3,
+      3,
+      3,
+      6,
+      6
+    ],
+    "encoding_table": {
+      "0,2,4": "01011",
+      "0,3,3": "00001",
+      "0,4,2": "01101",
+      "1,2,3": "01010",
+      "1,3,2": "01100",
+      "2,0,4": "10011",
+      "2,1,3": "10001",
+      "2,2,2": "00000",
+      "2,3,1": "11001",
+      "2,4,0": "11101",
+      "3,0,3": "00010",
+      "3,1,2": "10100",
+      "3,2,1": "11010",
+      "3,3,0": "00100",
+      "4,0,2": "10110",
+      "4,2,0": "11110"
+    },
+    "equivariant": true,
+    "generator_r_three_cycle": [
+      [
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
+      [
+        1,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        1
+      ]
+    ],
+    "generator_s_transposition": [
+      [
+        1,
+        0,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        1
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    ],
+    "information_bits": 4,
+    "minimal_affine_binary_dimension": 5,
+    "selected_signature_orbit_profile": [
+      1,
+      3,
+      6,
+      6
+    ],
+    "symmetry_overhead_bits": 1
+  },
+  "four_bit_affine_obstruction": {
+    "affine_four_bit_realization": false,
+    "gl4_order": 20160,
+    "obstruction_reason": "The signature action has one fixed point, so any affine realization is translation-conjugate to a linear action; no S3 subgroup of GL(4,2) has orbit profile 1+3+6+6.",
+    "orbit_profile_counts": {
+      "1+1+1+1+3+3+3+3": 560,
+      "1+1+2+3+3+6": 1680,
+      "1+3+3+3+6": 560
+    },
+    "s3_subgroup_count": 2800,
+    "target_profile_present": false
+  },
+  "global_signature_count": 720,
+  "local_alphabet_size": 16,
+  "local_signature_types": {
+    "T104": {
+      "orbit_size": 6,
+      "seed": [
+        1,
+        2,
+        3
+      ],
+      "states": [
+        [
+          1,
+          2,
+          3
+        ],
+        [
+          1,
+          3,
+          2
+        ],
+        [
+          2,
+          1,
+          3
+        ],
+        [
+          2,
+          3,
+          1
+        ],
+        [
+          3,
+          1,
+          2
+        ],
+        [
+          3,
+          2,
+          1
+        ]
+      ]
+    },
+    "T120": {
+      "orbit_size": 3,
+      "seed": [
+        0,
+        3,
+        3
+      ],
+      "states": [
+        [
+          0,
+          3,
+          3
+        ],
+        [
+          3,
+          0,
+          3
+        ],
+        [
+          3,
+          3,
+          0
+        ]
+      ]
+    },
+    "T128": {
+      "orbit_size": 1,
+      "seed": [
+        2,
+        2,
+        2
+      ],
+      "states": [
+        [
+          2,
+          2,
+          2
+        ]
+      ]
+    },
+    "T96": {
+      "orbit_size": 6,
+      "seed": [
+        0,
+        2,
+        4
+      ],
+      "states": [
+        [
+          0,
+          2,
+          4
+        ],
+        [
+          0,
+          4,
+          2
+        ],
+        [
+          2,
+          0,
+          4
+        ],
+        [
+          2,
+          4,
+          0
+        ],
+        [
+          4,
+          0,
+          2
+        ],
+        [
+          4,
+          2,
+          0
+        ]
+      ]
+    }
+  },
+  "pass_range": "3262-3265",
+  "rank_degree_identity": "720 = 45 * 16 = dim(End_S3(Q^Omega)) * |Omega|",
+  "source_boundary": "The four cell-pattern seeds and 45-anchor/720-signature count are imported from the frozen complete exact-cover signature classification.",
+  "theorem": "Exact-cover signature S3 Fourier and five-bit affine-lift theorem"
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,6 +41,45 @@
       </aside>
     </section>
 
+<!-- BT3262-BT3265-SIGNATURE-S3-AFFINE-LIFT -->
+<h2>Passes 3262–3265: exact-cover signatures expose a one-bit symmetry cost</h2>
+<section class="grid">
+  <article class="card theorem">
+    <div class="eyebrow">Local signature alphabet</div>
+    <div class="metric">16 = 1 + 3 + 6 + 6</div>
+    <p>The four complete-census cell patterns form one fixed state, one three-state orbit, and two regular <span class="mono">S3</span> orbits.</p>
+  </article>
+  <article class="card theorem">
+    <div class="eyebrow">Fourier character</div>
+    <div class="metric">χ = (16, 2, 1)</div>
+    <p>The exact rational module is <span class="mono">4·1 ⊕ 2·sgn ⊕ 5·std</span>: four scalar channels, two sign channels, and five non-Abelian Fourier doublets.</p>
+  </article>
+  <article class="card theorem">
+    <div class="eyebrow">Coherent algebra</div>
+    <div class="metric">dim EndS3 = 45</div>
+    <p>Direct orbital enumeration also gives 45 relations, with size profile <span class="mono">1¹ 3³ 6⁴¹</span> and commutant <span class="mono">M4(Q) ⊕ M2(Q) ⊕ M5(Q)</span>.</p>
+  </article>
+  <article class="card theorem">
+    <div class="eyebrow">Exact rank-degree law</div>
+    <div class="metric">720 = 45 × 16</div>
+    <p>The global signature count equals local alphabet size times local commutant rank. This is an exact identity, not a claimed canonical anchor-to-orbital bijection.</p>
+  </article>
+  <article class="card theorem">
+    <div class="eyebrow">Four-bit affine no-go</div>
+    <div class="metric">2,800 S3 subgroups</div>
+    <p>Every embedded <span class="mono">S3 ≤ GL(4,2)</span> was classified. None has orbit profile <span class="mono">1+3+6+6</span>, so no affine four-bit realization exists.</p>
+  </article>
+  <article class="card theorem">
+    <div class="eyebrow">Minimal affine lift</div>
+    <div class="metric">4 + 1 = 5 bits</div>
+    <p>An explicit five-bit linear action realizes all sixteen states equivariantly. Four bits still work only through nonlinear lookup/permutation logic.</p>
+  </article>
+</section>
+<section class="card boundary" style="margin-top:18px">
+  <strong>Identification boundary.</strong> Equal cardinality does not identify the sixteen signature states with the <span class="mono">OA(16,3,4,2)</span> port alphabet. A direct intertwiner remains a separate proof obligation.
+</section>
+<!-- /BT3262-BT3265-SIGNATURE-S3-AFFINE-LIFT -->
+
 <!-- BT3205-BT3213-CHROMATIC-CLOSURE -->
 <h2>Passes 3205–3213: the frame graph becomes a finite port machine</h2>
 <section class="grid">
@@ -132,7 +171,7 @@
   </main>
 
   <footer>
-    <p>Passes 3205–3213 · semantic certificate SHA-256 <span class="mono">68e93f6bc4a583be…bbdb21d19</span></p>
+    <p>Passes 3262–3265 · exact signature <span class="mono">S3</span> Fourier and affine-lift certificate</p>
   </footer>
 </div>
 </body>

--- a/holonet_machine_blueprint.tex
+++ b/holonet_machine_blueprint.tex
@@ -7,6 +7,7 @@
     \newpage
     \input{analysis/BT3191_chromatic_defect_block_filter_insert}%
     \input{analysis/BT3212_chromatic_closure_insert}%
+    \input{analysis/BT3262_BT3265_signature_s3_affine_lift_insert}%
   }%
 }
 \input{holonet_machine_blueprint_body.tex}

--- a/photonic_holonet.tex
+++ b/photonic_holonet.tex
@@ -69,6 +69,7 @@
     \input{analysis/BT3124_BT3132_deep_five_front_closure_insert}%
     \input{analysis/BT3191_chromatic_defect_block_filter_insert}%
     \input{analysis/BT3212_chromatic_closure_insert}%
+    \input{analysis/BT3262_BT3265_signature_s3_affine_lift_insert}%
   }%
 }
 \input{photonic_holonet_body.tex}

--- a/tests/test_bt3262_3265_signature_s3_affine_lift.py
+++ b/tests/test_bt3262_3265_signature_s3_affine_lift.py
@@ -1,0 +1,26 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "analysis" / "bt3262_3265_signature_s3_affine_lift.py"
+SPEC = spec_from_file_location("bt3262_3265", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_signature_s3_affine_lift_theorem():
+    result = MODULE.build_results()
+    assert result["local_alphabet_size"] == 16
+    assert result["global_signature_count"] == 720
+    assert result["character"]["fixed_point_character"] == [16, 2, 1]
+    assert result["character"]["irreducible_multiplicities"] == {
+        "trivial": 4,
+        "sign": 2,
+        "standard": 5,
+    }
+    assert result["character"]["commutant_dimension"] == 45
+    assert result["coherent_configuration"]["orbital_count"] == 45
+    assert result["four_bit_affine_obstruction"]["s3_subgroup_count"] == 2800
+    assert result["four_bit_affine_obstruction"]["affine_four_bit_realization"] is False
+    assert result["five_bit_lift"]["minimal_affine_binary_dimension"] == 5
+    assert result["five_bit_lift"]["equivariant"] is True

--- a/w33_paper.tex
+++ b/w33_paper.tex
@@ -68,6 +68,7 @@
     \input{analysis/BT3124_BT3132_deep_five_front_closure_insert}%
     \input{analysis/BT3191_chromatic_defect_block_filter_insert}%
     \input{analysis/BT3212_chromatic_closure_insert}%
+    \input{analysis/BT3262_BT3265_signature_s3_affine_lift_insert}%
   }%
 }
 \input{w33_paper_body.tex}


### PR DESCRIPTION
## Summary

This packet derives an independent exact theorem from the frozen complete exact-cover signature classification and the current non-Abelian S3 port frontier.

- builds the 16-state local signature S3-set with orbit profile `1+3+6+6`;
- proves character `χ=(16,2,1)` and rational decomposition `4·1 ⊕ 2·sgn ⊕ 5·std`;
- computes the 45-dimensional commutant and all 45 orbitals (`1^1 3^3 6^41`);
- exhaustively classifies all 2,800 embedded S3 subgroups of `GL(4,2)` and proves the four-bit affine no-go;
- supplies an explicit minimal five-bit equivariant linear encoding;
- integrates one shared theorem insert into `w33_paper.tex`, `photonic_holonet.tex`, and `holonet_machine_blueprint.tex`;
- updates `docs/index.html` with the engineering choice and evidence boundaries.

## Exact engineering law

`4 information bits + 1 symmetry bit = 5 affine-equivariant bits`.

A four-bit controller is still possible through nonlinear LUT/permutation logic. The theorem rules out only affine binary implementations.

## Boundaries

- No canonical bijection between the 45 anchor octets and the 45 local orbitals is claimed.
- The 16 signature states are not identified with the `OA(16,3,4,2)` port alphabet without a separate intertwiner.
- The current chromatic boundary remains `10 ≤ χ(H) ≤ 11`.

## Validation

- `PASS 6/6 exact signature-S3 affine-lift checks`
- `pytest`: 1 passed
- frozen JSON regenerated byte-for-byte
- exhaustive `GL(4,2)` / S3 subgroup classification: 20,160 matrices, 2,800 subgroups
