### PR TITLE
Enable the stable Pages source switch on master merges

### DIFF
--- a/.github/workflows/stabilize-pages-source.yml
+++ b/.github/workflows/stabilize-pages-source.yml
@@ -3,10 +3,12 @@ name: Stabilize W33 Pages source
 on:
   push:
     branches:
+      - master
       - main
     paths:
       - '.github/workflows/stabilize-pages-source.yml'
       - 'docs/.pages-source-stabilize-*'
+      - 'docs/.pages-source-switch-*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The controller already moves legacy Pages from high-churn `master/docs` to stable `main/docs` and requests a build. This PR makes it listen to `master` merge events as well as `main`, so merging this change launches the controller immediately through a native GitHub event.