### PR TITLE
Force native Pages rebuild from master/docs

### DIFF
--- a/docs/.pages-native-rebuild-2026-08-06T1239-0400
+++ b/docs/.pages-native-rebuild-2026-08-06T1239-0400
@@ -1,0 +1,4 @@
+Authoritative GitHub Pages source: master:/docs
+Canonical index blob: 41a8d733f42da18282fa276f5d2fa82bac7516f6
+Purpose: force a native pull-request merge event against the published source tree.
+Created: 2026-08-06T12:39:00-04:00


### PR DESCRIPTION
This PR changes the published `/docs` tree through a native pull-request merge while preserving `master/docs/index.html` byte-for-byte at canonical blob `41a8d733f42da18282fa276f5d2fa82bac7516f6`.

Purpose: trigger GitHub's managed branch-based Pages publisher with a native merge event after API-originated commits failed to deploy. Issue #287 remains the verification ledger and must stay open until the live root and mirror hash correctly.