### PR TITLE
Verify Passes 4833–4840 exact producers

### DIFF
--- a/.github/workflows/w33_pass4833_4840_code_interaction_cycles.yml
+++ b/.github/workflows/w33_pass4833_4840_code_interaction_cycles.yml
@@ -77,3 +77,4 @@ jobs:
           fi
       - name: Enforce final status
         run: test "$(cat analysis/PASS4833_4840_RUN.status)" -eq 0
+# verification-branch trigger only


### PR DESCRIPTION
Verification branch only. Closed without merge because the canonical Pass 4834/4836/4840 certificates materialized directly on master while the PR run was queued; the branch-only workflow comment is intentionally not needed.