### PR TITLE
Validate Pass9197-9260 eight-front theorem stack

### DIFF
--- a/analysis/PASS9197_9260_VALIDATION_TRIGGER.md
+++ b/analysis/PASS9197_9260_VALIDATION_TRIGGER.md
@@ -1,0 +1,3 @@
+# Pass 9197–9260 validation trigger
+
+This branch-only marker exists solely to trigger the inspectable pull-request workflow for the eight-front theorem stack. It carries no mathematical claim.


### PR DESCRIPTION
Superseded by a fresh validation PR from the final Pass9197-9260 master state. The original run was still queued behind the repository-wide workflow fan-out and did not include the later symbolic q^6 selector upgrade.