### PR TITLE
Diagnose authoritative GitHub Pages source and live payload

### DIFF
--- a/docs/.pages-deploy-restored-index-pr-diagnostic-20260806T1028ET
+++ b/docs/.pages-deploy-restored-index-pr-diagnostic-20260806T1028ET
@@ -1,0 +1,2 @@
+Pages diagnostic PR trigger
+expected_blob=41a8d733f42da18282fa276f5d2fa82bac7516f6


### PR DESCRIPTION
Closed without merge. The artifact inspection established the actual root cause: legacy Pages built the 4,064-byte tiny `master/docs/index.html` artifact and its deployment was cancelled. The replacement fix now uses an isolated issue-event controller to move Pages to stable `main/docs` and request a build, avoiding the repo-wide PR workflow matrix.