### PR TITLE
Trigger stable GitHub Pages source switch

### DIFF
--- a/docs/.pages-source-switch-merge-trigger-20260806T1115ET
+++ b/docs/.pages-source-switch-merge-trigger-20260806T1115ET
@@ -1,0 +1,3 @@
+Trigger the installed Pages source controller through a native merge event.
+target_source=main:/docs
+expected_index_blob=41a8d733f42da18282fa276f5d2fa82bac7516f6


### PR DESCRIPTION
This one-file PR triggers the already-installed Pages source controller through a native GitHub merge event. The controller changes the legacy Pages source from the high-churn `master/docs` branch to the stable `main/docs` mirror, where the authoritative large website is stored, and explicitly requests a Pages build.