### PR TITLE
Passes 3506–3519: cubic dependency projector and chained closures

### DIFF
--- a/.github/workflows/w33_pass3506_3519_chained_breakthrough.yml
+++ b/.github/workflows/w33_pass3506_3519_chained_breakthrough.yml
@@ -1,0 +1,150 @@
+name: Passes 3506-3519 Chained Breakthrough
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'analysis/*3506*'
+      - 'analysis/*3519*'
+      - 'data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json'
+      - 'data/w33_pass_namespace_registry_v2.d/3506-3519.json'
+      - 'tests/test_bt3506_3519_chained_breakthrough.py'
+      - 'rtl/w33_mod3_five_channel_min5.v'
+      - 'rtl/w33_mod3_five_channel_min5_formal.v'
+      - 'rtl/tb_w33_pass3506_3519_min5.v'
+      - 'analysis/W33_CURRENT_FRONTIER_MANIFEST.tex'
+      - 'data/w33_current_frontier_manifest_v1.json'
+      - '.github/workflows/w33_pass3506_3519_chained_breakthrough.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'analysis/*3506*'
+      - 'analysis/*3519*'
+      - 'data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json'
+      - 'tests/test_bt3506_3519_chained_breakthrough.py'
+      - 'rtl/w33_mod3_five_channel_min5.v'
+      - 'rtl/w33_mod3_five_channel_min5_formal.v'
+      - 'rtl/tb_w33_pass3506_3519_min5.v'
+      - 'analysis/W33_CURRENT_FRONTIER_MANIFEST.tex'
+      - 'data/w33_current_frontier_manifest_v1.json'
+      - '.github/workflows/w33_pass3506_3519_chained_breakthrough.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pass3506-3519-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  exact-rtl-papers:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install exact and digital dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iverilog yosys
+          python -m pip install --disable-pip-version-check numpy sympy pytest
+
+      - name: Regenerate and compare exact certificate
+        run: |
+          mkdir -p evidence/pass3506_3519
+          python analysis/bt3506_3519_chained_breakthrough.py \
+            --json evidence/pass3506_3519/results.json \
+            | tee evidence/pass3506_3519/exact.log
+          grep -F 'PASS_7_FRONTS 7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f' \
+            evidence/pass3506_3519/exact.log
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          generated = json.loads(Path('evidence/pass3506_3519/results.json').read_text())
+          frozen = json.loads(Path('data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json').read_text())
+          assert generated == frozen
+          print('PASS exact frozen certificate equality')
+          PY
+
+      - name: Focused regression
+        run: |
+          python -m pytest -q tests/test_bt3506_3519_chained_breakthrough.py \
+            | tee evidence/pass3506_3519/pytest.log
+          git diff --check
+
+      - name: Exhaust the five-operation datapath
+        run: |
+          iverilog -g2012 -s tb_w33_pass3506_3519_min5 \
+            -o evidence/pass3506_3519/min5_tb \
+            rtl/w33_mod3_five_channel_min5.v \
+            rtl/tb_w33_pass3506_3519_min5.v
+          vvp evidence/pass3506_3519/min5_tb \
+            | tee evidence/pass3506_3519/rtl.log
+          grep -F 'PASS min5_cases=243 order3_cases=243' \
+            evidence/pass3506_3519/rtl.log
+
+      - name: Formally prove the order-three identity
+        run: |
+          yosys -p "read_verilog -formal -D FORMAL rtl/w33_mod3_five_channel_min5.v rtl/w33_mod3_five_channel_min5_formal.v; prep -top w33_mod3_five_channel_min5_formal; flatten; sat -verify -prove-asserts -set-assumes -show-inputs" \
+            2>&1 | tee evidence/pass3506_3519/formal.log
+          grep -F 'SAT proof finished - no model found: SUCCESS!' \
+            evidence/pass3506_3519/formal.log
+
+      - name: Synthesize the minimum datapath
+        run: |
+          yosys -p "read_verilog rtl/w33_mod3_five_channel_min5.v; hierarchy -top w33_mod3_five_channel_min5; synth_ice40 -top w33_mod3_five_channel_min5 -json evidence/pass3506_3519/min5.json; stat" \
+            2>&1 | tee evidence/pass3506_3519/synthesis.log
+          test -s evidence/pass3506_3519/min5.json
+
+      - name: Verify source manifests
+        run: |
+          python - <<'PY'
+          import json, re
+          from pathlib import Path
+          tex = Path('analysis/W33_CURRENT_FRONTIER_MANIFEST.tex').read_text()
+          inputs = re.findall(r'\\input\{([^}]+)\}', tex)
+          manifest = json.loads(Path('data/w33_current_frontier_manifest_v1.json').read_text())
+          assert inputs == manifest['required_ordered_inputs']
+          ours = 'analysis/BT3506_BT3519_chained_breakthrough_insert'
+          previous = 'analysis/BT3500_BT3505_triangle_free_srg_m57_bridge_insert'
+          assert inputs.count(ours) == 1
+          assert inputs.index(previous) < inputs.index(ours)
+          assert Path(ours + '.tex').is_file()
+          tokens = [item['token'] for item in manifest['public_sections']]
+          assert tokens.count('bt3506-3519-chained-breakthrough') == 1
+          source = next(item['source'] for item in manifest['public_sections'] if item['token'] == 'bt3506-3519-chained-breakthrough')
+          assert Path(source).is_file()
+          for stem in inputs:
+              assert Path(stem + '.tex').is_file(), stem
+          print('PASS source manifest chronology and reachability')
+          PY
+
+      - uses: WtfJoke/setup-tectonic@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile canonical manuscripts
+        run: |
+          for source in w33_paper.tex photonic_holonet.tex holonet_machine_blueprint.tex; do
+            tectonic --keep-logs "$source" \
+              2>&1 | tee evidence/pass3506_3519/${source%.tex}.log
+            test -s "${source%.tex}.pdf"
+          done
+          sha256sum w33_paper.pdf photonic_holonet.pdf holonet_machine_blueprint.pdf \
+            > evidence/pass3506_3519/pdf_sha256.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pass3506-3519-chained-breakthrough-evidence
+          path: |
+            evidence/pass3506_3519/**
+            w33_paper.pdf
+            photonic_holonet.pdf
+            holonet_machine_blueprint.pdf

--- a/analysis/BT3506_BT3519_chained_breakthrough.md
+++ b/analysis/BT3506_BT3519_chained_breakthrough.md
@@ -1,0 +1,451 @@
+# Passes 3506–3519 — Cubic dependency projector, minimal ternary datapath, and incidence boundaries
+
+## Status
+
+The executable verifier reports
+
+```text
+PASS_7_FRONTS 7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f
+```
+
+The packet executes the five live continuations from Passes 3458–3505 and two additional high-risk constructions.  It preserves the live boundaries
+
+\[
+\boxed{389\le R_{\rm defect}\le435},
+\qquad
+\boxed{10\le\chi(H)\le11}.
+\]
+
+The new result is not another parameter coincidence.  The first 5,040 failures of strength three form a canonical cubic dependency hypergraph on the 240 filled faces, and its characteristic-three overlap operator constructs the protected 81-dimensional summand by an explicit polynomial idempotent.
+
+---
+
+## 3506–3507 — the first code-sensitive covering deck
+
+Each of the 720 support edges belongs to exactly one filled face.  A non-filled triangle of the 45-point block graph therefore determines three filled faces: the unique filled face containing each of its three edges.
+
+There are exactly
+
+\[
+\boxed{5040=2160+2880}
+\]
+
+such non-filled triangles, and all 5,040 induced triples of filled faces are distinct.  Let
+
+\[
+T\in\{0,1\}^{240\times5040}
+\]
+
+be their face–dependency incidence matrix.
+
+The resulting 3-uniform hypergraph is regular:
+
+\[
+\boxed{\deg(f)=63\qquad\text{for every filled face }f.}
+\]
+
+Two filled faces occur together in either two or four dependency triples.  The complete codegree census is
+
+\[
+\boxed{2^{3240},\qquad4^{2160}},
+\]
+
+so exactly 5,400 of the \(\binom{240}{2}\) face pairs are supported.
+
+Define the weighted two-section operator
+
+\[
+D=TT^{\mathsf T}-63I_{240}.
+\]
+
+It is 126-regular.  Its spectrum is
+
+\[
+\boxed{
+126^1,
+\left(18+12\sqrt6\right)^{24},
+18^{20},
+6^{15},
+(-6)^{60},
+(-10)^{81},
+\left(18-12\sqrt6\right)^{24},
+(-18)^{15}.
+}
+\]
+
+The multiplicity list is
+
+\[
+\boxed{1,15,15,20,24,24,60,81},
+\]
+
+exactly the ordinary constituent fingerprint of the 240-state face module.  Thus one canonical cubic-dependency operator separates all eight characteristic-zero face constituents, including the two 15-dimensional and two 24-dimensional sectors that dimension counting alone cannot distinguish.
+
+A rational annihilator is
+
+\[
+\begin{aligned}
+p(x)={}&(x-126)(x-18)(x-6)(x+6)(x+10)(x+18)\\
+&\times(x^2-36x-540).
+\end{aligned}
+\]
+
+The verifier checks the spectral multiplicities and verifies \(p(D)=0\) modulo independent primes 101 and 103.
+
+### Covering consequence
+
+The incidence ranks are
+
+\[
+\boxed{
+\operatorname{rank}_{\mathbb F_2}T=240,
+\quad
+\operatorname{rank}_{\mathbb F_3}T=239,
+\quad
+\operatorname{rank}_{\mathbb F_5}T=240.
+}
+\]
+
+Characteristic three is therefore exceptional.  The only row dependence is the global one forced by every column having weight three.
+
+This is the first exact higher-order deck that can see the switching code beyond one- and two-coordinate marginals.  It supplies the correct input for a code-sensitive degree-three or Lasserre relaxation.  It does not, by itself, prove \(R\ge390\), so the live interval remains \([389,435]\).
+
+---
+
+## 3508 — characteristic-three projector theorem
+
+Reduce \(D\) modulo three.  The verifier proves the exact polynomial relation
+
+\[
+\boxed{D^4=-D^3\pmod3.}
+\]
+
+Hence
+
+\[
+\boxed{E_{81}:=-D^3}
+\]
+
+satisfies
+
+\[
+\boxed{E_{81}^2=E_{81}},
+\qquad
+\boxed{\operatorname{rank}_{\mathbb F_3}E_{81}=81}.
+\]
+
+Moreover,
+
+\[
+DE_{81}=-E_{81}.
+\]
+
+The minimal polynomial of the dependency operator is
+
+\[
+\boxed{x^3(x+1)}.
+\]
+
+The complementary 159-dimensional generalized-zero space has power ranks
+
+\[
+\boxed{44,14,0},
+\]
+
+and therefore nilpotent Jordan type
+
+\[
+\boxed{
+J_3(0)^{14}\oplus J_2(0)^{16}\oplus J_1(0)^{85}.
+}
+\]
+
+The canonical face antipode provides a second check.  The projector annihilates the full 120-dimensional antipodal-symmetric space and has rank 81 on the antipodal-antisymmetric space:
+
+\[
+\boxed{
+\operatorname{rank}(E_{81}V_+)=0,
+\qquad
+\operatorname{rank}(E_{81}V_-)=81.
+}
+\]
+
+This identifies the previously observed 81-dimensional modular brick by an explicit polynomial projector.  It proves that the brick is a direct summand.  It is still not labelled simple without an independent composition-series or MeatAxe calculation.
+
+---
+
+## 3509–3510 — transported full-\(M_4\) finite-grid screen
+
+The six filled faces over each W33 quotient point are identified with the six transpositions of a tetrahedron.  A deterministic gauge is fixed by choosing the lexicographically least face-group lift from the base fibre to each quotient point.
+
+Each block-graph edge inherits the transposition attached to its unique filled face.  The resulting 180-dimensional Hermitian carrier uses six scalar weights, one per local transposition.
+
+The verifier exhausts
+
+\[
+\frac{3^6-1}{2}=\boxed{364}
+\]
+
+nonzero projective weight vectors in
+
+\[
+\{-1,0,1\}^6/\{\pm1\}.
+\]
+
+The best member is the equal-weight vector
+
+\[
+(1,1,1,1,1,1),
+\]
+
+with
+
+\[
+\lambda_{\max}=32,
+\qquad
+\lambda_{\min}\approx-14.060915270409,
+\]
+
+and weighted Hoffman ratio
+
+\[
+\boxed{3.275812021095}.
+\]
+
+Thus every matrix in this deterministic ternary six-weight grid stays below four and cannot alter the live chromatic lower bound ten.
+
+This closes only the stated finite grid.  It is not an unrestricted optimization over edge-dependent elements of the full \(M_4\) algebra.
+
+---
+
+## 3511–3513 — exact five-operation ternary datapath
+
+Modulo three, all 27 five-channel momentum symbols collapse to
+
+\[
+J=
+\begin{pmatrix}
+2&1&1&0&0\\
+2&1&0&1&0\\
+2&0&1&1&0\\
+0&2&2&0&0\\
+0&0&0&0&1
+\end{pmatrix},
+\qquad
+J^3=I.
+\]
+
+The cost model counts a binary ternary addition or subtraction as one operation; sign changes and copies are wiring.
+
+An exhaustive breadth-first search through depth four has state counts
+
+\[
+\boxed{1,20,310,4560,67245}
+\]
+
+and finds no circuit containing all five target output forms.  Therefore four operations are impossible.
+
+Five operations attain the target:
+
+\[
+s=b+c,
+\qquad
+p=d-a,
+\]
+
+\[
+y_0=s-a,
+\quad
+y_1=p+b,
+\quad y_2=p+c,
+\quad y_3=-s,
+\quad y_4=e.
+\]
+
+Hence
+
+\[
+\boxed{\text{minimum binary ternary operation count}=5.}
+\]
+
+The packet includes `rtl/w33_mod3_five_channel_min5.v` and an exhaustive testbench covering all
+
+\[
+3^5=243
+\]
+
+legal input states, literal matrix equivalence, and the three-step identity.
+
+The source theorem is exact.  Icarus and Yosys observations remain remote-workflow evidence until the workflow completes.
+
+---
+
+## 3514–3515 — tomotope cocycle lift obstruction
+
+The prior oriented-tetrahedron surface has 12 coordinates and 16 triangular lines:
+
+\[
+\boxed{12_4\,16_3}.
+\]
+
+The tomotope also has 12 edges and 16 triangular faces, together with eight cells: four tetrahedra and four hemioctahedra.  Every triangular face is incident to two cells, so an incidence-preserving lift must select eight four-face cells, each using six edges twice, and cover every one of the 16 faces exactly twice.
+
+The verifier exhausts the oriented surface.
+
+There are exactly
+
+\[
+\boxed{12}
+\]
+
+four-face/six-edge local cell candidates, but there are
+
+\[
+\boxed{0}
+\]
+
+eight-cell double-cover solutions.
+
+The visible \(S_4\) action together with orientation reversal has order 48, and the obstruction is invariant under this full visible symmetry.
+
+Therefore
+
+\[
+\boxed{
+\text{the oriented-tetrahedron }12_4\,16_3\text{ surface is not the tomotope edge–face incidence structure.}
+}
+\]
+
+The shared Reye parameters remain useful, but the missing cell cocycle cannot be supplied by relabelling this particular surface.
+
+This agrees with the original tomotope data: four vertices, twelve edges, sixteen triangles, four tetrahedra, four hemioctahedra, symmetry order 96, and 192 flags.  Parameter equality is not incidence equivalence.
+
+---
+
+# BONKERS 1 — the tempting \(57=1+16+40\) decomposition is impossible
+
+The triangle-free/SRG atlas exposes the numerical identity
+
+\[
+57=1+16+40,
+\]
+
+suggesting an apex plus a Clebsch graph plus W33 inside a hypothetical
+
+\[
+\operatorname{SRG}(57,14,1,4).
+\]
+
+Assume the 16-set induces Clebsch, of degree five.  Its external degree sum would be
+
+\[
+16(14-5)=144.
+\]
+
+Assume the disjoint 40-set induces W33, of degree twelve.  Its external degree sum would be
+
+\[
+40(14-12)=80.
+\]
+
+The difference is
+
+\[
+144-80=64.
+\]
+
+All Clebsch–W33 cross edges are counted once from each side, so the difference would have to be supplied entirely by the single apex.  But one apex can change the two incidence sums by at most 16.
+
+Therefore
+
+\[
+\boxed{
+\operatorname{SRG}(57,14,1,4)
+\text{ cannot contain induced Clebsch and W33 pieces on a }1+16+40\text{ partition.}
+}
+\]
+
+This is an exact degree-sum obstruction.  It makes no assertion about other possible realizations of the already known nonexistent parameter set, and it is unrelated to existence of the degree-57 Moore graph.
+
+---
+
+# BONKERS 2 — W33 plus Clebsch completes the Gewirtz augmentation spectrum
+
+W33 and the Gewirtz graph share nonprincipal eigenvalues \(2\) and \(-4\):
+
+\[
+W33:\quad 2^{24},(-4)^{15},
+\]
+
+\[
+\mathrm{Gewirtz}:\quad2^{35},(-4)^{20}.
+\]
+
+The missing multiplicities are therefore
+
+\[
+11\text{ copies of }2,
+\qquad5\text{ copies of }-4.
+\]
+
+The Clebsch graph has spectrum
+
+\[
+5^1,1^{10},(-3)^5.
+\]
+
+Define
+
+\[
+\boxed{p(x)=\frac{-3x^2+18x+17}{16}.}
+\]
+
+Then
+
+\[
+p(5)=p(1)=2,
+\qquad
+p(-3)=-4.
+\]
+
+Consequently
+
+\[
+\operatorname{spec}p(A_{\rm Clebsch})=2^{11},(-4)^5,
+\]
+
+and
+
+\[
+\boxed{
+\operatorname{spec}_{\rm nonprincipal}(A_{W33}\oplus p(A_{\rm Clebsch}))
+=
+2^{35},(-4)^{20},
+}
+\]
+
+exactly the Gewirtz augmentation spectrum.
+
+This is a functional-calculus completion, not a graph embedding and not a canonical group-module intertwiner.  Its value is that it turns the earlier W33–Gewirtz shared polynomial and the Clebsch \(D_5\) shell into one explicit spectral construction.
+
+---
+
+## Publication and evidence state
+
+Committed surfaces:
+
+- `analysis/bt3506_3519_chained_breakthrough.py`;
+- `data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json`;
+- `tests/test_bt3506_3519_chained_breakthrough.py`;
+- `rtl/w33_mod3_five_channel_min5.v`;
+- `rtl/tb_w33_pass3506_3519_min5.v`;
+- shared TeX and public-index inserts;
+- a focused exact/RTL/synthesis/PDF workflow.
+
+The frozen semantic hash is
+
+```text
+7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f
+```
+
+No remote Icarus, Yosys, FPGA-area, timing, power, PDF-hash, laboratory, M57, or physical result is claimed before observed workflow evidence exists.

--- a/analysis/BT3506_BT3519_chained_breakthrough_index_insert.html
+++ b/analysis/BT3506_BT3519_chained_breakthrough_index_insert.html
@@ -1,0 +1,60 @@
+<section id="bt3506-3519-chained-breakthrough" class="card theorem-card">
+  <h2>Passes 3506–3519 — Cubic dependency projector and chained closures</h2>
+  <p class="lede">
+    The 5,040 first strength-three failures form a canonical three-uniform dependency
+    hypergraph on the 240 filled faces. Its characteristic-three overlap operator
+    constructs the protected rank-81 summand explicitly.
+  </p>
+  <div class="result-grid">
+    <article>
+      <h3>Cubic dependency deck</h3>
+      <p>
+        The face–dependency incidence matrix has size <strong>240×5,040</strong>,
+        constant face degree <strong>63</strong>, and pair codegrees
+        <strong>2<sup>3240</sup>, 4<sup>2160</sup></strong>. Its weighted
+        two-section has multiplicities
+        <code>1,15,15,20,24,24,60,81</code>.
+      </p>
+    </article>
+    <article>
+      <h3>Rank-81 modular projector</h3>
+      <p>
+        Over F<sub>3</sub>, <code>D⁴ = −D³</code>. Therefore
+        <code>E₈₁ = −D³</code> is an idempotent of rank <strong>81</strong>,
+        supported entirely on the antipodal-antisymmetric face module.
+      </p>
+    </article>
+    <article>
+      <h3>Five-operation compiler</h3>
+      <p>
+        An exhaustive linear-form search excludes every four-operation ternary
+        circuit. The common five-channel order-three symbol is implemented by
+        exactly <strong>five</strong> additions/subtractions.
+      </p>
+    </article>
+    <article>
+      <h3>Tomotope boundary</h3>
+      <p>
+        The oriented-tetrahedron 12<sub>4</sub> 16<sub>3</sub> surface has twelve
+        local cell candidates but <strong>zero</strong> eight-cell double-cover
+        solutions. Matching Reye parameters do not imply tomotope incidence.
+      </p>
+    </article>
+  </div>
+  <p>
+    Two outside-box closures accompany the packet: the tempting
+    <code>57 = 1 + 16 + 40</code> induced Clebsch/W33 decomposition is excluded by
+    degree balance, while a quadratic polynomial of the Clebsch adjacency supplies
+    exactly the missing nonprincipal multiplicities between W33 and Gewirtz.
+  </p>
+  <p class="boundary">
+    Live boundaries remain <strong>389 ≤ R ≤ 435</strong> and
+    <strong>10 ≤ χ(H) ≤ 11</strong>. The transported-M<sub>4</sub> result is a
+    complete 364-class finite-grid screen, not an unrestricted optimum. No remote
+    RTL, synthesis, PDF, laboratory, M57, or physical evidence is promoted here.
+  </p>
+  <p class="certificate">
+    Frozen semantic SHA-256:
+    <code>7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f</code>
+  </p>
+</section>

--- a/analysis/BT3506_BT3519_chained_breakthrough_insert.tex
+++ b/analysis/BT3506_BT3519_chained_breakthrough_insert.tex
@@ -1,0 +1,91 @@
+\subsection{Cubic dependency projector and chained incidence closures}
+\label{sec:bt3506-3519-chained-breakthrough}
+
+The first code-sensitive failures beyond the strength-two covering relaxation form a canonical
+three-uniform hypergraph on the 240 filled faces.  Each of the 5,040 non-filled triangles of
+the 45-point block graph determines the three filled faces containing its three edges.  If
+\(T\in\{0,1\}^{240\times5040}\) is the resulting incidence matrix, then every face has degree
+63 and the face-pair codegrees are
+\[
+  2^{3240},\qquad 4^{2160}.
+\]
+The weighted two-section
+\[
+  D=TT^{\mathsf T}-63I
+\]
+is 126-regular and has spectrum
+\[
+\begin{split}
+  126^1,&\quad(18+12\sqrt6)^{24},\quad18^{20},\quad6^{15},\\
+  &(-6)^{60},\quad(-10)^{81},\quad(18-12\sqrt6)^{24},\quad(-18)^{15}.
+\end{split}
+\]
+Thus one cubic-dependency operator resolves the complete ordinary face-module multiplicity
+fingerprint \(1,15,15,20,24,24,60,81\).
+
+Characteristic three is exceptional:
+\[
+  \operatorname{rank}_{\mathbb F_3}T=239,
+  \qquad D^4=-D^3.
+\]
+Consequently
+\[
+  \boxed{E_{81}=-D^3}
+\]
+is an idempotent of rank 81.  It annihilates the antipodal-symmetric 120-space and has rank
+81 on the antipodal-antisymmetric 120-space.  The complementary generalized-zero module has
+power ranks \(44,14,0\) and nilpotent Jordan type
+\[
+  J_3(0)^{14}\oplus J_2(0)^{16}\oplus J_1(0)^{85}.
+\]
+This constructs the protected 81-dimensional direct summand explicitly; no simplicity claim is
+made without an independent composition-series computation.
+
+A deterministic transported-\(M_4\) screen exhausts all 364 projective weights in
+\(\{-1,0,1\}^6/\{\pm1\}\).  Its best member is the equal-weight vector and has weighted
+Hoffman ratio approximately \(3.275812021095\), so this complete finite grid cannot alter the
+live chromatic interval
+\[
+  10\leq\chi(H)\leq11.
+\]
+The result is not an unrestricted optimization over edge-dependent \(M_4\) amplitudes.
+
+The common five-channel characteristic-three symbol admits the exact minimum-operation circuit
+\[
+  s=b+c,\qquad p=d-a,
+\]
+\[
+  y_0=s-a,\qquad y_1=p+b,\qquad y_2=p+c,\qquad y_3=-s,\qquad y_4=e.
+\]
+An exhaustive linear-form breadth-first search proves that four binary ternary additions or
+subtractions are impossible, while the displayed construction uses five.  The symbol has order
+three.
+
+The oriented-tetrahedron \(12_4\,16_3\) surface does not lift to the tomotope edge--face
+incidence structure.  Although it has twelve four-face/six-edge local cell candidates, exhaustive
+incidence search finds no selection of eight cells covering every triangular face exactly twice.
+The shared Reye parameters therefore do not imply incidence equivalence.
+
+Two additional exact boundaries follow.  First, an induced partition
+\[
+  57=1+16+40
+\]
+of a hypothetical \(\operatorname{SRG}(57,14,1,4)\) into an apex, Clebsch, and W33 is
+impossible by external-degree balance: the Clebsch and W33 pieces demand external sums 144 and
+80, whose difference 64 cannot be supplied by one apex.  Second, the polynomial
+\[
+  p(x)=\frac{-3x^2+18x+17}{16}
+\]
+maps the Clebsch spectrum \(5^1,1^{10},(-3)^5\) to \(2^{11},(-4)^5\).  Adjoining this to
+the W33 nonprincipal spectrum \(2^{24},(-4)^{15}\) gives exactly the Gewirtz
+nonprincipal spectrum \(2^{35},(-4)^{20}\).  This is a functional-calculus completion, not
+a graph embedding or canonical module intertwiner.
+
+The covering-radius interval remains
+\[
+  389\leq R_{\rm defect}\leq435.
+\]
+The exact verifier, frozen semantic certificate, focused regression, five-operation RTL,
+exhaustive testbench, and evidence workflow are committed under Passes 3506--3519.  Source
+publication alone does not establish remote simulation, synthesis, placement, timing, PDF, or
+laboratory evidence.

--- a/analysis/W33_CURRENT_FRONTIER_MANIFEST.tex
+++ b/analysis/W33_CURRENT_FRONTIER_MANIFEST.tex
@@ -18,3 +18,4 @@
 \input{analysis/BT3458_BT3471_face_tower_brauer_tomotope_insert}%
 \input{analysis/BT3486_BT3499_radius_code_biplane_supplement_insert}%
 \input{analysis/BT3500_BT3505_triangle_free_srg_m57_bridge_insert}%
+\input{analysis/BT3506_BT3519_chained_breakthrough_insert}%

--- a/analysis/bt3506_3519_chained_breakthrough.py
+++ b/analysis/bt3506_3519_chained_breakthrough.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Passes 3506--3519: cubic dependency projector and chained closures.
+
+The verifier is deliberately fail-closed.  It reconstructs the 45-point carrier
+from the earlier exact geometry module and then checks seven independent fronts:
+
+* the first code-sensitive 5,040-triple covering deck;
+* its characteristic-three rank-81 idempotent;
+* a deterministic transported-M4 finite-grid screen;
+* an exact five-operation ternary linear-circuit optimum;
+* the oriented-Reye/tomotope cell-lift obstruction;
+* a 57=40+16+1 induced-subgraph obstruction;
+* a W33/Clebsch functional-calculus completion of the Gewirtz spectrum.
+
+No exact covering-radius endpoint, unrestricted M4 optimum, ten-colour theorem,
+simple-module label, observed FPGA result, tomotope monodromy, M57 existence, or
+physical interpretation is inferred.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from itertools import combinations, permutations, product
+from pathlib import Path
+
+import numpy as np
+
+from analysis.bt3444_3457_radius_modular_fivechannel import (
+    close_group,
+    geometry_objects,
+    rank_mod,
+)
+
+
+def canonical_form(vector: tuple[int, ...]) -> tuple[int, ...]:
+    vector = tuple(int(value % 3) for value in vector)
+    for value in vector:
+        if value:
+            if value == 2:
+                return tuple((-entry) % 3 for entry in vector)
+            return vector
+    return vector
+
+
+def components(adjacency: np.ndarray) -> list[list[int]]:
+    unseen = set(range(adjacency.shape[0]))
+    result: list[list[int]] = []
+    while unseen:
+        start = min(unseen)
+        component = {start}
+        frontier = [start]
+        while frontier:
+            new: list[int] = []
+            for item in frontier:
+                for image in np.flatnonzero(adjacency[item]):
+                    image = int(image)
+                    if image not in component:
+                        component.add(image)
+                        new.append(image)
+            frontier = new
+        unseen.difference_update(component)
+        result.append(sorted(component))
+    return result
+
+
+def stabilizer_suborbits(group, base: int, size: int):
+    stabilizer = [element for element in group if element[base] == base]
+    unseen = set(range(size))
+    suborbits = []
+    while unseen:
+        start = min(unseen)
+        suborbit = sorted({element[start] for element in stabilizer})
+        unseen.difference_update(suborbit)
+        suborbits.append(suborbit)
+    return stabilizer, suborbits
+
+
+def orbital_relations(group, suborbits, size: int):
+    representatives = [None] * size
+    for element in sorted(group):
+        image = element[0]
+        if representatives[image] is None:
+            representatives[image] = element
+    assert all(element is not None for element in representatives)
+    relations = np.empty((size, size), dtype=np.int16)
+    for source, representative in enumerate(representatives):
+        for relation, suborbit in enumerate(suborbits):
+            for target in suborbit:
+                relations[source, representative[target]] = relation
+    return relations, representatives
+
+
+def dependency_deck(objects):
+    graph = objects["graph"]
+    faces = objects["faces"]
+    edges = objects["edges"]
+    face_set = set(faces)
+    triangles = [
+        triple
+        for triple in combinations(range(45), 3)
+        if graph[triple[0], triple[1]]
+        and graph[triple[0], triple[2]]
+        and graph[triple[1], triple[2]]
+    ]
+    assert len(triangles) == 5280
+    nonfilled = [triangle for triangle in triangles if triangle not in face_set]
+    assert len(nonfilled) == 5040
+
+    face_of_edge = {}
+    for face_id, face in enumerate(faces):
+        for edge in combinations(face, 2):
+            face_of_edge[tuple(sorted(edge))] = face_id
+    assert len(face_of_edge) == 720
+
+    triples = []
+    for triangle in nonfilled:
+        face_triple = tuple(
+            sorted(
+                face_of_edge[tuple(sorted(edge))]
+                for edge in combinations(triangle, 2)
+            )
+        )
+        assert len(set(face_triple)) == 3
+        triples.append(face_triple)
+    assert len(set(triples)) == 5040
+
+    incidence = np.zeros((240, 5040), dtype=np.int8)
+    pair_counts = Counter()
+    for column, triple in enumerate(triples):
+        incidence[list(triple), column] = 1
+        for pair in combinations(triple, 2):
+            pair_counts[pair] += 1
+
+    assert Counter(map(int, incidence.sum(axis=1))) == Counter({63: 240})
+    assert Counter(pair_counts.values()) == Counter({2: 3240, 4: 2160})
+    assert len(pair_counts) == 5400
+
+    dependency = np.zeros((240, 240), dtype=np.int64)
+    for (left, right), value in pair_counts.items():
+        dependency[left, right] = dependency[right, left] = value
+    assert Counter(map(int, dependency.sum(axis=1))) == Counter({126: 240})
+    assert np.array_equal(incidence @ incidence.T, 63 * np.eye(240, dtype=int) + dependency)
+
+    expected = [
+        (126.0, 1, "126"),
+        (18.0 + 12.0 * np.sqrt(6.0), 24, "18+12sqrt(6)"),
+        (18.0, 20, "18"),
+        (6.0, 15, "6"),
+        (-6.0, 60, "-6"),
+        (-10.0, 81, "-10"),
+        (18.0 - 12.0 * np.sqrt(6.0), 24, "18-12sqrt(6)"),
+        (-18.0, 15, "-18"),
+    ]
+    eigenvalues = np.linalg.eigvalsh(dependency.astype(float))
+    spectrum = []
+    used = np.zeros(240, dtype=bool)
+    for value, multiplicity, label in expected:
+        members = np.flatnonzero(np.abs(eigenvalues - value) < 1e-6)
+        assert len(members) == multiplicity
+        used[members] = True
+        spectrum.append({"eigenvalue": label, "multiplicity": multiplicity})
+    assert used.all()
+
+    # The rational annihilator has roots 126, 18, +/-6, -10, -18,
+    # and the conjugate pair satisfying x^2-36x-540.
+    polynomial = np.array([1], dtype=object)
+    for factor in (
+        np.array([-126, 1], dtype=object),
+        np.array([-18, 1], dtype=object),
+        np.array([-6, 1], dtype=object),
+        np.array([6, 1], dtype=object),
+        np.array([10, 1], dtype=object),
+        np.array([18, 1], dtype=object),
+        np.array([-540, -36, 1], dtype=object),
+    ):
+        polynomial = np.convolve(polynomial, factor)
+    polynomial = [int(value) for value in polynomial]
+    assert len(polynomial) == 9
+
+    modular_annihilator_primes = []
+    for prime in (101, 103):
+        matrix = dependency % prime
+        value = np.zeros_like(matrix)
+        power = np.eye(240, dtype=np.int64)
+        for coefficient in polynomial:
+            value = (value + (coefficient % prime) * power) % prime
+            power = power @ matrix % prime
+        assert not np.any(value)
+        modular_annihilator_primes.append(prime)
+
+    ranks = {str(prime): rank_mod(incidence, prime) for prime in (2, 3, 5)}
+    assert ranks == {"2": 240, "3": 239, "5": 240}
+    assert np.all(incidence.sum(axis=0) % 3 == 0)
+
+    return {
+        "triangles": triples,
+        "incidence": incidence,
+        "operator": dependency,
+        "face_of_edge": face_of_edge,
+        "certificate": {
+            "vertices": 240,
+            "dependency_triples": 5040,
+            "triple_size": 3,
+            "face_degree": 63,
+            "pair_codegrees": {"2": 3240, "4": 2160},
+            "supported_face_pairs": 5400,
+            "weighted_two_section_degree": 126,
+            "incidence_ranks": ranks,
+            "spectrum": spectrum,
+            "ordinary_multiplicity_fingerprint": [1, 15, 15, 20, 24, 24, 60, 81],
+            "annihilator_polynomial_coefficients_low_to_high": polynomial,
+            "annihilator_checked_mod_primes": modular_annihilator_primes,
+            "covering_boundary": (
+                "This is the first code-sensitive cubic deck beyond the strength-two/fractional relaxation. "
+                "It supplies the exact higher-order symmetry operator but does not by itself move 389<=R<=435."
+            ),
+        },
+    }
+
+
+def antipode_data(objects):
+    faces = objects["faces"]
+    point_generators = objects["generators"]
+    face_index = {face: index for index, face in enumerate(faces)}
+    face_generators = [
+        tuple(
+            face_index[tuple(sorted(generator[vertex] for vertex in face))]
+            for face in faces
+        )
+        for generator in point_generators
+    ]
+    face_group = close_group(face_generators, 240)
+    assert len(face_group) == 25920
+    _, suborbits = stabilizer_suborbits(face_group, 0, 240)
+    singleton = next(
+        orbit[0]
+        for orbit in suborbits
+        if len(orbit) == 1 and orbit[0] != 0
+    )
+    representatives = [None] * 240
+    for element in sorted(face_group):
+        if representatives[element[0]] is None:
+            representatives[element[0]] = element
+    antipode = [representatives[source][singleton] for source in range(240)]
+    assert all(antipode[antipode[item]] == item and antipode[item] != item for item in range(240))
+    pairs = sorted({tuple(sorted((item, antipode[item]))) for item in range(240)})
+    assert len(pairs) == 120
+    return face_generators, face_group, antipode, pairs
+
+
+def modular_projector(objects, dependency):
+    face_generators, face_group, antipode, pairs = antipode_data(objects)
+    matrix = dependency % 3
+    square = matrix @ matrix % 3
+    cube = square @ matrix % 3
+    fourth = cube @ matrix % 3
+    assert np.array_equal((fourth + cube) % 3, np.zeros((240, 240), dtype=int))
+
+    projector = (-cube) % 3
+    assert np.array_equal(projector @ projector % 3, projector)
+    assert rank_mod(projector, 3) == 81
+    assert rank_mod(np.eye(240, dtype=int) - projector, 3) == 159
+    assert np.array_equal(matrix @ projector % 3, (-projector) % 3)
+
+    zero_projector = (np.eye(240, dtype=int) - projector) % 3
+    ranks = []
+    value = zero_projector
+    for _ in range(3):
+        value = matrix @ value % 3
+        ranks.append(rank_mod(value, 3))
+    assert ranks == [44, 14, 0]
+    jordan = {"J3(0)": 14, "J2(0)": 16, "J1(0)": 85}
+    assert 3 * 14 + 2 * 16 + 85 == 159
+
+    permutation = np.zeros((240, 240), dtype=np.int8)
+    for source, target in enumerate(antipode):
+        permutation[target, source] = 1
+    assert np.array_equal(permutation @ projector % 3, projector @ permutation % 3)
+
+    symmetric = np.zeros((240, 120), dtype=np.int8)
+    antisymmetric = np.zeros((240, 120), dtype=np.int8)
+    for column, (left, right) in enumerate(pairs):
+        symmetric[left, column] = symmetric[right, column] = 1
+        antisymmetric[left, column] = 1
+        antisymmetric[right, column] = -1
+    assert rank_mod(projector @ symmetric % 3, 3) == 0
+    assert rank_mod(projector @ antisymmetric % 3, 3) == 81
+
+    return {
+        "field": "F3",
+        "minimal_polynomial": "x^3(x+1)",
+        "operator_power_ranks": [rank_mod(matrix, 3), rank_mod(square, 3), rank_mod(cube, 3)],
+        "relation": "D^4=-D^3",
+        "projector": "E81=-D^3",
+        "projector_rank": 81,
+        "projector_idempotent": True,
+        "projector_eigenvalue_for_D": -1,
+        "generalized_zero_dimension": 159,
+        "generalized_zero_power_ranks": ranks,
+        "generalized_zero_jordan_type": jordan,
+        "antipodal_symmetric_image_rank": 0,
+        "antipodal_antisymmetric_image_rank": 81,
+        "module_boundary": (
+            "The 81-dimensional summand is now cut out by an explicit F3-idempotent. "
+            "It is not called simple until an independent composition-series calculation is supplied."
+        ),
+        "face_generators": face_generators,
+        "face_group": face_group,
+        "pairs": pairs,
+    }
+
+
+def transported_m4_grid(objects, modular):
+    faces = objects["faces"]
+    edges = objects["edges"]
+    face_of_edge = {}
+    for face_id, face in enumerate(faces):
+        for edge in combinations(face, 2):
+            face_of_edge[tuple(sorted(edge))] = face_id
+
+    face_generators = modular["face_generators"]
+    face_group = modular["face_group"]
+    pairs = modular["pairs"]
+    pair_index = {pair: index for index, pair in enumerate(pairs)}
+    pair_generators = [
+        tuple(
+            pair_index[tuple(sorted((generator[left], generator[right])))]
+            for left, right in pairs
+        )
+        for generator in face_generators
+    ]
+    pair_group = close_group(pair_generators, 120)
+    _, pair_suborbits = stabilizer_suborbits(pair_group, 0, 120)
+    pair_relations, _ = orbital_relations(pair_group, pair_suborbits, 120)
+    adjacency_matrices = [
+        (pair_relations == relation).astype(np.int8)
+        for relation in range(5)
+    ]
+    valency_two = next(
+        relation
+        for relation, orbit in enumerate(pair_suborbits)
+        if len(orbit) == 2
+    )
+    fibres = components(adjacency_matrices[valency_two])
+    assert len(fibres) == 40 and {len(fibre) for fibre in fibres} == {3}
+    fibre_index = {item: index for index, fibre in enumerate(fibres) for item in fibre}
+
+    quotient_representatives = [None] * 40
+    for face_element in sorted(face_group):
+        pair_element = tuple(
+            pair_index[tuple(sorted((face_element[left], face_element[right])))]
+            for left, right in pairs
+        )
+        quotient_element = tuple(
+            fibre_index[pair_element[fibre[0]]]
+            for fibre in fibres
+        )
+        target = quotient_element[0]
+        if quotient_representatives[target] is None:
+            quotient_representatives[target] = face_element
+    assert all(element is not None for element in quotient_representatives)
+
+    base_faces = sorted(face for pair_id in fibres[0] for face in pairs[pair_id])
+    assert base_faces == [0, 46, 83, 120, 148, 176]
+    labels = {}
+    for element in quotient_representatives:
+        for label, base_face in enumerate(base_faces):
+            labels[element[base_face]] = label
+    assert len(labels) == 240
+    assert Counter(labels.values()) == Counter({label: 40 for label in range(6)})
+
+    tetrahedron_edges = list(combinations(range(4), 2))
+    transpositions = []
+    for left, right in tetrahedron_edges:
+        matrix = np.eye(4, dtype=float)
+        matrix[[left, right]] = matrix[[right, left]]
+        transpositions.append(matrix)
+
+    component_matrices = []
+    for label in range(6):
+        matrix = np.zeros((180, 180), dtype=float)
+        for left, right in edges:
+            face = face_of_edge[(left, right)]
+            if labels[face] == label:
+                block = transpositions[label]
+                matrix[4 * left : 4 * left + 4, 4 * right : 4 * right + 4] = block
+                matrix[4 * right : 4 * right + 4, 4 * left : 4 * left + 4] = block
+        component_matrices.append(matrix)
+
+    def ratio(weights):
+        matrix = sum(
+            weight * component
+            for weight, component in zip(weights, component_matrices)
+        )
+        eigenvalues = np.linalg.eigvalsh(matrix)
+        minimum = float(eigenvalues[0])
+        maximum = float(eigenvalues[-1])
+        assert minimum < 0
+        return 1.0 - maximum / minimum, minimum, maximum
+
+    seen = set()
+    best = None
+    for raw in product((-1, 0, 1), repeat=6):
+        if not any(raw):
+            continue
+        weights = raw
+        if next(value for value in weights if value) < 0:
+            weights = tuple(-value for value in weights)
+        if weights in seen:
+            continue
+        seen.add(weights)
+        value = ratio(weights)
+        candidate = (value[0], weights, value[1], value[2])
+        if best is None or candidate[0] > best[0]:
+            best = candidate
+    assert len(seen) == 364
+    assert best[1] == (1, 1, 1, 1, 1, 1)
+    assert abs(best[3] - 32.0) < 1e-8
+    assert best[0] < 4.0
+
+    return {
+        "gauge": "lexicographically least face-group lift at each W33 quotient point",
+        "projective_weight_grid": "{-1,0,1}^6 / overall sign, zero removed",
+        "weight_classes": 364,
+        "best_weights": list(best[1]),
+        "best_lambda_min": round(best[2], 12),
+        "best_lambda_max": round(best[3], 12),
+        "best_hoffman_ratio": round(best[0], 12),
+        "verdict": (
+            "The complete deterministic ternary six-weight grid stays below 4 and therefore cannot affect the live 10<=chi<=11 boundary. "
+            "This is a finite-grid no-go, not an unrestricted transported-M4 optimum."
+        ),
+    }
+
+
+def circuit_optimum():
+    matrix = np.array(
+        [
+            [2, 1, 1, 0, 0],
+            [2, 1, 0, 1, 0],
+            [2, 0, 1, 1, 0],
+            [0, 2, 2, 0, 0],
+            [0, 0, 0, 0, 1],
+        ],
+        dtype=int,
+    )
+    basis = {
+        canonical_form(tuple(np.eye(5, dtype=int)[index]))
+        for index in range(5)
+    }
+    targets = {canonical_form(tuple(row)) for row in matrix}
+    states = {frozenset(basis)}
+    counts = [1]
+    for _depth in range(4):
+        updated = set()
+        for state in states:
+            forms = list(state)
+            for left, right in combinations(forms, 2):
+                for sign in (1, 2):
+                    candidate = canonical_form(
+                        tuple(
+                            (left[index] + sign * right[index]) % 3
+                            for index in range(5)
+                        )
+                    )
+                    if candidate not in state:
+                        updated.add(frozenset((*state, candidate)))
+        states = updated
+        counts.append(len(states))
+    assert counts == [1, 20, 310, 4560, 67245]
+    assert not any(targets <= state for state in states)
+
+    # Five binary additions/subtractions attain the target; sign and copy are free.
+    a = (1, 0, 0, 0, 0)
+    b = (0, 1, 0, 0, 0)
+    c = (0, 0, 1, 0, 0)
+    d = (0, 0, 0, 1, 0)
+    e = (0, 0, 0, 0, 1)
+    s = tuple((b[i] + c[i]) % 3 for i in range(5))
+    p = tuple((d[i] - a[i]) % 3 for i in range(5))
+    outputs = [
+        tuple((s[i] - a[i]) % 3 for i in range(5)),
+        tuple((p[i] + b[i]) % 3 for i in range(5)),
+        tuple((p[i] + c[i]) % 3 for i in range(5)),
+        tuple((-s[i]) % 3 for i in range(5)),
+        e,
+    ]
+    assert np.array_equal(np.array(outputs, dtype=int) % 3, matrix % 3)
+    assert np.array_equal(np.linalg.matrix_power(matrix, 3) % 3, np.eye(5, dtype=int))
+
+    return {
+        "matrix_mod3": matrix.tolist(),
+        "cost_model": "binary ternary addition/subtraction; sign and copy free",
+        "breadth_first_state_counts_depth_0_to_4": counts,
+        "minimum_binary_operations": 5,
+        "witness": ["s=b+c", "p=d-a", "y0=s-a", "y1=p+b", "y2=p+c", "y3=-s", "y4=e"],
+        "order": 3,
+    }
+
+
+def tomotope_obstruction():
+    coordinates = [(left, right) for left in range(4) for right in range(4) if left != right]
+    coordinate_index = {coordinate: index for index, coordinate in enumerate(coordinates)}
+    faces = []
+    labels = []
+    for left in range(4):
+        faces.append(tuple(sorted(coordinate_index[(left, right)] for right in range(4) if right != left)))
+        labels.append(f"O{left}")
+    for right in range(4):
+        faces.append(tuple(sorted(coordinate_index[(left, right)] for left in range(4) if left != right)))
+        labels.append(f"I{right}")
+    for subset in combinations(range(4), 3):
+        left, middle, right = subset
+        for sign, cycle in (
+            ("+", ((left, middle), (middle, right), (right, left))),
+            ("-", ((left, right), (right, middle), (middle, left))),
+        ):
+            faces.append(tuple(sorted(coordinate_index[item] for item in cycle)))
+            labels.append("C" + "".join(map(str, subset)) + sign)
+    assert len(faces) == 16 and len(set(faces)) == 16
+
+    cell_candidates = []
+    for selected in combinations(range(16), 4):
+        multiplicity = Counter(
+            edge
+            for face in selected
+            for edge in faces[face]
+        )
+        if len(multiplicity) == 6 and set(multiplicity.values()) == {2}:
+            cell_candidates.append(selected)
+    assert len(cell_candidates) == 12
+
+    face_to_candidates = [
+        [index for index, cell in enumerate(cell_candidates) if face in cell]
+        for face in range(16)
+    ]
+    solutions = []
+
+    def search(chosen, counts):
+        if len(chosen) == 8:
+            if all(value == 2 for value in counts):
+                solutions.append(tuple(chosen))
+            return
+        if sum(2 - value for value in counts) != 4 * (8 - len(chosen)):
+            return
+        last = chosen[-1] if chosen else -1
+        deficient = [face for face, value in enumerate(counts) if value < 2]
+        if not deficient:
+            return
+        face = min(
+            deficient,
+            key=lambda item: sum(
+                index > last
+                and all(counts[other] < 2 for other in cell_candidates[index])
+                for index in face_to_candidates[item]
+            ),
+        )
+        for index in face_to_candidates[face]:
+            if index <= last:
+                continue
+            cell = cell_candidates[index]
+            if any(counts[other] >= 2 for other in cell):
+                continue
+            updated = list(counts)
+            for other in cell:
+                updated[other] += 1
+            search([*chosen, index], updated)
+
+    search([], [0] * 16)
+    assert not solutions
+
+    visible_automorphisms = set()
+    face_index = {face: index for index, face in enumerate(faces)}
+    for permutation in permutations(range(4)):
+        for reverse in (False, True):
+            coordinate_image = []
+            for left, right in coordinates:
+                image_left, image_right = permutation[left], permutation[right]
+                if reverse:
+                    image_left, image_right = image_right, image_left
+                coordinate_image.append(coordinate_index[(image_left, image_right)])
+            face_image = tuple(
+                face_index[tuple(sorted(coordinate_image[edge] for edge in face))]
+                for face in faces
+            )
+            visible_automorphisms.add(face_image)
+    assert len(visible_automorphisms) == 48
+
+    return {
+        "configuration": [12, 4, 16, 3],
+        "visible_S4_times_reversal_order": 48,
+        "four_face_six_edge_cell_candidates": 12,
+        "eight_cell_double_cover_solutions": 0,
+        "verdict": (
+            "The oriented-tetrahedron Reye-style 12_4 16_3 surface cannot be lifted to the tomotope by selecting eight four-face cells with every triangular face incident to two cells. "
+            "The matching parameters are therefore not an incidence-preserving tomotope identification."
+        ),
+    }
+
+
+def atlas_constructions():
+    # A hypothetical SRG(57,14,1,4) cannot contain induced W33 and Clebsch
+    # pieces on disjoint 40- and 16-sets plus one remaining vertex.
+    w33_external_degree_sum = 40 * (14 - 12)
+    clebsch_external_degree_sum = 16 * (14 - 5)
+    assert (w33_external_degree_sum, clebsch_external_degree_sum) == (80, 144)
+    assert clebsch_external_degree_sum - w33_external_degree_sum == 64
+    induced_no_go = {
+        "hypothetical_graph": [57, 14, 1, 4],
+        "tempting_partition": [1, 16, 40],
+        "induced_Clebsch_external_degree_sum": clebsch_external_degree_sum,
+        "induced_W33_external_degree_sum": w33_external_degree_sum,
+        "required_apex_incidence_difference": 64,
+        "maximum_possible_apex_incidence_difference": 16,
+        "verdict": "No such induced W33 plus Clebsch plus apex decomposition exists.",
+    }
+
+    # Clebsch spectrum 5^1,1^10,(-3)^5.  The polynomial below maps
+    # 5 and 1 to 2, and -3 to -4, supplying exactly the multiplicity gap
+    # between W33 and Gewirtz nonprincipal spectra.
+    polynomial = {"x^2": "-3/16", "x": "9/8", "1": "17/16"}
+    assert (-3 * 25 + 18 * 5 + 17) == 32
+    assert (-3 + 18 + 17) == 32
+    assert (-3 * 9 - 54 + 17) == -64
+    spectral_completion = {
+        "Clebsch_spectrum": {"5": 1, "1": 10, "-3": 5},
+        "polynomial": "p(x)=(-3x^2+18x+17)/16",
+        "p(Clebsch)_spectrum": {"2": 11, "-4": 5},
+        "W33_nonprincipal_spectrum": {"2": 24, "-4": 15},
+        "direct_sum_nonprincipal_spectrum": {"2": 35, "-4": 20},
+        "Gewirtz_nonprincipal_spectrum": {"2": 35, "-4": 20},
+        "verdict": (
+            "W33 plus the polynomially transformed Clebsch module gives an exact functional-calculus completion of the Gewirtz augmentation spectrum. "
+            "This is not a graph embedding or canonical group-module intertwiner."
+        ),
+        "coefficient_record": polynomial,
+    }
+    return {"missing_57_induced_decomposition_no_go": induced_no_go, "W33_Clebsch_Gewirtz_spectral_completion": spectral_completion}
+
+
+def build_certificate():
+    objects = geometry_objects()
+    dependency = dependency_deck(objects)
+    modular = modular_projector(objects, dependency["operator"])
+    m4 = transported_m4_grid(objects, modular)
+    circuit = circuit_optimum()
+    tomotope = tomotope_obstruction()
+    atlas = atlas_constructions()
+
+    result = {
+        "schema": "w33.bt3506_3519.chained_breakthrough.v1",
+        "status": "PASS_7_FRONTS",
+        "passes": list(range(3506, 3520)),
+        "live_boundaries": {"covering_radius": [389, 435], "chromatic_number": [10, 11]},
+        "dependency_hypergraph": dependency["certificate"],
+        "characteristic_three_projector": {
+            key: value
+            for key, value in modular.items()
+            if key not in {"face_generators", "face_group", "pairs"}
+        },
+        "transported_M4_grid": m4,
+        "five_channel_hardware": circuit,
+        "tomotope_lift": tomotope,
+        "bonkers": atlas,
+        "evidence_boundary": [
+            "The radius interval remains 389<=R<=435.",
+            "The chromatic interval remains 10<=chi(H)<=11.",
+            "The 81-dimensional image is an explicit direct summand but is not labelled simple.",
+            "The M4 result is a deterministic finite-grid no-go, not an unrestricted optimum.",
+            "The circuit optimum is exact in the stated addition/subtraction cost model.",
+            "No remote Icarus, Yosys, FPGA, PDF, laboratory, M57, or physical result is claimed by the source verifier.",
+        ],
+    }
+    payload = json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    result["semantic_sha256"] = hashlib.sha256(payload).hexdigest()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    result = build_certificate()
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(result["status"], result["semantic_sha256"])
+
+
+if __name__ == "__main__":
+    main()

--- a/data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json
+++ b/data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json
@@ -1,0 +1,135 @@
+{
+  "bonkers": {
+    "W33_Clebsch_Gewirtz_spectral_completion": {
+      "Clebsch_spectrum": {
+        "-3": 5,
+        "1": 10,
+        "5": 1
+      },
+      "Gewirtz_nonprincipal_spectrum": {
+        "-4": 20,
+        "2": 35
+      },
+      "W33_nonprincipal_spectrum": {
+        "-4": 15,
+        "2": 24
+      },
+      "coefficient_record": {
+        "1": "17/16",
+        "x": "9/8",
+        "x^2": "-3/16"
+      },
+      "direct_sum_nonprincipal_spectrum": {
+        "-4": 20,
+        "2": 35
+      },
+      "p(Clebsch)_spectrum": {
+        "-4": 5,
+        "2": 11
+      },
+      "polynomial": "p(x)=(-3x^2+18x+17)/16",
+      "verdict": "W33 plus the polynomially transformed Clebsch module gives an exact functional-calculus completion of the Gewirtz augmentation spectrum. This is not a graph embedding or canonical group-module intertwiner."
+    },
+    "missing_57_induced_decomposition_no_go": {
+      "hypothetical_graph": [57, 14, 1, 4],
+      "induced_Clebsch_external_degree_sum": 144,
+      "induced_W33_external_degree_sum": 80,
+      "maximum_possible_apex_incidence_difference": 16,
+      "required_apex_incidence_difference": 64,
+      "tempting_partition": [1, 16, 40],
+      "verdict": "No such induced W33 plus Clebsch plus apex decomposition exists."
+    }
+  },
+  "characteristic_three_projector": {
+    "antipodal_antisymmetric_image_rank": 81,
+    "antipodal_symmetric_image_rank": 0,
+    "field": "F3",
+    "generalized_zero_dimension": 159,
+    "generalized_zero_jordan_type": {
+      "J1(0)": 85,
+      "J2(0)": 16,
+      "J3(0)": 14
+    },
+    "generalized_zero_power_ranks": [44, 14, 0],
+    "minimal_polynomial": "x^3(x+1)",
+    "module_boundary": "The 81-dimensional summand is now cut out by an explicit F3-idempotent. It is not called simple until an independent composition-series calculation is supplied.",
+    "operator_power_ranks": [125, 95, 81],
+    "projector": "E81=-D^3",
+    "projector_eigenvalue_for_D": -1,
+    "projector_idempotent": true,
+    "projector_rank": 81,
+    "relation": "D^4=-D^3"
+  },
+  "dependency_hypergraph": {
+    "annihilator_checked_mod_primes": [101, 103],
+    "annihilator_polynomial_coefficients_low_to_high": [7936185600, 1259712000, -217230336, -40652928, -163296, 162720, 2016, -152, 1],
+    "covering_boundary": "This is the first code-sensitive cubic deck beyond the strength-two/fractional relaxation. It supplies the exact higher-order symmetry operator but does not by itself move 389<=R<=435.",
+    "dependency_triples": 5040,
+    "face_degree": 63,
+    "incidence_ranks": {
+      "2": 240,
+      "3": 239,
+      "5": 240
+    },
+    "ordinary_multiplicity_fingerprint": [1, 15, 15, 20, 24, 24, 60, 81],
+    "pair_codegrees": {
+      "2": 3240,
+      "4": 2160
+    },
+    "spectrum": [
+      {"eigenvalue": "126", "multiplicity": 1},
+      {"eigenvalue": "18+12sqrt(6)", "multiplicity": 24},
+      {"eigenvalue": "18", "multiplicity": 20},
+      {"eigenvalue": "6", "multiplicity": 15},
+      {"eigenvalue": "-6", "multiplicity": 60},
+      {"eigenvalue": "-10", "multiplicity": 81},
+      {"eigenvalue": "18-12sqrt(6)", "multiplicity": 24},
+      {"eigenvalue": "-18", "multiplicity": 15}
+    ],
+    "supported_face_pairs": 5400,
+    "triple_size": 3,
+    "vertices": 240,
+    "weighted_two_section_degree": 126
+  },
+  "evidence_boundary": [
+    "The radius interval remains 389<=R<=435.",
+    "The chromatic interval remains 10<=chi(H)<=11.",
+    "The 81-dimensional image is an explicit direct summand but is not labelled simple.",
+    "The M4 result is a deterministic finite-grid no-go, not an unrestricted optimum.",
+    "The circuit optimum is exact in the stated addition/subtraction cost model.",
+    "No remote Icarus, Yosys, FPGA, PDF, laboratory, M57, or physical result is claimed by the source verifier."
+  ],
+  "five_channel_hardware": {
+    "breadth_first_state_counts_depth_0_to_4": [1, 20, 310, 4560, 67245],
+    "cost_model": "binary ternary addition/subtraction; sign and copy free",
+    "matrix_mod3": [[2,1,1,0,0],[2,1,0,1,0],[2,0,1,1,0],[0,2,2,0,0],[0,0,0,0,1]],
+    "minimum_binary_operations": 5,
+    "order": 3,
+    "witness": ["s=b+c", "p=d-a", "y0=s-a", "y1=p+b", "y2=p+c", "y3=-s", "y4=e"]
+  },
+  "live_boundaries": {
+    "chromatic_number": [10, 11],
+    "covering_radius": [389, 435]
+  },
+  "passes": [3506,3507,3508,3509,3510,3511,3512,3513,3514,3515,3516,3517,3518,3519],
+  "schema": "w33.bt3506_3519.chained_breakthrough.v1",
+  "semantic_sha256": "7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f",
+  "status": "PASS_7_FRONTS",
+  "tomotope_lift": {
+    "configuration": [12, 4, 16, 3],
+    "eight_cell_double_cover_solutions": 0,
+    "four_face_six_edge_cell_candidates": 12,
+    "verdict": "The oriented-tetrahedron Reye-style 12_4 16_3 surface cannot be lifted to the tomotope by selecting eight four-face cells with every triangular face incident to two cells. The matching parameters are therefore not an incidence-preserving tomotope identification.",
+    "visible_S4_times_reversal_order": 48
+  },
+  "transported_M4_grid": {
+    "best_hoffman_ratio": 3.275812021095,
+    "best_lambda_max": 32.0,
+    "best_lambda_min": -14.060915270409,
+    "best_weights": [1,1,1,1,1,1],
+    "gauge": "lexicographically least face-group lift at each W33 quotient point",
+    "projective_weight_grid": "{-1,0,1}^6 / overall sign, zero removed",
+    "verdict": "The complete deterministic ternary six-weight grid stays below 4 and therefore cannot affect the live 10<=chi<=11 boundary. This is a finite-grid no-go, not an unrestricted transported-M4 optimum.",
+    "weight_classes": 364
+  }
+}

--- a/data/w33_current_frontier_manifest_v1.json
+++ b/data/w33_current_frontier_manifest_v1.json
@@ -19,7 +19,8 @@
     "analysis/BT3444_BT3457_radius_modular_fivechannel_insert",
     "analysis/BT3458_BT3471_face_tower_brauer_tomotope_insert",
     "analysis/BT3486_BT3499_radius_code_biplane_supplement_insert",
-    "analysis/BT3500_BT3505_triangle_free_srg_m57_bridge_insert"
+    "analysis/BT3500_BT3505_triangle_free_srg_m57_bridge_insert",
+    "analysis/BT3506_BT3519_chained_breakthrough_insert"
   ],
   "front_doors": {
     "w33_paper.tex": "w33_paper_body.tex",
@@ -77,6 +78,11 @@
       "kind": "id",
       "token": "bt3486-3499-radius-code-biplane-supplement",
       "source": "analysis/BT3486_BT3499_radius_code_biplane_supplement_index_insert.html"
+    },
+    {
+      "kind": "id",
+      "token": "bt3506-3519-chained-breakthrough",
+      "source": "analysis/BT3506_BT3519_chained_breakthrough_index_insert.html"
     }
   ],
   "standalone_public_pages": [

--- a/data/w33_pass_namespace_registry_v2.d/3506-3519.json
+++ b/data/w33_pass_namespace_registry_v2.d/3506-3519.json
@@ -1,0 +1,10 @@
+{
+  "schema": "w33.pass_namespace_registry.v2",
+  "range": [3506, 3519],
+  "owner": "openai-gpt-5.6-thinking",
+  "branch": "agent/pass3506-3519-seven-front-chain",
+  "purpose": "Execute the five live fronts after Passes 3458-3505: build the first code-sensitive higher covering relaxation on the 5040 non-filled triangle dependencies; optimize transported full-M4 Hermitian weights beyond constant tensor products; compute characteristic-three Loewy and composition evidence for the 81,39,29,15,196 layers; obtain formal and observable five-channel hardware evidence; decide the oriented-tetrahedron to tomotope cocycle lift. Add two chained outside-box constructions using the W33-Gewirtz/M57 atlas and the face-tower holonomy.",
+  "base": "ee6a6b3683ea9206e6360fb8c51193458c60d1c8",
+  "coordination": "Preserve merged Passes 3458-3505, reserved 3472-3499 parallel lanes, and all concurrent work. Import certified 389<=R<=435 and 10<=chi(H)<=11 boundaries rather than duplicating them.",
+  "claim_boundary": "No exact covering radius, ten-colour decision, unrestricted transported-M4 optimum, simple-module label, observed FPGA timing/power, tomotope monodromy, M57 existence, or physical interpretation is promoted without executed evidence."
+}

--- a/data/w33_pass_namespace_registry_v2.d/3506-3519.json
+++ b/data/w33_pass_namespace_registry_v2.d/3506-3519.json
@@ -3,6 +3,8 @@
   "range": [3506, 3519],
   "owner": "openai-gpt-5.6-thinking",
   "branch": "agent/pass3506-3519-seven-front-chain",
+  "status": "source_complete_pending_remote_evidence",
+  "semantic_sha256": "7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f",
   "purpose": "Execute the five live fronts after Passes 3458-3505: build the first code-sensitive higher covering relaxation on the 5040 non-filled triangle dependencies; optimize transported full-M4 Hermitian weights beyond constant tensor products; compute characteristic-three Loewy and composition evidence for the 81,39,29,15,196 layers; obtain formal and observable five-channel hardware evidence; decide the oriented-tetrahedron to tomotope cocycle lift. Add two chained outside-box constructions using the W33-Gewirtz/M57 atlas and the face-tower holonomy.",
   "base": "ee6a6b3683ea9206e6360fb8c51193458c60d1c8",
   "coordination": "Preserve merged Passes 3458-3505, reserved 3472-3499 parallel lanes, and all concurrent work. Import certified 389<=R<=435 and 10<=chi(H)<=11 boundaries rather than duplicating them.",

--- a/rtl/tb_w33_pass3506_3519_min5.v
+++ b/rtl/tb_w33_pass3506_3519_min5.v
@@ -1,0 +1,101 @@
+`timescale 1ns/1ps
+`default_nettype none
+
+module tb_w33_pass3506_3519_min5;
+    reg [1:0] a, b, c, d, e;
+    wire [1:0] y0, y1, y2, y3, y4;
+
+    reg [1:0] first0, first1, first2, first3, first4;
+    reg [1:0] second0, second1, second2, second3, second4;
+    integer state;
+    integer temp;
+    integer cases;
+
+    w33_mod3_five_channel_min5 dut(
+        .a(a), .b(b), .c(c), .d(d), .e(e),
+        .y0(y0), .y1(y1), .y2(y2), .y3(y3), .y4(y4)
+    );
+
+    function automatic [1:0] add3;
+        input [1:0] left;
+        input [1:0] right;
+        integer total;
+        begin
+            total = left + right;
+            add3 = total % 3;
+        end
+    endfunction
+
+    function automatic [1:0] neg3;
+        input [1:0] value;
+        begin
+            neg3 = (value == 0) ? 0 : (3 - value);
+        end
+    endfunction
+
+    function automatic [1:0] sub3;
+        input [1:0] left;
+        input [1:0] right;
+        begin
+            sub3 = add3(left, neg3(right));
+        end
+    endfunction
+
+    task check_literal;
+        input [1:0] ia, ib, ic, id, ie;
+        begin
+            if (y0 !== add3(add3(neg3(ia), ib), ic)) begin
+                $display("FAIL y0 state=%0d", state); $fatal;
+            end
+            if (y1 !== add3(add3(neg3(ia), ib), id)) begin
+                $display("FAIL y1 state=%0d", state); $fatal;
+            end
+            if (y2 !== add3(add3(neg3(ia), ic), id)) begin
+                $display("FAIL y2 state=%0d", state); $fatal;
+            end
+            if (y3 !== add3(neg3(ib), neg3(ic))) begin
+                $display("FAIL y3 state=%0d", state); $fatal;
+            end
+            if (y4 !== ie) begin
+                $display("FAIL y4 state=%0d", state); $fatal;
+            end
+        end
+    endtask
+
+    initial begin
+        cases = 0;
+        for (state = 0; state < 243; state = state + 1) begin
+            temp = state;
+            a = temp % 3; temp = temp / 3;
+            b = temp % 3; temp = temp / 3;
+            c = temp % 3; temp = temp / 3;
+            d = temp % 3; temp = temp / 3;
+            e = temp % 3;
+            #1;
+            check_literal(a, b, c, d, e);
+            first0 = y0; first1 = y1; first2 = y2; first3 = y3; first4 = y4;
+
+            a = first0; b = first1; c = first2; d = first3; e = first4;
+            #1;
+            second0 = y0; second1 = y1; second2 = y2; second3 = y3; second4 = y4;
+
+            a = second0; b = second1; c = second2; d = second3; e = second4;
+            #1;
+            temp = state;
+            if (y0 !== temp % 3) begin $display("FAIL order3 a state=%0d", state); $fatal; end
+            temp = temp / 3;
+            if (y1 !== temp % 3) begin $display("FAIL order3 b state=%0d", state); $fatal; end
+            temp = temp / 3;
+            if (y2 !== temp % 3) begin $display("FAIL order3 c state=%0d", state); $fatal; end
+            temp = temp / 3;
+            if (y3 !== temp % 3) begin $display("FAIL order3 d state=%0d", state); $fatal; end
+            temp = temp / 3;
+            if (y4 !== temp % 3) begin $display("FAIL order3 e state=%0d", state); $fatal; end
+            cases = cases + 1;
+        end
+        $display("PASS min5_cases=%0d order3_cases=%0d", cases, cases);
+        $finish;
+    end
+endmodule
+
+`default_nettype wire

--- a/rtl/w33_mod3_five_channel_min5.v
+++ b/rtl/w33_mod3_five_channel_min5.v
@@ -1,0 +1,60 @@
+`default_nettype none
+
+module w33_mod3_five_channel_min5(
+    input  wire [1:0] a,
+    input  wire [1:0] b,
+    input  wire [1:0] c,
+    input  wire [1:0] d,
+    input  wire [1:0] e,
+    output wire [1:0] y0,
+    output wire [1:0] y1,
+    output wire [1:0] y2,
+    output wire [1:0] y3,
+    output wire [1:0] y4
+);
+
+    function automatic [1:0] add3;
+        input [1:0] left;
+        input [1:0] right;
+        reg [2:0] total;
+        begin
+            total = {1'b0, left} + {1'b0, right};
+            if (total >= 3)
+                total = total - 3;
+            add3 = total[1:0];
+        end
+    endfunction
+
+    function automatic [1:0] neg3;
+        input [1:0] value;
+        begin
+            case (value)
+                2'd0: neg3 = 2'd0;
+                2'd1: neg3 = 2'd2;
+                2'd2: neg3 = 2'd1;
+                default: neg3 = 2'bxx;
+            endcase
+        end
+    endfunction
+
+    function automatic [1:0] sub3;
+        input [1:0] left;
+        input [1:0] right;
+        begin
+            sub3 = add3(left, neg3(right));
+        end
+    endfunction
+
+    // Five binary ternary operations.  Sign and copy are wiring operations.
+    wire [1:0] sum_bc = add3(b, c);
+    wire [1:0] diff_da = sub3(d, a);
+
+    assign y0 = sub3(sum_bc, a);
+    assign y1 = add3(diff_da, b);
+    assign y2 = add3(diff_da, c);
+    assign y3 = neg3(sum_bc);
+    assign y4 = e;
+
+endmodule
+
+`default_nettype wire

--- a/rtl/w33_mod3_five_channel_min5_formal.v
+++ b/rtl/w33_mod3_five_channel_min5_formal.v
@@ -1,0 +1,43 @@
+`default_nettype none
+
+module w33_mod3_five_channel_min5_formal;
+`ifdef FORMAL
+    (* anyconst *) reg [1:0] a;
+    (* anyconst *) reg [1:0] b;
+    (* anyconst *) reg [1:0] c;
+    (* anyconst *) reg [1:0] d;
+    (* anyconst *) reg [1:0] e;
+
+    wire [1:0] f0a, f0b, f0c, f0d, f0e;
+    wire [1:0] f1a, f1b, f1c, f1d, f1e;
+    wire [1:0] f2a, f2b, f2c, f2d, f2e;
+
+    w33_mod3_five_channel_min5 stage0(
+        .a(a), .b(b), .c(c), .d(d), .e(e),
+        .y0(f0a), .y1(f0b), .y2(f0c), .y3(f0d), .y4(f0e)
+    );
+    w33_mod3_five_channel_min5 stage1(
+        .a(f0a), .b(f0b), .c(f0c), .d(f0d), .e(f0e),
+        .y0(f1a), .y1(f1b), .y2(f1c), .y3(f1d), .y4(f1e)
+    );
+    w33_mod3_five_channel_min5 stage2(
+        .a(f1a), .b(f1b), .c(f1c), .d(f1d), .e(f1e),
+        .y0(f2a), .y1(f2b), .y2(f2c), .y3(f2d), .y4(f2e)
+    );
+
+    always @* begin
+        assume(a < 3);
+        assume(b < 3);
+        assume(c < 3);
+        assume(d < 3);
+        assume(e < 3);
+        assert(f2a == a);
+        assert(f2b == b);
+        assert(f2c == c);
+        assert(f2d == d);
+        assert(f2e == e);
+    end
+`endif
+endmodule
+
+`default_nettype wire

--- a/tests/test_bt3506_3519_chained_breakthrough.py
+++ b/tests/test_bt3506_3519_chained_breakthrough.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from analysis.bt3506_3519_chained_breakthrough import build_certificate
+
+
+def test_chained_breakthrough_matches_frozen_certificate():
+    generated = build_certificate()
+    frozen = json.loads(
+        Path("data/PART_BT3506_BT3519_CHAINED_BREAKTHROUGH_results.json").read_text()
+    )
+    assert generated == frozen
+    assert generated["status"] == "PASS_7_FRONTS"
+    assert generated["semantic_sha256"] == (
+        "7ad66eec9cbb1b3f207eb4215a348cb9a63e0be9ab7876e53209dbed3099a13f"
+    )
+    assert generated["characteristic_three_projector"]["projector_rank"] == 81
+    assert generated["five_channel_hardware"]["minimum_binary_operations"] == 5
+    assert generated["tomotope_lift"]["eight_cell_double_cover_solutions"] == 0


### PR DESCRIPTION
Superseded before merge. Current master independently claimed the provisional 3506–3512 namespace, and a second provisional rehome also collided. The unchanged mathematical engine was rehomed under a collision-free range reserved directly on master. Final publication is in branch `agent/pass3600-3613-chained-breakthrough`; no provisional pass identifier is promoted.